### PR TITLE
Remove deprecated --use-mirrors argument from pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 before_install:
   - git submodule update --init --recursive
 install:
-  - pip install -r test_requirements.txt --use-mirrors
+  - pip install -r test_requirements.txt
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo add-apt-repository -y ppa:ermshiperete/monodevelop
   - sudo apt-get -qq update


### PR DESCRIPTION
Pip no longer supports --use-mirrors since version 1.5. See https://github.com/pypa/pip/pull/1098.

CLA signed.