### PR TITLE
Fix the shebang line

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import os.path as p


### PR DESCRIPTION
Quoting PEP394: “python should be used in the shebang line only for scripts
that are source compatible with both Python 2 and 3. (…) Python 2 only scripts
should (…) use python2 in the shebang line.”

This will let users of distros where Python 3 is the default execute ./build.py
directly. It does not affect YouCompleteMe at all, since YCM explicitly calls
python2 if available.

I already signed the CLA.