### PR TITLE
Use the omnisharp port specified in user_options

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -237,7 +237,7 @@ class CsharpCompleter( Completer ):
       raise RuntimeError( 'Autodetection of solution file failed.\n' )
     self._logger.info( u'Loading solution file {0}'.format( path_to_solutionfile ) )
 
-    self._omnisharp_port = utils.GetUnusedLocalhostPort()
+    self._omnisharp_port = int( self.user_options.get( 'csharp_server_port', utils.GetUnusedLocalhostPort() ) )
 
     # we need to pass the command to Popen as a string since we're passing
     # shell=True (as recommended by Python's doc)

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -237,7 +237,10 @@ class CsharpCompleter( Completer ):
       raise RuntimeError( 'Autodetection of solution file failed.\n' )
     self._logger.info( u'Loading solution file {0}'.format( path_to_solutionfile ) )
 
-    self._omnisharp_port = int( self.user_options.get( 'csharp_server_port', utils.GetUnusedLocalhostPort() ) )
+    self._omnisharp_port = int( self.user_options.get( 'csharp_server_port', 0 ) )
+    if not self._omnisharp_port:
+        self._omnisharp_port = utils.GetUnusedLocalhostPort()
+    self._logger.info( u'using port {0}'.format( self._omnisharp_port ) )
 
     # we need to pass the command to Popen as a string since we're passing
     # shell=True (as recommended by Python's doc)

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -277,6 +277,7 @@ class CsharpCompleter( Completer ):
   def _StopServer( self ):
     """ Stop the OmniSharp server """
     self._GetResponse( '/stopserver' )
+    self._omnisharp_phandle.wait()
     self._omnisharp_port = None
     self._omnisharp_phandle = None
     if ( not self.user_options[ 'server_keep_logfiles' ] ):

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -237,10 +237,7 @@ class CsharpCompleter( Completer ):
       raise RuntimeError( 'Autodetection of solution file failed.\n' )
     self._logger.info( u'Loading solution file {0}'.format( path_to_solutionfile ) )
 
-    self._omnisharp_port = int( self.user_options.get( 'csharp_server_port', 0 ) )
-    if not self._omnisharp_port:
-        self._omnisharp_port = utils.GetUnusedLocalhostPort()
-    self._logger.info( u'using port {0}'.format( self._omnisharp_port ) )
+    self._ChooseOmnisharpPort()
 
     # we need to pass the command to Popen as a string since we're passing
     # shell=True (as recommended by Python's doc)
@@ -397,6 +394,12 @@ class CsharpCompleter( Completer ):
     target = urlparse.urljoin( self._ServerLocation(), handler )
     response = requests.post( target, data = parameters )
     return response.json()
+
+  def _ChooseOmnisharpPort( self ):
+    self._omnisharp_port = int( self.user_options.get( 'csharp_server_port', 0 ) )
+    if not self._omnisharp_port:
+        self._omnisharp_port = utils.GetUnusedLocalhostPort()
+    self._logger.info( u'using port {0}'.format( self._omnisharp_port ) )
 
 
 

--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -34,7 +34,7 @@
   "auto_start_csharp_server": 1,
   "auto_stop_csharp_server": 1,
   "use_ultisnips_completer": 1,
-  "csharp_server_port": 2000,
+  "csharp_server_port": 0,
   "hmac_secret": "",
   "server_keep_logfiles": 0
 }


### PR DESCRIPTION
I saw this issue: 

https://github.com/Valloric/YouCompleteMe/issues/802

Obviously, two completion plugins active at the same time is a bad idea, but Omnisharp has functionality that isn't exposed in YCM (e.g. refactoring tools, find usages of a symbol, etc.). With this change, YCM will start the Omnisharp server listening on a fixed port. This value is already being set to 2000 (where Omnisharp's vim plugin expects the server) in default_settings.json, but was not being used by anything.

I've signed the CLA.