### PR TITLE
Fix running scripts from certain directories

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -74,30 +74,30 @@ function num_cores {
 
 function install {
   build_dir=`mktemp -d -t ycm_build.XXXXXX`
-  pushd $build_dir
+  pushd "${build_dir}"
 
   if [[ `uname -s` == "Darwin" ]]; then
-    cmake -G "Unix Makefiles" $(python_finder) "$@" . $SCRIPT_DIR/cpp
+    cmake -G "Unix Makefiles" $(python_finder) "$@" . "${SCRIPT_DIR}/cpp"
   else
-    cmake -G "Unix Makefiles" "$@" . $SCRIPT_DIR/cpp
+    cmake -G "Unix Makefiles" "$@" . "${SCRIPT_DIR}/cpp"
   fi
 
   make -j $(num_cores) ycm_support_libs
   popd
-  rm -rf $build_dir
+  rm -rf "${build_dir}"
 }
 
 function testrun {
   build_dir=`mktemp -d -t ycm_build.XXXXXX`
-  pushd $build_dir
+  pushd "${build_dir}"
 
-  cmake -G "Unix Makefiles" "$@" . $SCRIPT_DIR/cpp
+  cmake -G "Unix Makefiles" "$@" . "${SCRIPT_DIR}/cpp"
   make -j $(num_cores) ycm_core_tests
   cd ycm/tests
-  LD_LIBRARY_PATH=$SCRIPT_DIR ./ycm_core_tests
+  LD_LIBRARY_PATH="${SCRIPT_DIR}" ./ycm_core_tests
 
   popd
-  rm -rf $build_dir
+  rm -rf "${build_dir}"
 }
 
 function linux_cmake_install {
@@ -112,8 +112,8 @@ function usage {
 
 function check_third_party_libs {
   libs_present=true
-  for folder in $SCRIPT_DIR/third_party/*; do
-    num_files_in_folder=$(find $folder -maxdepth 1 -mindepth 1 | wc -l)
+  for folder in "${SCRIPT_DIR}"/third_party/*; do
+    num_files_in_folder=$(find "${folder}" -maxdepth 1 -mindepth 1 | wc -l)
     if [[ $num_files_in_folder -eq 0 ]]; then
       libs_present=false
     fi
@@ -176,9 +176,9 @@ if $omnisharp_completer; then
     fi
   fi
 
-  build_dir=$SCRIPT_DIR"/third_party/OmniSharpServer"
+  build_dir="${SCRIPT_DIR}/third_party/OmniSharpServer"
 
-  cd $build_dir
+  cd "${build_dir}"
   $buildcommand
-  cd $ycm_dir
+  cd "${ycm_dir}"
 fi

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,7 +9,7 @@ function usage {
   exit 0
 }
 
-flake8 --select=F,C9 --max-complexity=10 $SCRIPT_DIR/ycmd
+flake8 --select=F,C9 --max-complexity=10 "${SCRIPT_DIR}/ycmd"
 
 use_clang_completer=true
 for flag in $@; do
@@ -34,16 +34,16 @@ else
 fi
 
 EXTRA_CMAKE_ARGS=$extra_cmake_args YCM_TESTRUN=1 \
-   $SCRIPT_DIR/build.sh --omnisharp-completer
+   "${SCRIPT_DIR}/build.sh" --omnisharp-completer
 
-for directory in $SCRIPT_DIR/third_party/*; do
+for directory in "${SCRIPT_DIR}"/third_party/*; do
   if [ -d "${directory}" ]; then
     export PYTHONPATH=${directory}:$PYTHONPATH
   fi
 done
 
 if $use_clang_completer; then
-  nosetests -v $SCRIPT_DIR/ycmd
+  nosetests -v "${SCRIPT_DIR}/ycmd"
 else
-  nosetests -v --exclude=".*Clang.*" $SCRIPT_DIR/ycmd
+  nosetests -v --exclude=".*Clang.*" "${SCRIPT_DIR}/ycmd"
 fi

--- a/update_boost.sh
+++ b/update_boost.sh
@@ -11,7 +11,7 @@ if [ -z "$1" ]; then
   exit 0
 fi
 
-pushd $1
+pushd "$1"
 
 ./bootstrap.sh
 ./b2 tools/bcp
@@ -20,7 +20,7 @@ boost_part_dir=`mktemp -d -t boost_parts.XXXXXX`
 
 dist/bin/bcp boost/utility.hpp boost/python.hpp boost/bind.hpp boost/lambda/lambda.hpp boost/exception/all.hpp boost/tuple/tuple_io.hpp boost/tuple/tuple_comparison.hpp boost/regex.hpp boost/foreach.hpp boost/smart_ptr.hpp boost/algorithm/string_regex.hpp boost/thread.hpp boost/unordered_map.hpp boost/unordered_set.hpp boost/format.hpp boost/ptr_container/ptr_container.hpp boost/filesystem.hpp boost/filesystem/fstream.hpp boost/utility.hpp boost/algorithm/cxx11/any_of.hpp atomic lockfree assign $boost_part_dir
 
-pushd $boost_part_dir
+pushd "${boost_part_dir}"
 
 # DON'T exit if error
 set +e
@@ -38,7 +38,7 @@ popd
 rm -rf cpp/BoostParts/libs
 rm -rf cpp/BoostParts/boost
 
-cp -R $boost_part_dir/libs cpp/BoostParts/libs
-cp -R $boost_part_dir/boost cpp/BoostParts/boost
+cp -R "${boost_part_dir}/libs" cpp/BoostParts/libs
+cp -R "${boost_part_dir}/boost" cpp/BoostParts/boost
 
-rm -rf $boost_part_dir
+rm -rf "${boost_part_dir}"


### PR DESCRIPTION
When running `build.sh` from any directory other than the root directory of `ycmd` or `YouCompleteMe`, it prints the following output regardless of whether the `third_party` is available, because it's looking for `third_party` in `$PWD`.

```
find: third_party/*: No such file or directory
Some folders in ./third_party are empty; you probably forgot to run:

    git submodule update --init --recursive
```

This PR fixes that and it also fixes the problem when running the scripts from a directory whose name contains space.
## 

CLA signed.
