### PR TITLE
fix complete error when the line has multi-bytes utf-8 chars

### DIFF
--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
-from ycmd.utils import IsIdentifierChar
+from ycmd.utils import IsIdentifierChar, ToUtf8IfNeeded
 
 # TODO: Change the custom computed (and other) keys to be actual properties on
 # the object.
@@ -61,7 +61,8 @@ class RequestWrap( object ):
     if contents is not None and len( contents ) == 0:
       self._line_value = ''
       return self._line_value
-    self._line_value = contents.splitlines()[ self._request[ 'line_num' ] - 1 ]
+    self._line_value = ToUtf8IfNeeded(contents.splitlines()[ self._request[ 'line_num' ] - 1 ])
+
     return self._line_value
 
 


### PR DESCRIPTION
Hi, Valloric, Nice to meet you.  
YouCompleteMe is amazing, It's very useful.  

 but I found a small bug. when type after the multi-bytes utf-8 chars, the python will throw exception and no  complete list popup.  
I found this is because the python get the contents as unicode, but the index is according to bytes index, so index is out range  
I already fix this. you can check the modified code.  

In my mine branch, I also change the match algorithm. this is mainly because I can't bear LetterNode use so much memory, and slow down my computer. Also, I think the result compare should return immediately, since it will be call many times. and the result size should be as less as possible, since  you sort them by value, not ref.  
If  you're interesting, you can fetch and check it.
