### PR TITLE
Add GetType completer command for CSharp completer

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -95,6 +95,8 @@ class CsharpCompleter( Completer ):
         self._GoToImplementation( request_data, False ) ),
     'GoToImplementationElseDeclaration': ( lambda self, request_data:
         self._GoToImplementation( request_data, True ) ),
+    'TypeLookup': ( lambda self, request_data: self._TypeLookup(
+        request_data ) ),
   }
 
   def __init__( self, user_options ):
@@ -364,6 +366,12 @@ class CsharpCompleter( Completer ):
         raise RuntimeError( 'Can\'t jump to implementation' )
       else:
         raise RuntimeError( 'No implementations found' )
+
+
+  def _TypeLookup( self, request_data ):
+    result = self._GetResponse( '/typelookup',
+                                self._DefaultParameters( request_data ) )
+    return responses.BuildDisplayMessageResponse( result[ "Documentation" ] )
 
 
   def _DefaultParameters( self, request_data ):

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -95,7 +95,7 @@ class CsharpCompleter( Completer ):
         self._GoToImplementation( request_data, False ) ),
     'GoToImplementationElseDeclaration': ( lambda self, request_data:
         self._GoToImplementation( request_data, True ) ),
-    'TypeLookup': ( lambda self, request_data: self._TypeLookup(
+    'GetType': ( lambda self, request_data: self._GetType(
         request_data ) ),
   }
 
@@ -368,7 +368,7 @@ class CsharpCompleter( Completer ):
         raise RuntimeError( 'No implementations found' )
 
 
-  def _TypeLookup( self, request_data ):
+  def _GetType( self, request_data ):
     request = self._DefaultParameters( request_data )
     request[ "IncludeDocumentation" ] = True
 

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -369,9 +369,15 @@ class CsharpCompleter( Completer ):
 
 
   def _TypeLookup( self, request_data ):
-    result = self._GetResponse( '/typelookup',
-                                self._DefaultParameters( request_data ) )
-    return responses.BuildDisplayMessageResponse( result[ "Documentation" ] )
+    request = self._DefaultParameters( request_data )
+    request[ "IncludeDocumentation" ] = True
+
+    result = self._GetResponse( '/typelookup', request )
+    message = result[ "Type" ]
+    if ( result[ "Documentation" ] ):
+      message += "\n" + result[ "Documentation" ]
+
+    return responses.BuildDisplayMessageResponse( message )
 
 
   def _DefaultParameters( self, request_data ):

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -603,11 +603,11 @@ def RunCompleterCommand_GoToImplementationElseDeclaration_CsCompleter_MultipleIm
 
 
 @with_setup( Setup )
-def RunCompleterCommand_TypeLookup_CsCompleter_test():
+def RunCompleterCommand_GetType_CsCompleter_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/TypeLookupTestCase.cs' )
+  filepath = PathToTestFile( 'testy/GetTypeTestCase.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -617,8 +617,8 @@ def RunCompleterCommand_TypeLookup_CsCompleter_test():
   app.post_json( '/event_notification', event_data )
   WaitUntilOmniSharpServerReady( app )
 
-  typelookup_data = BuildRequest( completer_target = 'filetype_default',
-                            command_arguments = ['TypeLookup'],
+  gettype_data = BuildRequest( completer_target = 'filetype_default',
+                            command_arguments = ['GetType'],
                             line_num = 5,
                             column_num = 5,
                             contents = contents,
@@ -628,7 +628,7 @@ def RunCompleterCommand_TypeLookup_CsCompleter_test():
   eq_( {
         u'message': u"string str"
       },
-      app.post_json( '/run_completer_command', typelookup_data ).json )
+      app.post_json( '/run_completer_command', gettype_data ).json )
 
   StopOmniSharpServer( app )
 

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -603,7 +603,69 @@ def RunCompleterCommand_GoToImplementationElseDeclaration_CsCompleter_MultipleIm
 
 
 @with_setup( Setup )
-def RunCompleterCommand_GetType_CsCompleter_test():
+def RunCompleterCommand_GetType_CsCompleter_EmptyMessage_test():
+  app = TestApp( handlers.app )
+  app.post_json( '/ignore_extra_conf_file',
+                 { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
+  filepath = PathToTestFile( 'testy/GetTypeTestCase.cs' )
+  contents = open( filepath ).read()
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'cs',
+                             contents = contents,
+                             event_name = 'FileReadyToParse' )
+
+  app.post_json( '/event_notification', event_data )
+  WaitUntilOmniSharpServerReady( app )
+
+  gettype_data = BuildRequest( completer_target = 'filetype_default',
+                            command_arguments = ['GetType'],
+                            line_num = 1,
+                            column_num = 1,
+                            contents = contents,
+                            filetype = 'cs',
+                            filepath = filepath )
+
+  eq_( {
+        u'message': u""
+      },
+      app.post_json( '/run_completer_command', gettype_data ).json )
+
+  StopOmniSharpServer( app )
+
+
+@with_setup( Setup )
+def RunCompleterCommand_GetType_CsCompleter_VariableDeclaration_test():
+  app = TestApp( handlers.app )
+  app.post_json( '/ignore_extra_conf_file',
+                 { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
+  filepath = PathToTestFile( 'testy/GetTypeTestCase.cs' )
+  contents = open( filepath ).read()
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'cs',
+                             contents = contents,
+                             event_name = 'FileReadyToParse' )
+
+  app.post_json( '/event_notification', event_data )
+  WaitUntilOmniSharpServerReady( app )
+
+  gettype_data = BuildRequest( completer_target = 'filetype_default',
+                            command_arguments = ['GetType'],
+                            line_num = 4,
+                            column_num = 5,
+                            contents = contents,
+                            filetype = 'cs',
+                            filepath = filepath )
+
+  eq_( {
+        u'message': u"string"
+      },
+      app.post_json( '/run_completer_command', gettype_data ).json )
+
+  StopOmniSharpServer( app )
+
+
+@with_setup( Setup )
+def RunCompleterCommand_GetType_CsCompleter_VariableUsage_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
@@ -627,6 +689,37 @@ def RunCompleterCommand_GetType_CsCompleter_test():
 
   eq_( {
         u'message': u"string str"
+      },
+      app.post_json( '/run_completer_command', gettype_data ).json )
+
+  StopOmniSharpServer( app )
+
+
+@with_setup( Setup )
+def RunCompleterCommand_GetType_CsCompleter_Constant_test():
+  app = TestApp( handlers.app )
+  app.post_json( '/ignore_extra_conf_file',
+                 { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
+  filepath = PathToTestFile( 'testy/GetTypeTestCase.cs' )
+  contents = open( filepath ).read()
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'cs',
+                             contents = contents,
+                             event_name = 'FileReadyToParse' )
+
+  app.post_json( '/event_notification', event_data )
+  WaitUntilOmniSharpServerReady( app )
+
+  gettype_data = BuildRequest( completer_target = 'filetype_default',
+                            command_arguments = ['GetType'],
+                            line_num = 4,
+                            column_num = 14,
+                            contents = contents,
+                            filetype = 'cs',
+                            filepath = filepath )
+
+  eq_( {
+        u'message': u"System.String"
       },
       app.post_json( '/run_completer_command', gettype_data ).json )
 

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -620,16 +620,13 @@ def RunCompleterCommand_TypeLookup_CsCompleter_test():
   typelookup_data = BuildRequest( completer_target = 'filetype_default',
                             command_arguments = ['TypeLookup'],
                             line_num = 5,
-                            column_num = 12,
+                            column_num = 5,
                             contents = contents,
                             filetype = 'cs',
                             filepath = filepath )
 
   eq_( {
-        u'message': u"""Determines whether the end of this string instance matches the specified string.\r
-Returns: true if value matches the end of this instance; otherwise, false.\r
-value: The string to compare to the substring at the end of this instance. \r
-System.ArgumentNullException: value is null. """
+        u'message': u"string str"
       },
       app.post_json( '/run_completer_command', typelookup_data ).json )
 

--- a/ycmd/tests/testdata/testy/GetTypeTestCase.cs
+++ b/ycmd/tests/testdata/testy/GetTypeTestCase.cs
@@ -1,0 +1,8 @@
+namespace testy {
+	public class GetTypeTestCase {
+		public GetTypeTestCase() {
+			var str = "";
+			str.EndsWith("A");
+		}
+	}
+}

--- a/ycmd/tests/testdata/testy/TypeLookupTestCase.cs
+++ b/ycmd/tests/testdata/testy/TypeLookupTestCase.cs
@@ -1,8 +1,0 @@
-namespace testy {
-	public class TypeLookupTestCase {
-		public TypeLookupTestCase() {
-			var str = "";
-			str.EndsWith("A");
-		}
-	}
-}

--- a/ycmd/tests/testdata/testy/TypeLookupTestCase.cs
+++ b/ycmd/tests/testdata/testy/TypeLookupTestCase.cs
@@ -1,0 +1,8 @@
+namespace testy {
+	public class TypeLookupTestCase {
+		public TypeLookupTestCase() {
+			var str = "";
+			str.EndsWith("A");
+		}
+	}
+}

--- a/ycmd/tests/testdata/testy/testy.csproj
+++ b/ycmd/tests/testdata/testy/testy.csproj
@@ -37,6 +37,7 @@
     <Compile Include="GotoTestCase.cs" />
     <Compile Include="ImportTest.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="TypeLookupTestCase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/ycmd/tests/testdata/testy/testy.csproj
+++ b/ycmd/tests/testdata/testy/testy.csproj
@@ -34,10 +34,10 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GetTypeTestCase.cs" />
     <Compile Include="GotoTestCase.cs" />
     <Compile Include="ImportTest.cs" />
     <Compile Include="Program.cs" />
-    <Compile Include="TypeLookupTestCase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This command displays documentation on the type under the cursor.

This is the command I was using in the screenshot in  https://github.com/Valloric/YouCompleteMe/pull/1499.

I've already signed the CLA.