### PR TITLE
Allow '*' in ycm_filetype_specific_completion_to_disable.

### DIFF
--- a/ycmd/server_state.py
+++ b/ycmd/server_state.py
@@ -109,5 +109,8 @@ class ServerState( object ):
   def CurrentFiletypeCompletionEnabled( self, current_filetypes ):
     filetype_to_disable = self._user_options[
         'filetype_specific_completion_to_disable' ]
-    return not all([ x in filetype_to_disable for x in current_filetypes ])
+    if '*' in filetype_to_disable:
+      return False
+    else:
+      return not all([ x in filetype_to_disable for x in current_filetypes ])
 


### PR DESCRIPTION
Server-side counterpart to https://github.com/Valloric/YouCompleteMe/pull/869

As mentioned in the linked pull request, already signed the Google CLA and added documentation to the client regarding the option. Haven't seen any documentation regarding the server. If I missed it let me know and I'll update it as well.
