### PR TITLE
make build.py choose python2

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import os.path as p


### PR DESCRIPTION
The build script will error out on distributions that have already switched their python binary to python3 (i.e. archlinux, not sure if there are others). Since 'The build script requires Python version > 2.6 and < 3.0.' I think it makes sense to use env python2 instead of env python. This makes the script work in archlinux out of the box.