### PR TITLE
New completer subcommands GetType and GetParent

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -165,6 +165,46 @@ Location ClangCompleter::GetDefinitionLocation(
   return unit->GetDefinitionLocation( line, column, unsaved_files, reparse );
 }
 
+std::string ClangCompleter::GetTypeAtLocation(
+  const std::string &filename,
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  const std::vector< std::string > &flags,
+  bool reparse ) {
+
+  ReleaseGil unlock;
+  shared_ptr< TranslationUnit > unit =
+    translation_unit_store_.GetOrCreate( filename, unsaved_files, flags );
+
+  if ( !unit ) {
+    return "no unit";
+  }
+
+  return unit->GetTypeAtLocation( line, column, unsaved_files, reparse );
+}
+
+std::string ClangCompleter::GetEnclosingFunctionAtLocation(
+  const std::string &filename,
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  const std::vector< std::string > &flags,
+  bool reparse ) {
+
+  ReleaseGil unlock;
+  shared_ptr< TranslationUnit > unit =
+    translation_unit_store_.GetOrCreate( filename, unsaved_files, flags );
+
+  if ( !unit ) {
+    return "no unit";
+  }
+
+  return unit->GetEnclosingFunctionAtLocation( line, 
+                                               column, 
+                                               unsaved_files, 
+                                               reparse );
+}
 
 void ClangCompleter::DeleteCachesForFile( const std::string &filename ) {
   ReleaseGil unlock;

--- a/cpp/ycm/ClangCompleter/ClangCompleter.h
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.h
@@ -73,6 +73,22 @@ public:
     const std::vector< std::string > &flags,
     bool reparse = true );
 
+  std::string GetTypeAtLocation(
+    const std::string &filename,
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    const std::vector< std::string > &flags,
+    bool reparse = true );
+
+  std::string GetEnclosingFunctionAtLocation(
+    const std::string &filename,
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    const std::vector< std::string > &flags,
+    bool reparse = true );
+
   void DeleteCachesForFile( const std::string &filename );
 
 private:

--- a/cpp/ycm/ClangCompleter/ClangUtils.h
+++ b/cpp/ycm/ClangCompleter/ClangUtils.h
@@ -23,6 +23,12 @@
 
 namespace YouCompleteMe {
 
+/**
+ * Return a std::string from the supplied CXString.
+ *
+ * Takes ownership of, and destroys, the supplied CXString which must not be used
+ * subsequently.
+ */
 std::string CXStringToString( CXString text );
 
 bool CursorIsValid( CXCursor cursor );

--- a/cpp/ycm/ClangCompleter/TranslationUnit.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.h
@@ -78,6 +78,18 @@ public:
     const std::vector< UnsavedFile > &unsaved_files,
     bool reparse = true );
 
+  std::string GetTypeAtLocation(
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    bool reparse = true );
+
+  std::string GetEnclosingFunctionAtLocation(
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    bool reparse = true );
+
 private:
   void Reparse( std::vector< CXUnsavedFile > &unsaved_files );
 

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -97,7 +97,10 @@ BOOST_PYTHON_MODULE(ycm_core)
     .def( "UpdatingTranslationUnit", &ClangCompleter::UpdatingTranslationUnit )
     .def( "UpdateTranslationUnit", &ClangCompleter::UpdateTranslationUnit )
     .def( "CandidatesForLocationInFile",
-          &ClangCompleter::CandidatesForLocationInFile );
+          &ClangCompleter::CandidatesForLocationInFile )
+    .def( "GetTypeAtLocation", &ClangCompleter::GetTypeAtLocation )
+    .def( "GetEnclosingFunctionAtLocation", 
+          &ClangCompleter::GetEnclosingFunctionAtLocation );
 
   enum_< CompletionKind >( "CompletionKind" )
     .value( "STRUCT", STRUCT )

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -59,19 +59,8 @@ foo()
 @with_setup( Setup )
 def RunCompleterCommand_GoTo_Clang_ZeroBasedLineAndColumn_test():
   app = TestApp( handlers.app )
-  contents = """
-struct Foo {
-  int x;
-  int y;
-  char c;
-};
-
-int main()
-{
-  Foo foo;
-  return 0;
-}
-"""
+  contents = open(
+        PathToTestFile( 'GoTo_Clang_ZeroBasedLineAndColumn_test.cc' ) ).read()
 
   goto_data = BuildRequest( completer_target = 'filetype_default',
                             command_arguments = ['GoToDefinition'],
@@ -88,6 +77,291 @@ int main()
       },
       app.post_json( '/run_completer_command', goto_data ).json )
 
