### PR TITLE
build: fix `python_finder`: prefer python2, look for/prefer .so

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -132,8 +132,12 @@ function usage {
 function check_third_party_libs {
   libs_present=true
   for folder in "${SCRIPT_DIR}"/third_party/*; do
+    if ! [[ -d $folder ]]; then
+      continue
+    fi
     num_files_in_folder=$(find "${folder}" -maxdepth 1 -mindepth 1 | wc -l)
     if [[ $num_files_in_folder -eq 0 ]]; then
+      echo "Missing libs in: $folder"
       libs_present=false
     fi
   done


### PR DESCRIPTION
This fixes building YCM / ycmd for pyenv with python3 and python2
activated/configured.
