### PR TITLE
Add path and line to python completion data

### DIFF
--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -56,12 +56,30 @@ class JediCompleter( Completer ):
       return jedi.Script( contents, line, column, filename )
 
 
+  def _GetExtraData( self, completion ):
+      location = {}
+      if completion.module_path:
+        location[ 'filepath' ] = ToUtf8IfNeeded( completion.module_path )
+      if completion.line:
+        location[ 'line_num' ] = completion.line
+      if completion.column:
+        location[ 'column_num' ] = completion.column + 1
+
+      if location:
+        extra_data = {}
+        extra_data[ 'location' ] = location
+        return extra_data
+      else:
+        return None
+
+
   def ComputeCandidatesInner( self, request_data ):
     script = self._GetJediScript( request_data )
     return [ responses.BuildCompletionData(
                 ToUtf8IfNeeded( completion.name ),
                 ToUtf8IfNeeded( completion.description ),
-                ToUtf8IfNeeded( completion.docstring() ) )
+                ToUtf8IfNeeded( completion.docstring() ),
+                extra_data = self._GetExtraData( completion ) )
              for completion in script.completions() ]
 
   def DefinedSubcommands( self ):

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -42,6 +42,12 @@ def CompletionEntryMatcher( insertion_text ):
   return has_entry( 'insertion_text', insertion_text )
 
 
+def CompletionLocationMatcher( location_type, value ):
+  return has_entry( 'extra_data',
+                    has_entry( 'location',
+                               has_entry( location_type, value ) ) )
+
+
 @with_setup( Setup )
 def GetCompletions_RequestValidation_NoLineNumException_test():
   app = TestApp( handlers.app )
@@ -677,8 +683,15 @@ def GetCompletions_JediCompleter_Basic_test():
 
   results = app.post_json( '/completions',
                            completion_data ).json[ 'completions' ]
-  assert_that( results, has_items( CompletionEntryMatcher( 'a' ),
-                                   CompletionEntryMatcher( 'b' ) ) )
+
+  assert_that( results,
+               has_items(
+                 CompletionEntryMatcher( 'a' ),
+                 CompletionEntryMatcher( 'b' ),
+                 CompletionLocationMatcher( 'line_num', 3 ),
+                 CompletionLocationMatcher( 'line_num', 4 ),
+                 CompletionLocationMatcher( 'column_num', 10 ),
+                 CompletionLocationMatcher( 'filepath', filepath ) ) )
 
 
 @with_setup( Setup )


### PR DESCRIPTION
jedi provides the location of the completion candidate as `line` and `path`. In `company-ycmd` for Emacs this information can be used to jump to the location while completion popup is open.

I have read and signed the Google CLA