+def _RunCompleterCommand_GoTo_all_Clang(filename, command, test):
+  contents = open( PathToTestFile( filename ) ).read()
+  app = TestApp( handlers.app )
+  common_request = {
+    'completer_target'  : 'filetype_default',
+    'command_arguments' : command,
+    'compilation_flags' : ['-x', 
+                           'c++', 
+                           '-std=c++11'],
+    'line_num'          : 10,
+    'column_num'        : 3,
+    'contents'          : contents,
+    'filetype'          : 'cpp'
+  }
+  common_response = {
+    'filepath'  : '/foo',
+  }
+
+  request = common_request
+  request.update({
+      'line_num'  : test['request'][0],
+      'column_num': test['request'][1],
+  })
+  response = common_response
+  response.update({
+      'line_num'  : test['response'][0],
+      'column_num': test['response'][1],
+  })
+
+  goto_data = BuildRequest( **request ) 
+
+  eq_( response,
+       app.post_json( '/run_completer_command', goto_data ).json )
+
+@with_setup( Setup )
+def RunCompleterCommand_GoTo_all_Clang_test():
+  # GoToDeclaration
+  #
+  # the semantics of this seem the wrong way round to me. GoToDeclaration should
+  # go to where a method is declared, not where it is defined.
+  #
+  tests = [
+    # Local::x -> declaration of x
+    { 'request': [24,25], 'response': [5 ,9 ] },
+    # Local::in_line -> declaration of Local::inline
+    { 'request': [25,29], 'response': [7 ,10] },
+    # Local -> declaration of Local
+    { 'request': [25,19], 'response': [3 ,11] },
+    # sic: Local::out_of_line -> definition of Local::out_of_line
+    { 'request': [26,30], 'response': [15,13 ] }, # sic
+    # sic: GoToDeclaration on definition of out_of_line moves to itself
+    { 'request': [15,13], 'response': [15,13] }, # sic
+    # main -> definition of main (not declaration)
+    { 'request': [22,7 ], 'response': [22,5] }, # sic
+  ]
+
+  for test in tests:
+    yield _RunCompleterCommand_GoTo_all_Clang, \
+          'GoTo_all_Clang_test.cc',            \
+          ['GoToDeclaration'],                 \
+          test
+
+  # GoToDefinition - identical to GoToDeclaration
+  #
+  # the semantics of this seem the wrong way round to me. GoToDefinition should
+  # go to where a method is implemented, not where it is declared.
+  #
+  tests = [
+    # Local::x -> declaration of x
+    { 'request': [24,25], 'response': [5 ,9 ] },
+    # Local::in_line -> declaration of Local::inline
+    { 'request': [25,29], 'response': [7 ,10] },
+    # Local -> declaration of Local
+    { 'request': [25,19], 'response': [3 ,11] },
+    # sic: Local::out_of_line -> definition of Local::out_of_line
+    { 'request': [26,30], 'response': [15,13 ] }, # sic
+    # sic: GoToDeclaration on definition of out_of_line moves to itself
+    { 'request': [15,13], 'response': [15,13] }, # sic
+    # main -> definition of main (not declaration)
+    { 'request': [22,7 ], 'response': [22,5] }, # sic
+  ]
+
+  for test in tests:
+    yield _RunCompleterCommand_GoTo_all_Clang, \
+          'GoTo_all_Clang_test.cc',            \
+          ['GoToDefinition'],                  \
+          test
+
+  # GoTo - identical to GoToDeclaration
+  #
+  # the semantics of this seem the wrong way round to me. GoToDefinition should
+  # go to where a method is implemented, not where it is declared.
+  #
+  tests = [
+    # Local::x -> declaration of x
+    { 'request': [24,25], 'response': [5 ,9 ] },
+    # Local::in_line -> declaration of Local::inline
+    { 'request': [25,29], 'response': [7 ,10] },
+    # Local -> declaration of Local
+    { 'request': [25,19], 'response': [3 ,11] },
+    # sic: Local::out_of_line -> definition of Local::out_of_line
+    { 'request': [26,30], 'response': [15,13 ] }, # sic
+    # sic: GoToDeclaration on definition of out_of_line moves to itself
+    { 'request': [15,13], 'response': [15,13] }, # sic
+    # main -> definition of main (not declaration)
+    { 'request': [22,7 ], 'response': [22,5] }, # sic
+  ]
+
+  for test in tests:
+    yield _RunCompleterCommand_GoTo_all_Clang, \
+          'GoTo_all_Clang_test.cc',            \
+          ['GoTo'],                            \
+          test
+
+  # GoToImprecise - identical to GoToDeclaration
+  #
+  # the semantics of this seem the wrong way round to me. GoToDefinition should
+  # go to where a method is implemented, not where it is declared.
+  #
+  tests = [
+    # Local::x -> declaration of x
+    { 'request': [24,25], 'response': [5 ,9 ] },
+    # Local::in_line -> declaration of Local::inline
+    { 'request': [25,29], 'response': [7 ,10] },
+    # Local -> declaration of Local
+    { 'request': [25,19], 'response': [3 ,11] },
+    # sic: Local::out_of_line -> definition of Local::out_of_line
+    { 'request': [26,30], 'response': [15,13 ] }, # sic
+    # sic: GoToDeclaration on definition of out_of_line moves to itself
+    { 'request': [15,13], 'response': [15,13] }, # sic
+    # main -> definition of main (not declaration)
+    { 'request': [22,7 ], 'response': [22,5] }, # sic
+  ]
+
+  for test in tests:
+    yield _RunCompleterCommand_GoTo_all_Clang, \
+          'GoTo_all_Clang_test.cc',            \
+          ['GoToImprecise'],                   \
+          test
+
+def _RunCompleterCommand_Message_Clang(filename, test, command):
+  contents = open( PathToTestFile( filename ) ).read()
+  app = TestApp( handlers.app )
+
+  common_args = {
+    'completer_target'  : 'filetype_default',
+    'command_arguments' : command,
+    'compilation_flags' : ['-x', 
+                           'c++', 
+                           '-std=c++11'],
+    'line_num'          : 10,
+    'column_num'        : 3,
+    'contents'          : contents,
+    'filetype'          : 'cpp'
+  }
+
+  args = test[0]
+  expected = test[1];
+
+  request = common_args
+  request.update( args )
+
+  request_data = BuildRequest( **request )
+
+  eq_( {'message': expected},
+        app.post_json( '/run_completer_command', request_data ).json )
+
+
+@with_setup( Setup )
+def RunCompleterCommand_GetType_Clang_test():
+  tests = [
+  # basic pod types
+    [{'line_num' : 12, 'column_num': 3} , 'Foo'],
+    [{'line_num' : 1,  'column_num': 1} , 'Internal error: cursor not valid'],
+    [{'line_num' : 4,  'column_num': 2} , 'Foo'],
+    [{'line_num' : 4,  'column_num': 8} , 'Foo'],
+    [{'line_num' : 4,  'column_num': 9} , 'Foo'],
+    [{'line_num' : 4,  'column_num': 10} , 'Foo'],
+    [{'line_num' : 5,  'column_num': 3} , 'int'],
+    [{'line_num' : 5,  'column_num': 7} , 'int'],
+    [{'line_num' : 7,  'column_num': 7} , 'char'],
+
+  # function
+    [{'line_num' : 10, 'column_num': 2} , 'int ()'],
+    [{'line_num' : 10, 'column_num': 6} , 'int ()'],
+
+  # std::string and canonical type
+    # on std:: (Unknown)
+    [{'line_num' : 13, 'column_num': 3} , 'Unknown type'], # sic
+    # on string (string)
+    [{'line_num' : 13, 'column_num': 8} , 
+                                  'string => std::basic_string<char>'], # sic
+    # on a (std::string)
+    [{'line_num' : 13, 'column_num': 15} , 
+                                  'std::string => std::basic_string<char>'],
+    [{'line_num' : 14, 'column_num': 16} , 
+                                  'std::string => std::basic_string<char>'],
+
+  # cursor on decl for refs & pointers
+    [{'line_num' : 27, 'column_num': 3} ,  'Foo'],
+    [{'line_num' : 27, 'column_num': 11} , 'Foo &'],
+    [{'line_num' : 27, 'column_num': 15} , 'Foo'],
+    [{'line_num' : 28, 'column_num': 3} ,  'Foo'],
+    [{'line_num' : 28, 'column_num': 11} , 'Foo *'],
+    [{'line_num' : 28, 'column_num': 18} , 'Foo'],
+    [{'line_num' : 30, 'column_num': 3} ,  'const Foo &'], 
+    [{'line_num' : 30, 'column_num': 16} , 'const Foo &'], 
+    [{'line_num' : 31, 'column_num': 3} ,  'const Foo *'], 
+    [{'line_num' : 31, 'column_num': 16} , 'const Foo *'], 
+  # cursor on usage
+    [{'line_num' : 33, 'column_num': 17} , 'const Foo'],
+    [{'line_num' : 33, 'column_num': 21} , 'const int'],
+    [{'line_num' : 34, 'column_num': 17} , 'const Foo *'],
+    [{'line_num' : 34, 'column_num': 22} , 'const int'],
+    [{'line_num' : 35, 'column_num': 17} , 'Foo'],
+    [{'line_num' : 35, 'column_num': 21} , 'int'],
+    [{'line_num' : 36, 'column_num': 17} , 'Foo *'],
+    [{'line_num' : 36, 'column_num': 22} , 'int'],
+
+  # auto behaves strangely (bug in libclang)
+    [{'line_num' : 16, 'column_num': 3} ,  'auto &'], # sic
+    [{'line_num' : 16, 'column_num': 11} , 'auto &'], # sic
+    [{'line_num' : 16, 'column_num': 18} , 'Foo'],
+    [{'line_num' : 17, 'column_num': 3} ,  'auto *'], # sic
+    [{'line_num' : 17, 'column_num': 11} , 'auto *'], # sic
+    [{'line_num' : 17, 'column_num': 18} , 'Foo'],
+    [{'line_num' : 19, 'column_num': 3} ,  'const auto &'], # sic
+    [{'line_num' : 19, 'column_num': 16} , 'const auto &'], # sic
+    [{'line_num' : 20, 'column_num': 3} ,  'const auto *'], # sic
+    [{'line_num' : 20, 'column_num': 16} , 'const auto *'], # sic
+  # auto sort of works in usage (but canonical types apparently differ)
+    [{'line_num' : 22, 'column_num': 17} , 'const Foo => const Foo'], #sic
+    [{'line_num' : 22, 'column_num': 23} , 'const int'],
+    [{'line_num' : 23, 'column_num': 17} , 'const Foo * => const Foo *'], #sic
+    [{'line_num' : 23, 'column_num': 24} , 'const int'],
+    [{'line_num' : 24, 'column_num': 17} , 'Foo => Foo'], #sic
+    [{'line_num' : 24, 'column_num': 22} , 'int'],
+    [{'line_num' : 25, 'column_num': 17} , 'Foo * => Foo *'], #sic
+    [{'line_num' : 25, 'column_num': 23} , 'int'],
+    
+  ]
+
+  for test in tests:
+    yield _RunCompleterCommand_Message_Clang, \
+          'GetType_Clang_test.cc',            \
+          test,                               \
+          ['GetType']
+
+@with_setup( Setup )
+def RunCompleterCommand_GetParent_Clang_test():
+  tests = [
+    [{'line_num' : 1 ,  'column_num': 1 } , 'Internal error: cursor not valid'],
+  # would be file name if we had one:
+    [{'line_num' : 3 ,  'column_num': 8 } , '/foo'],
+
+  # the reported scope does not include parents
+    [{'line_num' : 4 ,  'column_num': 11} , 'A'],
+    [{'line_num' : 5 ,  'column_num': 13} , 'B'],
+    [{'line_num' : 6 ,  'column_num': 13} , 'B'],
+    [{'line_num' : 10,  'column_num': 17} , 'do_z_inline()'],
+    [{'line_num' : 16,  'column_num': 22} , 'do_anything(T &)'],
+    [{'line_num' : 20,  'column_num': 9 } , 'A'],
+    [{'line_num' : 21,  'column_num': 9 } , 'A'],
+    [{'line_num' : 23,  'column_num': 12} , 'A'],
+    [{'line_num' : 24,  'column_num': 5 } , 'do_Z_inline()'],
+    [{'line_num' : 25,  'column_num': 12} , 'do_Z_inline()'],
+    [{'line_num' : 29,  'column_num': 14} , 'A'],
+
+    [{'line_num' : 35,  'column_num': 1 } , 'do_anything(T &)'],
+    [{'line_num' : 40,  'column_num': 1 } , 'do_x()'],
+    [{'line_num' : 45,  'column_num': 1 } , 'do_y()'],
+    [{'line_num' : 50,  'column_num': 1 } , 'main()'],
+
+  # lambdas report the name of the variable
+    [{'line_num' : 50,  'column_num': 14} , 'l'],
+    [{'line_num' : 51,  'column_num': 19} , 'l'],
+    [{'line_num' : 52,  'column_num': 16} , 'main()'],
+  
+  ]
+
+  for test in tests:
+    yield _RunCompleterCommand_Message_Clang, \
+          'GetParent_Clang_test.cc',          \
+          test,                               \
+          ['GetParent']
 
 @with_setup( Setup )
 def RunCompleterCommand_GoTo_CsCompleter_Works_test():

