### PR TITLE
Blacklist -Xclang flags for C/C++ completion

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -137,9 +137,30 @@ def _CallExtraConfFlagsForFile( module, filename, client_data ):
 
 
 def PrepareFlagsForClang( flags, filename ):
+  flags = _RemoveXclangFlags( flags )
   flags = _RemoveUnusedFlags( flags, filename )
   flags = _SanitizeFlags( flags )
   return flags
+
+
+def _RemoveXclangFlags( flags ):
+  """Drops -Xclang flags.  These are typically used to pass in options to
+  clang cc1 which are not used in the front-end, so they are not needed for
+  code completion."""
+
+  sanitized_flags = []
+  saw_xclang = False
+  for i, flag in enumerate( flags ):
+    if flag == '-Xclang':
+      saw_xclang = True
+      continue
+    elif saw_xclang:
+      saw_xclang = False
+      continue
+
+    sanitized_flags.append( flag )
+
+  return sanitized_flags
 
 
 def _SanitizeFlags( flags ):

--- a/ycmd/completers/cpp/tests/flags_test.py
+++ b/ycmd/completers/cpp/tests/flags_test.py
@@ -166,3 +166,18 @@ def RemoveUnusedFlags_RemoveFilenameWithoutPrecedingInclude_test():
   eq_( expected + expected,
        flags._RemoveUnusedFlags( expected + to_remove + expected, filename ) )
 
+def RemoveXclangFlags():
+  expected = [ '-I', '/foo/bar', '-DMACRO=Value' ]
+  to_remove = [ '-Xclang', 'load', '-Xclang', 'libplugin.so',
+                '-Xclang', '-add-plugin', '-Xclang', 'plugin-name' ]
+  filename = 'file'
+
+  eq_( expected,
+       flags._RemoveXclangFlags( expected + to_remove, filename ) )
+
+  eq_( expected,
+       flags._RemoveXclangFlags( to_remove + expected, filename ) )
+
+  eq_( expected + expected,
+       flags._RemoveXclangFlags( expected + to_remove + expected, filename ) )
+


### PR DESCRIPTION
-Xclang flags are typically not used in the front-end, so they shouldn't affect anything that we care about for code completion.

Some background on why I made this change: I was trying to get YCM to work on the Mozilla code base.  We use a clang plugin to perform some static analysis checks when building our code.  When ycmd tries to use libclang, libclang fails to load the plugin so semantic code completion doesn't work.

When I was thinking about how to fix this, we realized that we should just ignore -Xclang options, since they are intended for cc1, which means they usually affect code generation but not syntax parsing and AST generation, which is all we need from libclang for code completion.