### PR TITLE
fixed complete in objective-c.

### DIFF
--- a/cpp/ycm/ClangCompleter/CompletionData.h
+++ b/cpp/ycm/ClangCompleter/CompletionData.h
@@ -118,7 +118,8 @@ private:
   void ExtractDataFromChunk( CXCompletionString completion_string,
                              uint chunk_num,
                              bool &saw_left_paren,
-                             bool &saw_function_params );
+                             bool &saw_function_params,
+                             bool &saw_placeholder);
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/tests/ClangCompleter/ClangCompleter_test.cpp
+++ b/cpp/ycm/tests/ClangCompleter/ClangCompleter_test.cpp
@@ -41,6 +41,35 @@ TEST( ClangCompleterTest, CandidatesForLocationInFile ) {
 
   EXPECT_TRUE( !completions.empty() );
 }
+    
+TEST( ClangCompleterTest, CandidatesObjCForLocationInFile ) {
+    ClangCompleter completer;
+    std::vector< CompletionData > completions =
+    completer.CandidatesForLocationInFile(
+                                          PathToTestFile( "SWObject.m" ).string(),
+                                          6,
+                                          16,
+                                          std::vector< UnsavedFile >(),
+                                          std::vector< std::string >{"-x", "objective-c"} );
+    
+    EXPECT_TRUE( !completions.empty() && completions[0].TextToInsertInBuffer() == "withArg2:");
+}
+    
+TEST( ClangCompleterTest, CandidatesObjCFuncForLocationInFile ) {
+    ClangCompleter completer;
+    std::vector< CompletionData > completions =
+    completer.CandidatesForLocationInFile(
+                                          PathToTestFile( "SWObject.m" ).string(),
+                                          9,
+                                          3,
+                                          std::vector< UnsavedFile >(),
+                                          std::vector< std::string >{"-x", "objective-c"} );
+    
+    EXPECT_TRUE( !completions.empty() &&
+      completions[0].TextToInsertInBuffer()
+      == "(void)test:(int)arg1 withArg2:(int)arg2 withArg3:(int)arg3");
+}
+    
 
 
 TEST( ClangCompleterTest, GetDefinitionLocation ) {

--- a/cpp/ycm/tests/testdata/SWObject.h
+++ b/cpp/ycm/tests/testdata/SWObject.h
@@ -1,0 +1,7 @@
+@interface SWObject 
+/** testFunc
+ *
+ * a detail description
+ */
+- (void)test:(int)arg1 withArg2:(int)arg2 withArg3:(int)arg3;
+@end

--- a/cpp/ycm/tests/testdata/SWObject.m
+++ b/cpp/ycm/tests/testdata/SWObject.m
@@ -1,0 +1,11 @@
+#import "SWObject.h"
+
+@implementation SWObject
+
+- (void)test {
+  [self test:0 /*complete at here*/]
+}
+
+- /*complete at here*/
+
+@end


### PR DESCRIPTION
> when completing multi-param in objective-c files, the origin implementation only
> completed the last param. this commit fixed it. it will complete the first param,
> then after the user input param, call completion again to get second param, and
> so on.
> it also support completing declared methods or inherited methods. the user can
> call the completion after input '+ ' or '- '

here I fixed objective-c support in ycm. I have used it for months. 
I think a good support for objective-c can earn more iOS & MAC developers. 
Relative Issue: [YouCompleteMe #1221](https://github.com/Valloric/YouCompleteMe/issues/1221)
here is a preview:
![img2](https://cloud.githubusercontent.com/assets/3897953/6884686/f96fdeda-d62f-11e4-89fd-a8c64980e0ba.gif)
(I already sign **Google Contributor License Agreement**)