--- a/ycmd/tests/testdata/GetParent_Clang_test.cc
+++ b/ycmd/tests/testdata/GetParent_Clang_test.cc
@@ -1,0 +1,57 @@
+// this file is used in RunCompleterCommand_GetParent_Clang_test
+#include <iostream>
+struct A {
+    struct B {
+        int x;
+        char do_x();
+
+        char do_z_inline()
+        {
+            return 'z';
+        }
+
+        template<typename T>
+        char do_anything(T &t)
+        {
+            std::cout << t;
+        }
+    };
+
+    int y;
+    char do_y();
+
+    char do_Z_inline()
+    {
+        return 'Z';
+    }
+ 
+    template<typename T>
+    char do_anything(T &t);
+};
+
+template<typename T>
+char A::do_anything(T &t)
+{
+    std::cout << t;
+}
+
+char A::B::do_x()
+{
+    return 'x';
+}
+
+char A::do_y()
+{
+    return 'y';
+}
+
+int main()
+{
+    auto l = [](){ 
+        std::cout << "lambda";
+    };
+
+    l();
+
+    return 0;
+}

--- a/ycmd/tests/testdata/GetType_Clang_test.cc
+++ b/ycmd/tests/testdata/GetType_Clang_test.cc
@@ -1,0 +1,40 @@
+// this file is used in RunCompleterCommand_GetType_Clang_test
+#include <iostream>
+#include <string>
+struct Foo {
+  int x;
+  int y;
+  char c;
+};
+
+int main()
+{
+  Foo foo;
+  std::string a = "hello";
+  std::cout << a;
+
+  auto &arFoo = foo;
+  auto *apFoo = &foo;
+
+  const auto &acrFoo = foo;
+  const auto *acpFoo = &foo;
+
+  std::cout << acrFoo.y
+            << acpFoo->x 
+            << arFoo.y 
+            << apFoo->x;
+
+  Foo &rFoo = foo;
+  Foo *pFoo = &foo;
+
+  const Foo &crFoo = foo;
+  const Foo *cpFoo = &foo;
+
+  std::cout << crFoo.y
+            << cpFoo->x 
+            << rFoo.y 
+            << pFoo->x;
+
+
+  return 0;
+}

