### PR TITLE
fix build on OpenBSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -65,7 +65,7 @@ function num_cores {
   elif [[ `uname -s` == "Linux" ]]; then
     num_cpus=$(grep -c ^processor /proc/cpuinfo)
   else
-    # Works on Mac and FreeBSD
+    # Works on Mac, FreeBSD and OpenBSD
     num_cpus=$(sysctl -n hw.ncpu)
   fi
   echo $num_cpus
@@ -106,7 +106,7 @@ function linux_cmake_install {
 }
 
 function usage {
-  echo "Usage: $0 [--clang-completer [--system-libclang]] [--omnisharp-completer]"
+  echo "Usage: $0 [--clang-completer [--system-libclang]] [--system-boost] [--omnisharp-completer]"
   exit 0
 }
 
@@ -135,6 +135,9 @@ for flag in $@; do
       ;;
     --system-libclang)
       cmake_args="$cmake_args -DUSE_SYSTEM_LIBCLANG=ON"
+      ;;
+    --system-boost)
+      cmake_args="$cmake_args -DUSE_SYSTEM_BOOST=ON"
       ;;
     --omnisharp-completer)
       omnisharp_completer=true

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -35,6 +35,10 @@ if ( ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" )
   set( SYSTEM_IS_FREEBSD true )
 endif()
 
+if ( ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD" )
+  set( SYSTEM_IS_OPENBSD true )
+endif()
+
 if ( ${CMAKE_SYSTEM_NAME} MATCHES "SunOS" )
   set( SYSTEM_IS_SUNOS true )
 endif()

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -236,8 +236,8 @@ if ( EXTRA_RPATH )
   set( CMAKE_INSTALL_RPATH "${EXTRA_RPATH}:${CMAKE_INSTALL_RPATH}" )
 endif()
 
-# Needed on Linux machines, but not on Macs
-if ( UNIX AND NOT APPLE )
+# Needed on Linux machines, but not on Macs and OpenBSD
+if ( UNIX AND NOT ( APPLE OR SYSTEM_IS_OPENBSD ) )
   set( EXTRA_LIBS rt )
 endif()
 
@@ -391,6 +391,10 @@ endif()
 if( SYSTEM_IS_SUNOS )
   # SunOS needs this setting for thread support
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthreads" )
+endif()
+
+if( SYSTEM_IS_OPENBSD )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread" )
 endif()
 
 add_subdirectory( tests )


### PR DESCRIPTION
Hi, 
i tried YouCompleteMe on OpenBSD/amd64,-current and with these changes it works for me pretty well.
- expose a new flag (--system-boost) to
  build ycmd with system boost.
- don't link against librt on OpenBSD
- add "-pthread" to CXX flags on OpenBSD

boost from third_party didn't compile but building it against system boost did work for me.

i build YouCompleteMe with

```
./install.sh --clang-completer --omnisharp-completer --system-libclang --system-boost
```

Any Comments or Feedback?

Thanks for this great software,
Fabian
