### PR TITLE
Support for clang completer subcommands GetType and GetParent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,8 @@ Creating good pull requests
     faster.
 
 4.  **Write tests for your code**. Your pull request is unlikely to be merged
-    without tests.
+    without tests. See [ycmd-tests][TESTS.md] for instructions on running the 
+    tests.
 
 5.  **Explain in detail why your pull request makes sense.** Ask yourself, would
     this feature be helpful to others? Not just a few people, but a lot of
@@ -103,3 +104,4 @@ Creating good pull requests
 [build-bots]: https://travis-ci.org/Valloric/ycmd
 [ycmd-users]: https://groups.google.com/forum/?hl=en#!forum/ycmd-users
 [cla]: https://developers.google.com/open-source/cla/individual
+[ycmd-tests] https://github.com/Valloric/ycmd/blob/master/TESTS.md

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,82 @@
+# Running ycmd tests
+
+This readme documents instructions on running the test suite
+
+## Requirements for running the tests
+
+You need to have installed:
+
+* nose (pip install nose)
+* mock (pip install mock)
+* flake8 (pip install flake8)
+* webtest (pip install webtest)
+* hamcrest (pip install PyHamcrest)
+
+See test_requirements.txt for specific minimum versions
+
+You also need to have build requirements for all of:
+
+* ycmd + libClang. See https://github.com/Valloric/YouCompleteMe
+* OmniSharpServer. See https://github.com/OmniSharp/omnisharp-server
+
+### mono non-standard path
+
+Note: if your installation of mono is in a non-standard location,
+OmniSharpServer will not start. Ensure that it is in a standard location, or
+change the paths in `OmniSharpServer/OmniSharp/Solution/CSharpProject.cs`
+
+A patch will be submitted upstream to read paths from the environment.
+
+## Running the tests
+
+To run the full suite, just run `run_tests.sh`. Options are:
+
+* `--skip-build`: don't attempt to run the build `build.py`, e.g. if you use
+a non-standard build environment (e.g. `cmake28`, self-build of clang, etc.)
+* `--no-clang-completer`: don't attempt to test the clang completer. Can also
+be set via environment variable `USE_CLANG_COMPLETER`.
+
+Anything after a trailing -- is passed to "nosetests" directly. This means that
+you can run a specific script or a specific test as follows:
+
+* Specific test: `./run_tests.sh -- ycmd/tests/<module_name>.py:<function name>`
+* Specific script: `./run_tests.sh -- ycmd.tests.<module_name>`
+
+For example:
+
+* `./run_tests.sh -- ycmd/tests/subcommands_test.py:RunCompleterCommand_GetType_test`
+* `./run_tests.sh -- ycmd.tests.subcommands_test`
+
+NOTE: you must have UTF8 support in your terminal when you do this, e.g.:
+
+    > LANG=en_GB.utf8 ./run_tests.sh --skip-build
+
+## Troubleshooting
+
+### All the tests fail with some missing package.
+
+Check the list of pip packages to install above. If there is one not listed,
+install it and add it to the list.
+
+### All the CsCompleter tests fail on unix.
+
+Likely to be a problem with the OmniSharpServer.
+
+* Check that you have compiled OmniSharpServer in `third-party/OmniSharpServer`
+* Check that OmniSharpServer starts manually from ycmd/tests/testdata with
+
+    > mono ../../../third_party/OmniSharpServer/OmniSharp/bin/Debug/OmniSharp.exe -s testy/testy.sln
+
+### You get one or all of the following failures
+
+    ERROR: ycmd.tests.get_completions_test.GetCompletions_CsCompleter_PathWithSpace_test
+    FAIL: ycmd.completers.general.tests.filename_completer_test.FilenameCompleter_test.QuotedIncludeCompletion_test
+    FAIL: ycmd.completers.general.tests.filename_completer_test.FilenameCompleter_test.SystemPathCompletion_test
+
+Ensure that you have UTF-8 support in your environment (see above)
+
+### Some of the CsCompleter tests just hang
+
+I think this is a timing issue of some sort because running the test suite
+again appears to work.
+

--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -165,6 +165,46 @@ Location ClangCompleter::GetDefinitionLocation(
   return unit->GetDefinitionLocation( line, column, unsaved_files, reparse );
 }
 
