### PR TITLE
Fix run_tests.sh for no clang case

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -62,7 +62,7 @@ if $use_clang_completer; then
     nosetests -v "${SCRIPT_DIR}/ycmd"
   fi
 else
-  if "$*"; then
+  if [ "$*" ]; then
     nosetests -v --exclude=".*Clang.*" $@
   else
     nosetests -v --exclude=".*Clang.*" "${SCRIPT_DIR}/ycmd"


### PR DESCRIPTION
The clang case has [] - the no clang case should too.

I've already signed the CLA.