### PR TITLE
Created example where fuzzy-matching fails.

### DIFF
--- a/examples/example_client.py
+++ b/examples/example_client.py
@@ -390,14 +390,14 @@ def CppSemanticCompletionResults( server ):
   # some_cpp.cpp file that we placed there intentionally (as an example).
   # Clang will recover from this error and still manage to parse the file
   # though.
-  server.SendEventNotification( Event.FileReadyToParse,
-                                test_filename = 'some_cpp.cpp',
-                                filetype = 'cpp' )
+  # server.SendEventNotification( Event.FileReadyToParse,
+  #                               test_filename = 'some_cpp.cpp',
+  #                               filetype = 'cpp' )
 
   server.SendCodeCompletionRequest( test_filename = 'some_cpp.cpp',
                                     filetype = 'cpp',
-                                    line_num = 25,
-                                    column_num = 7 )
+                                    line_num = 5,
+                                    column_num = 9 )
 
 
 def PythonGetSupportedCommands( server ):
@@ -435,18 +435,18 @@ def Main():
   server = YcmdHandle.StartYcmdAndReturnHandle()
   server.WaitUntilReady()
 
-  LanguageAgnosticIdentifierCompletion( server )
-  PythonSemanticCompletionResults( server )
+  #LanguageAgnosticIdentifierCompletion( server )
+  #PythonSemanticCompletionResults( server )
   CppSemanticCompletionResults( server )
-  CsharpSemanticCompletionResults( server )
+  #CsharpSemanticCompletionResults( server )
 
   # This will ask the server for a list of subcommands supported by a given
   # language completer.
-  PythonGetSupportedCommands( server )
+  #PythonGetSupportedCommands( server )
 
   # GoTo is an example of a completer subcommand.
   # Python and C# completers also support the GoTo subcommand.
-  CppGotoDeclaration( server )
+  #CppGotoDeclaration( server )
 
   print 'Shutting down server...'
   server.Shutdown()

--- a/examples/samples/some_cpp.cpp
+++ b/examples/samples/some_cpp.cpp
@@ -1,28 +1,6 @@
-// Copyright (C) 2014  Google Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-struct Foo {
-  int x;
-  int y  // There's a missing semicolon here
-  char c;
-};
+int add_two_numbers(int x, int y) { return x + y; }
 
 int main()
 {
-  Foo foo;
-  // The location after the dot is line 28, col 7
-  foo.
+    atnu
 }
-
-


### PR DESCRIPTION
As far as I can tell, this shows a case where fuzzy matching is not
working properly for C++ code.

This pull-request is for the purposes of sorting out https://github.com/Valloric/ycmd/issues/28.
