### PR TITLE
Continuous C# completions

### DIFF
--- a/ycmd/tests/testdata/testy/ContinuousTest.cs
+++ b/ycmd/tests/testdata/testy/ContinuousTest.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace testy
+{
+	public class ContinuousTest
+	{
+		public static void Main (string[] args)
+		{
+			var test = String
+		}
+	}
+}

--- a/ycmd/tests/testdata/testy/testy.csproj
+++ b/ycmd/tests/testdata/testy/testy.csproj
@@ -34,6 +34,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContinuousTest.cs" />
     <Compile Include="GetTypeTestCase.cs" />
     <Compile Include="GotoTestCase.cs" />
     <Compile Include="ImportTest.cs" />


### PR DESCRIPTION
While researching [NRefactory](https://github.com/icsharpcode/NRefactory), which our C# completer, [Omnisharp](https://github.com/OmniSharp/omnisharp-server), is a wrapper of, I noticed that it provided a "controlspace" parameter to a completion generator method. Upon investigation, it appears that [it should called with true for explicit completion (by, for example, pressing control-space), and with false for non-explicit completion (the completion-as-you-type that Ycmd is used for)](https://github.com/icsharpcode/SharpDevelop/blob/newNR/src/AddIns/BackendBindings/CSharpBinding/Project/Src/Completion/CSharpCompletionBinding.cs). This pull request implements this behavior.

When you are typing, the C# semantic completer is called in non-controlspace mode. Additionally, it is called everywhere, and is no longer restricted to locations matching the triggers. When it returns no completions, ycmd will fallback to the identifier completer. When you explicitly ask for completion (for example, by the completion key-bind in YouCompleteMe), the C# semantic completer is called in controlspace mode.

These two modes are not interchangeable, so this required altering the cache logic as well. We need to only return the cache if it matches the correct mode. I implemented this in a way which should not affect the other completers.

In my performance testing, the non-controlspace completions returns in sub-1/10 second in almost all cases. The only syntax which I noticed slowness is after a new keyword. The identifier completer results were rarely relevant in this case, and the semantic completions returns the constructors, so I feel this is acceptable.

Note also that this change required pulling forward our OmniSharpServer submodule. I have not noticed any regressions in my testing.

I have signed the CLA.