+std::string ClangCompleter::GetTypeAtLocation(
+  const std::string &filename,
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  const std::vector< std::string > &flags,
+  bool reparse ) {
+
+  ReleaseGil unlock;
+  shared_ptr< TranslationUnit > unit =
+    translation_unit_store_.GetOrCreate( filename, unsaved_files, flags );
+
+  if ( !unit ) {
+    return "no unit";
+  }
+
+  return unit->GetTypeAtLocation( line, column, unsaved_files, reparse );
+}
+
+std::string ClangCompleter::GetEnclosingFunctionAtLocation(
+  const std::string &filename,
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  const std::vector< std::string > &flags,
+  bool reparse ) {
+
+  ReleaseGil unlock;
+  shared_ptr< TranslationUnit > unit =
+    translation_unit_store_.GetOrCreate( filename, unsaved_files, flags );
+
+  if ( !unit ) {
+    return "no unit";
+  }
+
+  return unit->GetEnclosingFunctionAtLocation( line, 
+                                               column, 
+                                               unsaved_files, 
+                                               reparse );
+}
 
 void ClangCompleter::DeleteCachesForFile( const std::string &filename ) {
   ReleaseGil unlock;

--- a/cpp/ycm/ClangCompleter/ClangCompleter.h
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.h
@@ -73,6 +73,22 @@ public:
     const std::vector< std::string > &flags,
     bool reparse = true );
 
+  std::string GetTypeAtLocation(
+    const std::string &filename,
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    const std::vector< std::string > &flags,
+    bool reparse = true );
+
+  std::string GetEnclosingFunctionAtLocation(
+    const std::string &filename,
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    const std::vector< std::string > &flags,
+    bool reparse = true );
+
   void DeleteCachesForFile( const std::string &filename );
 
 private:

--- a/cpp/ycm/ClangCompleter/ClangUtils.h
+++ b/cpp/ycm/ClangCompleter/ClangUtils.h
@@ -23,6 +23,12 @@
 
 namespace YouCompleteMe {
 
+/**
+ * Return a std::string from the supplied CXString.
+ *
+ * Takes ownership of, and destroys, the supplied CXString which must not be used
+ * subsequently.
+ */
 std::string CXStringToString( CXString text );
 
 bool CursorIsValid( CXCursor cursor );

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -243,6 +243,100 @@ Location TranslationUnit::GetDefinitionLocation(
   return Location( clang_getCursorLocation( definition_cursor ) );
 }
 
+std::string TranslationUnit::GetTypeAtLocation(
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  bool reparse ) {
+
+  if (reparse)
+    ReparseForIndexing( unsaved_files );
+
+  unique_lock< mutex > lock( clang_access_mutex_ );
+
+  if ( !clang_translation_unit_ )
+    return "Internal error: no translation unit";
+
+  CXCursor cursor = GetCursor( line, column );
+
+  if ( !CursorIsValid( cursor ) )
+    return "Internal error: cursor not valid";
+
+  CXType type = clang_getCursorType( cursor );
+
+  std::string type_description = 
+                        CXStringToString( clang_getTypeSpelling( type ) );
+
+  if ( type_description.empty() )
+    return "Unknown type";
+ 
+  //
+  //
+  // we have a choice here. libClang provides clang_getCanonicalType which will
+  // return the "underlying" type for the type returned by clang_getCursorType
+  // e.g. for a typedef
+  //
+  // type = clang_getCanonicalType( type );
+  //
+  // Without the above, something like the following would return "MyType"
+  // rather than int:
+  //
+  // typedef int MyType;
+  // MyType i = 100; <-- type = MyType, canonical type = int
+  //
+  // I suspect there is more semantic value in calling it MyType. if we
+  // opt for the more specific type, if that means that we can get very long or
+  // confusing stl types even for simple usage. e.g. the following:
+  //
+  // std::string test = "test"; <-- type = std::string; 
+  //                                canonical=std::basic_string<char>
+  //
+  // so as a compromise, we return both if and only if the types differ, like
+  //
+  // std::string => std::basic_string<char>
+  //
+
+  // append the canonical type if different
+  CXType canonical_type = clang_getCanonicalType( type );
+
+  if ( !clang_equalTypes( type, canonical_type ) )
+  {
+    type_description += " => ";
+    type_description += CXStringToString(clang_getTypeSpelling(canonical_type));
+  }
+
+  return type_description;
+}
+
+std::string TranslationUnit::GetEnclosingFunctionAtLocation(
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  bool reparse ) {
+
+  if (reparse)
+    ReparseForIndexing( unsaved_files );
+
+  unique_lock< mutex > lock( clang_access_mutex_ );
+
+  if ( !clang_translation_unit_ )
+    return "Internal error: no translation unit";
+
+  CXCursor cursor = GetCursor( line, column );
+
+  if ( !CursorIsValid( cursor ) )
+    return "Internal error: cursor not valid";
+
+  CXCursor parent = clang_getCursorSemanticParent( cursor );
+
+  std::string parent_str = 
+                  CXStringToString( clang_getCursorDisplayName( parent ) );
+
+  if (parent_str.empty())
+    return "Unknown semantic parent";
+
+  return parent_str;
+}
 
 // Argument taken as non-const ref because we need to be able to pass a
 // non-const pointer to clang. This function (and clang too) will not modify the

--- a/cpp/ycm/ClangCompleter/TranslationUnit.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.h
@@ -78,6 +78,18 @@ public:
     const std::vector< UnsavedFile > &unsaved_files,
     bool reparse = true );
 
