### PR TITLE
Add additionial class information to gocode completion data

### DIFF
--- a/ycmd/completers/go/gocode_completer.py
+++ b/ycmd/completers/go/gocode_completer.py
@@ -130,6 +130,7 @@ def _ConvertCompletionData( completion_data ):
   return responses.BuildCompletionData(
     insertion_text = completion_data[ 'name' ],
     menu_text = completion_data[ 'name' ],
-    extra_menu_info = completion_data[ 'type' ] )
+    extra_menu_info = completion_data[ 'type' ],
+    kind = completion_data[ 'class' ])
 
 

--- a/ycmd/completers/go/tests/gocode_completer_test.py
+++ b/ycmd/completers/go/tests/gocode_completer_test.py
@@ -84,7 +84,8 @@ class GoCodeCompleter_test( object ):
     eq_(result, [{
         'menu_text': u'Prefix',
         'insertion_text': u'Prefix',
-        'extra_menu_info': u'func() string'
+        'extra_menu_info': u'func() string',
+        'kind': u'func'
     }])
 
   # Test gocode failure.


### PR DESCRIPTION
`gocode` also returns `class` information for candidate. Add this to `detailed_info`

I have read and signed the Google CLA.