### PR TITLE
Add CSS at-rules to identifier regex

### DIFF
--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -49,7 +49,7 @@ DEFAULT_IDENTIFIER_REGEX = re.compile( r"[_a-zA-Z]\w*", re.UNICODE )
 FILETYPE_TO_IDENTIFIER_REGEX = {
     # Spec: http://www.w3.org/TR/CSS2/syndata.html#characters
     # Good summary: http://stackoverflow.com/a/449000/1672783
-    'css': re.compile( r"-?[_a-zA-Z]+[_\w-]+", re.UNICODE ),
+    'css': re.compile( r"[@-]?[_a-zA-Z]+[_\w-]+", re.UNICODE ),
 
     # Spec: http://www.w3.org/TR/html5/syntax.html#tag-name-state
     # But not quite since not everything we want to pull out is a tag name. We

--- a/ycmd/tests/identifier_utils_test.py
+++ b/ycmd/tests/identifier_utils_test.py
@@ -138,15 +138,17 @@ def IsIdentifier_generic_test():
 
 
 def IsIdentifier_Css_test():
-  ok_( iu.IsIdentifier( 'foo'      , 'css' ) )
-  ok_( iu.IsIdentifier( 'a1'       , 'css' ) )
-  ok_( iu.IsIdentifier( 'a-'       , 'css' ) )
-  ok_( iu.IsIdentifier( 'a-b'      , 'css' ) )
-  ok_( iu.IsIdentifier( '_b'       , 'css' ) )
-  ok_( iu.IsIdentifier( '-ms-foo'  , 'css' ) )
-  ok_( iu.IsIdentifier( '-_o'      , 'css' ) )
-  ok_( iu.IsIdentifier( 'font-face', 'css' ) )
+  ok_( iu.IsIdentifier( 'foo'       , 'css' ) )
+  ok_( iu.IsIdentifier( 'a1'        , 'css' ) )
+  ok_( iu.IsIdentifier( 'a-'        , 'css' ) )
+  ok_( iu.IsIdentifier( 'a-b'       , 'css' ) )
+  ok_( iu.IsIdentifier( '_b'        , 'css' ) )
+  ok_( iu.IsIdentifier( '-ms-foo'   , 'css' ) )
+  ok_( iu.IsIdentifier( '-_o'       , 'css' ) )
+  ok_( iu.IsIdentifier( 'box-shadow', 'css' ) )
+  ok_( iu.IsIdentifier( '@font-face', 'css' ) )
 
+  ok_( not iu.IsIdentifier( '@-b', 'css' ) )
   ok_( not iu.IsIdentifier( '-3b', 'css' ) )
   ok_( not iu.IsIdentifier( '-3' , 'css' ) )
   ok_( not iu.IsIdentifier( '3'  , 'css' ) )


### PR DESCRIPTION
CSS also has things that start with `@`, such as `@import`, `@media`,
and `@keyframes`. It might make sense to add a `@` to the beginning of
the CSS identifier regex.

MDN lists the CSS at-rules as: CSS `@charset`, `@document`,
`@font-face`, `@import`, `@keyframes`, `@media`, `@page`, `@supports`.