+  std::string GetTypeAtLocation(
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    bool reparse = true );
+
+  std::string GetEnclosingFunctionAtLocation(
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    bool reparse = true );
+
 private:
   void Reparse( std::vector< CXUnsavedFile > &unsaved_files );
 

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -97,7 +97,10 @@ BOOST_PYTHON_MODULE(ycm_core)
     .def( "UpdatingTranslationUnit", &ClangCompleter::UpdatingTranslationUnit )
     .def( "UpdateTranslationUnit", &ClangCompleter::UpdateTranslationUnit )
     .def( "CandidatesForLocationInFile",
-          &ClangCompleter::CandidatesForLocationInFile );
+          &ClangCompleter::CandidatesForLocationInFile )
+    .def( "GetTypeAtLocation", &ClangCompleter::GetTypeAtLocation )
+    .def( "GetEnclosingFunctionAtLocation", 
+          &ClangCompleter::GetEnclosingFunctionAtLocation );
 
   enum_< CompletionKind >( "CompletionKind" )
     .value( "STRUCT", STRUCT )

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function usage {
-  echo "Usage: $0 [--no-clang-completer] [--skip-build]"
+  echo "Usage: $0 [--no-clang-completer] [--skip-build] [-- nose args]"
   exit 0
 }
 
@@ -14,13 +14,19 @@ flake8 --select=F,C9 --max-complexity=10 --exclude=testdata "${SCRIPT_DIR}/ycmd"
 
 use_clang_completer=true
 skip_build=false
-for flag in $@; do
-  case "$flag" in
+while [ "$*" ]; do
+  case "$1" in
     --no-clang-completer)
       use_clang_completer=false
+      shift
       ;;
     --skip-build)
       skip_build=true
+      shift
+      ;;
+    --)
+      shift
+      break
       ;;
     *)
       usage
