### PR TITLE
Improve Objective-C semantic completion triggering

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -135,21 +135,6 @@ DEFAULT_FILETYPE_TRIGGERS = {
             r're!\[[_a-zA-Z]+\w*\s',    # bracketed calls
             r're!^\s*[^\W\d]\w*\s',     # bracketless calls
             r're!\[.*\]\s',             # method composition
-            # literals
-            r're!\@"\.*"\s',
-            r're!\@\w+\.*\w*\s',
-            r're!\@\(\w+\.*\w*\)\s',
-            r're!\@\(\s*',
-            r're!\@\[.*\]\s',
-            r're!\@\[\s*',
-            r're!\@\{.*\}\s',
-            r're!\@\{\s*',
-            r're!\@\'.*\'\s',
-            # variables
-            '#ifdef ',
-            r're!:\s*',
-            r're!=\s*',
-            r're!,\s*',
            ],
   'ocaml' : ['.', '#'],
   'cpp,objcpp' : ['->', '.', '::'],

--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -130,7 +130,27 @@ TRIGGER_REGEX_PREFIX = 're!'
 
 DEFAULT_FILETYPE_TRIGGERS = {
   'c' : ['->', '.'],
-  'objc' : ['->', '.', r're!\[[_a-zA-Z]+\w*\s'],
+  'objc' : ['->',
+            '.',
+            r're!\[[_a-zA-Z]+\w*\s',    # bracketed calls
+            r're!^\s*[^\W\d]\w*\s',     # bracketless calls
+            r're!\[.*\]\s',             # method composition
+            # literals
+            r're!\@"\.*"\s',
+            r're!\@\w+\.*\w*\s',
+            r're!\@\(\w+\.*\w*\)\s',
+            r're!\@\(\s*',
+            r're!\@\[.*\]\s',
+            r're!\@\[\s*',
+            r're!\@\{.*\}\s',
+            r're!\@\{\s*',
+            r're!\@\'.*\'\s',
+            # variables
+            '#ifdef ',
+            r're!:\s*',
+            r're!=\s*',
+            r're!,\s*',
+           ],
   'ocaml' : ['.', '#'],
   'cpp,objcpp' : ['->', '.', '::'],
   'perl' : ['->'],

--- a/ycmd/completers/completer_utils_test.py
+++ b/ycmd/completers/completer_utils_test.py
@@ -128,6 +128,51 @@ def PreparedTriggers_UserTriggers_test():
 
 def PreparedTriggers_ObjectiveC_test():
   triggers = cu.PreparedTriggers()
+  # bracketed calls
   ok_( triggers.MatchesForFiletype( '[foo ', 5, 'objc' ) )
   ok_( not triggers.MatchesForFiletype( '[foo', 4, 'objc' ) )
   ok_( not triggers.MatchesForFiletype( '[3foo ', 6, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '[f3oo ', 6, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '[[foo ', 6, 'objc' ) )
+
+  # bracketless calls
+  ok_( not triggers.MatchesForFiletype( '3foo ', 5, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( 'foo3 ', 5, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( 'foo ', 4, 'objc' ) )
+
+  # method composition
+  ok_( triggers.MatchesForFiletype(
+      '[NSString stringWithFormat:@"Test %@", stuff] ', 46, 'objc' ) )
+  ok_( triggers.MatchesForFiletype(
+      '   [NSString stringWithFormat:@"Test"] ', 39, 'objc' ) )
+  ok_( triggers.MatchesForFiletype(
+      '   [[NSString stringWithFormat:@"Test"] stringByAppendingString:%@] ',
+      68,
+      'objc' ) )
+
+  # literals
+  ok_( triggers.MatchesForFiletype( '@"" ', 4, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '@3.14F ', 7, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '@3 ', 3, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '@YES ', 5, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '@(3) ', 5, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '@( )', 3, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '@{} ', 4, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '@{ } ', 3, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '@[] ', 4, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '@[ ] ', 3, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '@\'Z\' ', 5, 'objc' ) )
+  ok_( not triggers.MatchesForFiletype( '@"foo "', 6, 'objc' ) )
+  ok_( not triggers.MatchesForFiletype( '@[@"Test" ]', 10, 'objc' ) )
+  ok_( not triggers.MatchesForFiletype( '@"@"Test" "', 10, 'objc' ) )
+
+  # variables
+  ok_( triggers.MatchesForFiletype( 'NSString stringWithFormat:', 26, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( 'NSString stringWithFormat: ', 27, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( 'foo = ', 6, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( 'foo =', 5, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( 'NSLog(@"%@", )', 13, 'objc' ) )
+  ok_( triggers.MatchesForFiletype( '#ifdef ', 7, 'objc' ) )
+
+  ok_( not triggers.MatchesForFiletype( '// foo ', 8, 'objc' ) )
+

--- a/ycmd/completers/completer_utils_test.py
+++ b/ycmd/completers/completer_utils_test.py
@@ -150,29 +150,5 @@ def PreparedTriggers_ObjectiveC_test():
       68,
       'objc' ) )
 
-  # literals
-  ok_( triggers.MatchesForFiletype( '@"" ', 4, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( '@3.14F ', 7, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( '@3 ', 3, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( '@YES ', 5, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( '@(3) ', 5, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( '@( )', 3, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( '@{} ', 4, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( '@{ } ', 3, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( '@[] ', 4, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( '@[ ] ', 3, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( '@\'Z\' ', 5, 'objc' ) )
-  ok_( not triggers.MatchesForFiletype( '@"foo "', 6, 'objc' ) )
-  ok_( not triggers.MatchesForFiletype( '@[@"Test" ]', 10, 'objc' ) )
-  ok_( not triggers.MatchesForFiletype( '@"@"Test" "', 10, 'objc' ) )
-
-  # variables
-  ok_( triggers.MatchesForFiletype( 'NSString stringWithFormat:', 26, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( 'NSString stringWithFormat: ', 27, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( 'foo = ', 6, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( 'foo =', 5, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( 'NSLog(@"%@", )', 13, 'objc' ) )
-  ok_( triggers.MatchesForFiletype( '#ifdef ', 7, 'objc' ) )
-
   ok_( not triggers.MatchesForFiletype( '// foo ', 8, 'objc' ) )
 


### PR DESCRIPTION
Related to Valloric/YouCompleteMe#84.

With these additions, triggers for Objective-C semantic completion behave like Xcode.  This should be a sensible default because 99% of Objective-C developers are going to be used to Xcode.

I added both positive and negative unit tests for every case I could think of and thoroughly tested it by hand in a real project.  All unit tests pass. It works very well!

All of the syntax situations presented [here](http://clang.llvm.org/docs/ObjectiveCLiterals.html) are covered. 

Without these changes, Objective-C semantic triggering is unusable.  It fails to trigger in 90% of the cases a developer will expect it.  