### PR TITLE
Add CXTranslationUnit_Incomplete to the parse options.

### DIFF
--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -38,7 +38,8 @@ namespace {
 unsigned editingOptions() {
   return ( CXTranslationUnit_DetailedPreprocessingRecord |
            clang_defaultEditingTranslationUnitOptions() ) |
-         CXTranslationUnit_IncludeBriefCommentsInCodeCompletion;
+         CXTranslationUnit_IncludeBriefCommentsInCodeCompletion |
+         CXTranslationUnit_Incomplete;
 }
 
 unsigned completionOptions() {


### PR DESCRIPTION
This makes reparsing on large TUs > 10x faster. So far I haven't found
any diagnostics this might miss (the documentation says that it does not
do some template instantiations, but I have not yet been able to provide
an example where we would not diagnose the problem).