### PR TITLE
replace "hash" with "command -v"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 command_exists() {
-  hash "$1" 2>/dev/null ;
+  command -v "$1" 2>/dev/null ;
 }
 
 cmake_install() {


### PR DESCRIPTION
command -v is specified by POSIX and should
be more portable than hash.

Fixes build with ksh(1) on OpenBSD.

Idea for using "command" utility from
http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script

and here a link to the posix specification:
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html


This fixes issue https://github.com/Valloric/YouCompleteMe/issues/1320