--- a/ycmd/tests/testdata/GoTo_Clang_ZeroBasedLineAndColumn_test.cc
+++ b/ycmd/tests/testdata/GoTo_Clang_ZeroBasedLineAndColumn_test.cc
@@ -1,0 +1,12 @@
+// this file is used in RunCompleterCommand_GoTo_Clang_ZeroBasedLineAndColumn_test
+struct Foo {
+  int x;
+  int y;
+  char c;
+};
+
+int main()
+{
+  Foo foo;
+  return 0;
+}

--- a/ycmd/tests/testdata/GoTo_all_Clang_test.cc
+++ b/ycmd/tests/testdata/GoTo_all_Clang_test.cc
@@ -1,0 +1,28 @@
+// This file is used in RunCompleterCommand_GoTo_all_Clang_test
+#include <iostream>
+namespace Local
+{
+    int x;
+
+    char in_line()
+    {
+        return 'y';
+    };
+
+    char out_of_line();
+}
+
+char Local::out_of_line()
+{
+    return 'x';
+}
+
+int main();
+
+int main()
+{
+    std::cout << Local::x 
+              << Local::in_line()
+              << Local::out_of_line();
+    return 0;
+}


### PR DESCRIPTION
GetType - returns the type of the word at a specific location. This is used by
YouCompleteMe and echo'd in vim. Where the canonical type (the "derived" type,
e.g. for a typedef) is different from the declared type, that is also returned,
separated with " => ".
GetParent - returns the semantic parent of the word at a specific location.
This is also echo'd in vim by YouCompleteMe.

One other change was required to satisty the cylomatic complexity check in the
test suite: the  if:elif: pattern in OnUserCommand was changed to a pythonic
switch (a dictionary)

see also https://github.com/Valloric/ycmd/pull/87 for details and history.