@@ -50,7 +56,15 @@ for directory in "${SCRIPT_DIR}"/third_party/*; do
 done
 
 if $use_clang_completer; then
-  nosetests -v "${SCRIPT_DIR}/ycmd"
+  if [ "$*" ]; then
+    nosetests -v $@
+  else
+    nosetests -v "${SCRIPT_DIR}/ycmd"
+  fi
 else
-  nosetests -v --exclude=".*Clang.*" "${SCRIPT_DIR}/ycmd"
+  if "$*"; then
+    nosetests -v --exclude=".*Clang.*" $@
+  else
+    nosetests -v --exclude=".*Clang.*" "${SCRIPT_DIR}/ycmd"
+  fi
 fi

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -108,26 +108,72 @@ class ClangCompleter( Completer ):
              'GoToDeclaration',
              'GoTo',
              'GoToImprecise',
-             'ClearCompilationFlagCache']
+             'ClearCompilationFlagCache',
+             'GetType',
+             'GetParent']
 
 
-  def OnUserCommand( self, arguments, request_data ):
+  def OnUserCommand( self, arguments, request_data ): 
     if not arguments:
       raise ValueError( self.UserCommandsHelpMessage() )
 
-    command = arguments[ 0 ]
-    if command == 'GoToDefinition':
-      return self._GoToDefinition( request_data )
-    elif command == 'GoToDeclaration':
-      return self._GoToDeclaration( request_data )
-    elif command == 'GoTo':
-      return self._GoTo( request_data )
-    elif command == 'GoToImprecise':
-      return self._GoToImprecise( request_data )
-    elif command == 'ClearCompilationFlagCache':
-      return self._ClearCompilationFlagCache()
-    raise ValueError( self.UserCommandsHelpMessage() )
+    #
+    # An if/elif for each of the options fails the cyclomatic complexity check
+    # in the test suite. python doesn't have a switch statement, and
+    # recommendations typically point to using a dictionary. So we use a
+    # dictionary to map the entered command to the method which implements it
+    # via some (arguably ugly) metaprogramming.
+    #
+    # command_map maps: command -> { method, args }
+    #
+    # where:
+    #  "command" is the completer command entered by the user
+    #            (e.g. GoToDefinition)
+    #  "method"  is a method to call for that command 
+    #            (e.g. self._GoToDefinition)
+    #  "args"    is a dictionary of
+    #               "method_argument" : "value" ...
+    #            which defines the kwargs (via the ** double splat) 
+    #            when calling "method" 
+    #
+    command_map = {
+        'GoToDefinition' : { 
+            'method' : self._GoToDefinition,
+            'args'   : { 'request_data' : request_data } 
+         },
+        'GoToDeclaration' : {
+            'method' : self._GoToDeclaration,
+            'args'   : { 'request_data' : request_data } 
+        },
+        'GoTo' : {
+            'method' : self._GoTo,
+            'args'   : { 'request_data' : request_data } 
+        },
+        'GoToImprecise' : {
+            'method' : self._GoToImprecise,
+            'args'   : { 'request_data' : request_data } 
+        },
+        'ClearCompilationFlagCache' : {
+            'method' : self._ClearCompilationFlagCache,
+            'args'   : { }
+        },
+        'GetType' : {
+            'method' : self._GetSemanticInfo,
+            'args'   : { 'request_data' : request_data,  
+                         'func'         : 'GetTypeAtLocation' }
+        },
+        'GetParent' : {
+            'method' : self._GetSemanticInfo,
+            'args'   : { 'request_data' : request_data,  
+                         'func'         : 'GetEnclosingFunctionAtLocation' }
+        },
+    }
 
+    try:
+        command_def = command_map[arguments[0]]
+        return command_def['method']( **(command_def['args']) )
+    except KeyError:
+        raise ValueError( self.UserCommandsHelpMessage() )
 
   def _LocationForGoTo( self, goto_function, request_data, reparse = True ):
     filename = request_data[ 'filepath' ]
@@ -185,10 +231,34 @@ class ClangCompleter( Completer ):
       raise RuntimeError( 'Can\'t jump to definition or declaration.' )
     return _ResponseForLocation( location )
 
+  def _GetSemanticInfo( self, request_data, func, reparse = True ):
+    filename = request_data[ 'filepath' ]
+    if not filename:
+      raise ValueError( INVALID_FILE_MESSAGE )
+
+    flags = self._FlagsForRequest( request_data )
+    if not flags:
+      raise ValueError( NO_COMPILE_FLAGS_MESSAGE )
+
+    files = self.GetUnsavedFilesVector( request_data )
+    line = request_data[ 'line_num' ]
+    column = request_data[ 'column_num' ]
+
+    type = getattr( self._completer, func )(
+        ToUtf8IfNeeded( filename ),
+        line,
+        column,
+        files,
+        flags,
+        reparse)
+
+    if type == "":
+      type = "Type unknown"
+
+    return responses.BuildDisplayMessageResponse( type )
 
   def _ClearCompilationFlagCache( self ):
     self._flags.Clear()
-
 
   def OnFileReadyToParse( self, request_data ):
     filename = request_data[ 'filepath' ]

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -74,9 +74,12 @@ def StopOmniSharpServer( app ):
 
 
 def WaitUntilOmniSharpServerReady( app ):
-  while True:
+  retries = 100;
+  success = False;
+  while retries > 0:
     result = app.get( '/ready', { 'include_subservers': 1 } ).json
     if result:
+      success = True;
       break
     request = BuildRequest( completer_target = 'filetype_default',
                             command_arguments = [ 'ServerTerminated' ],
@@ -85,5 +88,9 @@ def WaitUntilOmniSharpServerReady( app ):
     if result:
       raise RuntimeError( "OmniSharp failed during startup." )
     time.sleep( 0.2 )
+    retries = retries - 1
+
+  if not success:
+    raise RuntimeError( "Time out waiting for OmniSharpServer" )
 
 

--- a/ycmd/tests/testdata/GetType_Clang_test.cc
+++ b/ycmd/tests/testdata/GetType_Clang_test.cc
@@ -1,0 +1,40 @@
+// this file is used in RunCompleterCommand_GetType_Clang_test
+#include <iostream>
+#include <string>
+struct Foo {
+  int x;
+  int y;
+  char c;
+};
+
+int main()
+{
+  Foo foo;
+  std::string a = "hello";
+  std::cout << a;
+
+  auto &arFoo = foo;
+  auto *apFoo = &foo;
+
+  const auto &acrFoo = foo;
+  const auto *acpFoo = &foo;
+
+  std::cout << acrFoo.y
+            << acpFoo->x 
+            << arFoo.y 
+            << apFoo->x;
+
+  Foo &rFoo = foo;
+  Foo *pFoo = &foo;
+
+  const Foo &crFoo = foo;
+  const Foo *cpFoo = &foo;
+
+  std::cout << crFoo.y
+            << cpFoo->x 
+            << rFoo.y 
+            << pFoo->x;
+
+
+  return 0;
+}

--- a/ycmd/tests/testdata/GoTo_Clang_ZeroBasedLineAndColumn_test.cc
+++ b/ycmd/tests/testdata/GoTo_Clang_ZeroBasedLineAndColumn_test.cc
@@ -1,0 +1,12 @@
+// this file is used in RunCompleterCommand_GoTo_Clang_ZeroBasedLineAndColumn_test
+struct Foo {
+  int x;
+  int y;
+  char c;
+};
+
+int main()
+{
+  Foo foo;
+  return 0;
+}

--- a/ycmd/tests/testdata/GoTo_all_Clang_test.cc
+++ b/ycmd/tests/testdata/GoTo_all_Clang_test.cc
@@ -1,0 +1,28 @@
+// This file is used in RunCompleterCommand_GoTo_all_Clang_test
+#include <iostream>
+namespace Local
+{
+    int x;
+
+    char in_line()
+    {
+        return 'y';
+    };
+
+    char out_of_line();
+}
+
+char Local::out_of_line()
+{
+    return 'x';
+}
+
+int main();
+
+int main()
+{
+    std::cout << Local::x 
+              << Local::in_line()
+              << Local::out_of_line();
+    return 0;
+}


### PR DESCRIPTION
## Requirement

Particularly in the context of c++11 and the pervasive use of `auto`, it is useful to have YouCompleteMe, via clang, deduce the type of a word within the source. Further, in large files or large projects, jumping around using searches and location lists, it can be useful to quickly determine the context of the current cursor position.

Typical example:

```c++
#include <third_party_api.h>

int main()
{
    auto x = third_party_init();
    // long, boring or otherwise complex code
    // ...
    // ... etc.
    do_something_with(x); // <-- what was x again?
}
```

## Specification

User can deduce the type of the word under the cursor by issuing a completer subcommand.
User can deduce the semantic parent of the cursor location by issuing a completer subcommand,
Commands can be bound using standard vim script or simple mappings.

## Design

### Deducing type

Clang provides simple APIs for this: `clang_GetTypeSpelling()` via `clang_GetCursorType()`. This returns the "lexical" type of the variable/method etc. It an be useful to know the "derived" type as well, and clang provides `clang_GetCannonicalType()` for that. So we return a simple string containing the type spelling of the type and append the canonical type to it if that is different from the simple type.

### Deducing semantic parent

Clang provies `clang_GetCursorSemanticParent()` for this; we just return the spelling returned by `clang_GetCursorDisplayName()`.

## Testing

Ran all existing regression tests for both ycmd and YouCompleteMe :  PASS
Added new regression tests for GetType and GetParent : PASS

The cyclomatic complexity check failed for clang_completer.py, so rather than suppressing it or changing the test suite, the implementation was changed from a `if: elif:` block to a dictionary mapping commands to a function to execute. Due to this change, tests were added for the existing commands too to ensure all changed code is exercised. Unfortunately, the behaviour of these commands seems strange, as commented. I have confirmed the behaviour of the tests is identical with and without the change to use a dictionary, so there is no regression.

As I had a number of problems getting the tests to work, i've also included a TESTS.md with some instructions on how to run the tests, at least on my platform (RHEL linux). Hopefully this can be extended by others with experience running them on other platforms.

## Foibles

As noted in the tests, and in the code, there is a clang bug that when executing GetType on the word auto, or on the line where a variable is declared, clang always returns `auto` rather than the deduced type. However, executing it on subsequent usage of the variable works roughly as expected, except that clang claims that the type and the canonical_type differ, though their spellings are the same. We could work around this, but it would be better for libClang to be fixed upstream.

The results of the clang_GetCursorSemanticParent() aren't fully qualified. Though I have been using this for months and I have found the hint that it gives has been useful enough when trying to get my bearings in a large file.

## Apologies, and Thanks

I don't fully understand git submodules usage, so I may have confused things a little with the commits. If so, apologies in advance, and thanks for providing a great product. I was very nearly forced to use eclipse at work until I proved that vim was superior ;)
