### PR TITLE
added $YCM_CORES - useful for building on machines with small amount of memory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,10 @@ function python_finder {
 }
 
 function num_cores {
-  if command_exists nproc; then
+  if [[ -n ${YCM_CORES} ]]; then
+      # Useful while building on machines with lot of CPUs but small amount of memory/swap
+      num_cpus=${YCM_CORES};
+  elif command_exists nproc; then
    num_cpus=$(nproc)
   else
     num_cpus=1


### PR DESCRIPTION
On virtual machines with lots of cores but small amount of memory YCM will not build due to the not enough of ram/swap, but if you try to build with less number of simultaneous make's it works.

So i've added handling of $YCM_CORES variable, the user can override the automagic cores detection.
