### PR TITLE
Enhance test suite

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function usage {
-  echo "Usage: $0 [--no-clang-completer] [--skip-build]"
+  echo "Usage: $0 [--no-clang-completer] [--skip-build] [-- nose args]"
   exit 0
 }
 
@@ -14,13 +14,19 @@ flake8 --select=F,C9 --max-complexity=10 --exclude=testdata "${SCRIPT_DIR}/ycmd"
 
 use_clang_completer=true
 skip_build=false
-for flag in $@; do
-  case "$flag" in
+while [ "$*" ]; do
+  case "$1" in
     --no-clang-completer)
       use_clang_completer=false
+      shift
       ;;
     --skip-build)
       skip_build=true
+      shift
+      ;;
+    --)
+      shift
+      break
       ;;
     *)
       usage
@@ -50,7 +56,15 @@ for directory in "${SCRIPT_DIR}"/third_party/*; do
 done
 
 if $use_clang_completer; then
-  nosetests -v "${SCRIPT_DIR}/ycmd"
+  if [ "$*" ]; then
+    nosetests -v $@
+  else
+    nosetests -v "${SCRIPT_DIR}/ycmd"
+  fi
 else
-  nosetests -v --exclude=".*Clang.*" "${SCRIPT_DIR}/ycmd"
+  if "$*"; then
+    nosetests -v --exclude=".*Clang.*" $@
+  else
+    nosetests -v --exclude=".*Clang.*" "${SCRIPT_DIR}/ycmd"
+  fi
 fi

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -74,9 +74,12 @@ def StopOmniSharpServer( app ):
 
 
 def WaitUntilOmniSharpServerReady( app ):
-  while True:
+  retries = 100;
+  success = False;
+  while retries > 0:
     result = app.get( '/ready', { 'include_subservers': 1 } ).json
     if result:
+      success = True;
       break
     request = BuildRequest( completer_target = 'filetype_default',
                             command_arguments = [ 'ServerTerminated' ],
@@ -85,5 +88,9 @@ def WaitUntilOmniSharpServerReady( app ):
     if result:
       raise RuntimeError( "OmniSharp failed during startup." )
     time.sleep( 0.2 )
+    retries = retries - 1
+
+  if not success:
+    raise RuntimeError( "Timeout waiting for OmniSharpServer" )
 
 


### PR DESCRIPTION
Enhance test suite

Update run_tests.sh to allow arguments to be passed directly to "nosetests".
This allows developers to run specific test scripts or specific test methods.

Ensure also that the test suite does not hang forever when problems with, say,
the installation cause OmniSharpServer to fail to start. Instead timeout after
20s.