### PR TITLE
Fix CustomPythonCmakeArgs() on Python 2.6

### DIFF
--- a/build.py
+++ b/build.py
@@ -67,7 +67,7 @@ def CustomPythonCmakeArgs():
   else:
     which_python = sh.python(
       '-c',
-      'import sys;i=sys.version_info;print "python%d.%d" % (i.major, i.minor)'
+      'import sys;i=sys.version_info;print "python%d.%d" % (i[0], i[1])'
       ).strip()
     lib_python = '{0}/lib/lib{1}'.format( python_prefix, which_python ).strip()
 


### PR DESCRIPTION
This PR fix the following error in a rare case where Python 2.6 is system default:

```
  RAN: '/usr/bin/python -c import sys;i=sys.version_info;print "python%d.%d" % (i.major, i.minor)'

  STDOUT:


  STDERR:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: 'tuple' object has no attribute 'major'
```
---
CLA signed.