### PR TITLE
Workaround for cmake on systems with boost built against both python 2 and 3

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -23,6 +23,9 @@ set( SERVER_LIB "ycm_core" )
 
 set( Python_ADDITIONAL_VERSIONS 2.7 2.6 )
 find_package( PythonLibs 2.6 REQUIRED )
+# The version of PythonInterp controls the version of boost.python which
+# is pulled in later, otherwise the highest python version is used
+find_package( PythonInterp 2.6 REQUIRED )
 
 if ( NOT PYTHONLIBS_VERSION_STRING VERSION_LESS "3.0.0" )
   message( FATAL_ERROR


### PR DESCRIPTION
On my Gentoo linux system, boost is built against python 2.7 and 3.4 so there are multiple versions of
the libboost_python library. find_package for boost.python defaults to the highest version of this library
unless a python executable has already been found, in which case it uses the version from the previously found executable. This causes the build to fail when it tries to link into the python3 version of boost.
The added call to find_package sets PYTHON_EXECUTABLE to the python2 binary, so when find_package is called on boost, it will choose the python2 version.
