### PR TITLE
New completion format

### DIFF
--- a/cpp/ycm/CandidateRepository.cpp
+++ b/cpp/ycm/CandidateRepository.cpp
@@ -95,11 +95,11 @@ std::vector< const Candidate * > CandidateRepository::GetCandidatesForStrings(
 
     foreach ( const CompletionData & data, datas ) {
       const Candidate *&candidate = GetValueElseInsert( candidate_holder_,
-                                                        data.original_string_,
+                                                        data.typed_string_,
                                                         NULL );
 
       if ( !candidate )
-        candidate = new Candidate( data.original_string_ );
+        candidate = new Candidate( data.typed_string_ );
 
       candidates.push_back( candidate );
     }

--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -165,7 +165,6 @@ std::vector< CompletionData > ToCompletionDataVector(
     return completions;
 
   completions.reserve( results->NumResults );
-  unordered_map< std::string, uint > seen_data;
 
   for ( uint i = 0; i < results->NumResults; ++i ) {
     CXCompletionResult completion_result = results->Results[ i ];
@@ -174,24 +173,7 @@ std::vector< CompletionData > ToCompletionDataVector(
       continue;
 
     CompletionData data( completion_result );
-    uint index = GetValueElseInsert( seen_data,
-                                     data.original_string_,
-                                     completions.size() );
-
-    if ( index == completions.size() ) {
-      completions.push_back( boost::move( data ) );
-    }
-
-    else {
-      // If we have already seen this completion, then this is an overload of a
-      // function we have seen. We add the signature of the overload to the
-      // detailed information.
-      completions[ index ].detailed_info_
-      .append( data.return_type_ )
-      .append( " " )
-      .append( data.everything_except_return_type_ )
-      .append( "\n" );
-    }
+    completions.push_back( boost::move( data ) );
   }
 
   return completions;

--- a/cpp/ycm/ClangCompleter/CompletionData.cpp
+++ b/cpp/ycm/ClangCompleter/CompletionData.cpp
@@ -80,30 +80,6 @@ CompletionKind CursorKindToCompletionKind( CXCursorKind kind ) {
 }
 
 
-bool IsMainCompletionTextInfo( CXCompletionChunkKind kind ) {
-  return
-    kind == CXCompletionChunk_Optional     ||
-    kind == CXCompletionChunk_TypedText    ||
-    kind == CXCompletionChunk_Placeholder  ||
-    kind == CXCompletionChunk_LeftParen    ||
-    kind == CXCompletionChunk_RightParen   ||
-    kind == CXCompletionChunk_RightBracket ||
-    kind == CXCompletionChunk_LeftBracket  ||
-    kind == CXCompletionChunk_LeftBrace    ||
-    kind == CXCompletionChunk_RightBrace   ||
-    kind == CXCompletionChunk_RightAngle   ||
-    kind == CXCompletionChunk_LeftAngle    ||
-    kind == CXCompletionChunk_Comma        ||
-    kind == CXCompletionChunk_Colon        ||
-    kind == CXCompletionChunk_SemiColon    ||
-    kind == CXCompletionChunk_Equal        ||
-    kind == CXCompletionChunk_Informative  ||
-    kind == CXCompletionChunk_HorizontalSpace ||
-    kind == CXCompletionChunk_Text;
-
-}
-
-
 std::string ChunkToString( CXCompletionString completion_string,
                            uint chunk_num ) {
   if ( !completion_string )
@@ -112,41 +88,6 @@ std::string ChunkToString( CXCompletionString completion_string,
   return YouCompleteMe::CXStringToString(
            clang_getCompletionChunkText( completion_string, chunk_num ) );
 }
-
-
-std::string OptionalChunkToString( CXCompletionString completion_string,
-                                   uint chunk_num ) {
-  std::string final_string;
-
-  if ( !completion_string )
-    return final_string;
-
-  CXCompletionString optional_completion_string =
-    clang_getCompletionChunkCompletionString( completion_string, chunk_num );
-
-  if ( !optional_completion_string )
-    return final_string;
-
-  uint optional_num_chunks = clang_getNumCompletionChunks(
-                               optional_completion_string );
-
-  for ( uint j = 0; j < optional_num_chunks; ++j ) {
-    CXCompletionChunkKind kind = clang_getCompletionChunkKind(
-                                   optional_completion_string, j );
-
-    if ( kind == CXCompletionChunk_Optional ) {
-      final_string.append( OptionalChunkToString( optional_completion_string,
-                                                  j ) );
-    }
-
-    else {
-      final_string.append( ChunkToString( optional_completion_string, j ) );
-    }
-  }
-
-  return final_string;
-}
-
 
 // NOTE: this function accepts the text param by value on purpose; it internally
 // needs a copy before processing the text so the copy might as well be made on
@@ -158,120 +99,89 @@ std::string RemoveTwoConsecutiveUnderscores( std::string text ) {
   return text;
 }
 
-
-// foo( -> foo
-// foo() -> foo
-std::string RemoveTrailingParens( std::string text ) {
-  if ( boost::ends_with( text, "(" ) ) {
-    boost::erase_tail( text, 1 );
-  } else if ( boost::ends_with( text, "()" ) ) {
-    boost::erase_tail( text, 2 );
-  }
-
-  return text;
-}
-
 } // unnamed namespace
 
 
 CompletionData::CompletionData( const CXCompletionResult &completion_result ) {
-  CXCompletionString completion_string = completion_result.CompletionString;
-
-  if ( !completion_string )
-    return;
-
-  uint num_chunks = clang_getNumCompletionChunks( completion_string );
-  bool saw_left_paren = false;
-  bool saw_function_params = false;
-  bool saw_placeholder = false;
-
-  for ( uint j = 0; j < num_chunks; ++j ) {
-    ExtractDataFromChunk( completion_string,
-                          j,
-                          saw_left_paren,
-                          saw_function_params,
-                          saw_placeholder );
-  }
-
-  original_string_ = RemoveTrailingParens( boost::move( original_string_ ) );
   kind_ = CursorKindToCompletionKind( completion_result.CursorKind );
 
-  // We remove any two consecutive underscores from the function definition
-  // since identifiers with them are ugly, compiler-reserved names. Functions
-  // from the standard library use parameter names like "__pos" and we want to
-  // show them as just "pos". This will never interfere with client code since
-  // ANY C++ identifier with two consecutive underscores in it is
-  // compiler-reserved.
-  everything_except_return_type_ =
-    RemoveTwoConsecutiveUnderscores(
-      boost::move( everything_except_return_type_ ) );
+  CXCompletionString completion_string = completion_result.CompletionString;
 
-  detailed_info_.append( return_type_ )
-  .append( " " )
-  .append( everything_except_return_type_ )
-  .append( "\n" );
-
-  doc_string_ = YouCompleteMe::CXStringToString(
-                  clang_getCompletionBriefComment( completion_string ) );
+  if ( completion_string ) {
+    doc_string_ = YouCompleteMe::CXStringToString(
+                    clang_getCompletionBriefComment( completion_string ) );
+    ExtractDataFromString( completion_string );
+  }
 }
 
+void CompletionData::ExtractDataFromString(
+  CXCompletionString completion_string ) {
 
-void CompletionData::ExtractDataFromChunk( CXCompletionString completion_string,
-                                           uint chunk_num,
-                                           bool &saw_left_paren,
-                                           bool &saw_function_params,
-                                           bool &saw_placeholder ) {
-  CXCompletionChunkKind kind = clang_getCompletionChunkKind(
-                                 completion_string, chunk_num );
+  uint num_chunks = clang_getNumCompletionChunks( completion_string );
 
-  if ( IsMainCompletionTextInfo( kind ) ) {
-    if ( kind == CXCompletionChunk_LeftParen ) {
-      saw_left_paren = true;
-    }
+  for ( uint chunk_number = 0; chunk_number < num_chunks; chunk_number++ ) {
+    CXCompletionChunkKind kind = clang_getCompletionChunkKind(
+                                   completion_string, chunk_number );
+    std::string chunk;
 
-    else if ( saw_left_paren &&
-              !saw_function_params &&
-              kind != CXCompletionChunk_RightParen &&
-              kind != CXCompletionChunk_Informative ) {
-      saw_function_params = true;
-      everything_except_return_type_.append( " " );
-    }
-
-    else if ( saw_function_params && kind == CXCompletionChunk_RightParen ) {
-      everything_except_return_type_.append( " " );
-    }
-
-    if ( kind == CXCompletionChunk_Optional ) {
-      everything_except_return_type_.append(
-        OptionalChunkToString( completion_string, chunk_num ) );
-    }
-
-    else {
-      everything_except_return_type_.append(
-        ChunkToString( completion_string, chunk_num ) );
-    }
-  }
-
-  switch ( kind ) {
-    case CXCompletionChunk_ResultType:
-      return_type_ = ChunkToString( completion_string, chunk_num );
-      break;
-    case CXCompletionChunk_Placeholder:
-      saw_placeholder = true;
-      break;
-    case CXCompletionChunk_TypedText:
-    case CXCompletionChunk_Text:
-      // need to add paren to insert string
-      // when implementing inherited methods or declared methods in objc.
-    case CXCompletionChunk_LeftParen:
-    case CXCompletionChunk_RightParen:
-    case CXCompletionChunk_HorizontalSpace:
-      if ( !saw_placeholder ) {
-        original_string_ += ChunkToString( completion_string, chunk_num );
+    switch ( kind ) {
+      case CXCompletionChunk_Optional: {
+        CXCompletionString optional_string =
+          clang_getCompletionChunkCompletionString( completion_string,
+                                                    chunk_number );
+        ExtractDataFromString( optional_string );
+        break;
       }
-      break;
-    default:
-      break;
+
+      case CXCompletionChunk_TypedText:
+      case CXCompletionChunk_Text:
+      case CXCompletionChunk_LeftParen:
+      case CXCompletionChunk_RightParen:
+      case CXCompletionChunk_LeftBracket:
+      case CXCompletionChunk_RightBracket:
+      case CXCompletionChunk_LeftBrace:
+      case CXCompletionChunk_RightBrace:
+      case CXCompletionChunk_LeftAngle:
+      case CXCompletionChunk_RightAngle:
+      case CXCompletionChunk_Comma:
+      case CXCompletionChunk_Colon:
+      case CXCompletionChunk_SemiColon:
+      case CXCompletionChunk_Equal:
+      case CXCompletionChunk_HorizontalSpace:
+      case CXCompletionChunk_VerticalSpace:
+        chunk = ChunkToString( completion_string, chunk_number );
+
+        if ( kind == CXCompletionChunk_TypedText )
+          typed_string_ += chunk;
+
+        display_string_ += chunk;
+
+        if ( completion_chunks_.size() > 0 && !completion_chunks_.back().placeholder_ )
+          completion_chunks_.back().chunk_ += chunk;
+        else
+          completion_chunks_.push_back( boost::move( CompletionChunk( chunk ) ) );
+
+        break;
+
+      case CXCompletionChunk_Placeholder:
+      case CXCompletionChunk_CurrentParameter:
+        chunk = ChunkToString( completion_string, chunk_number );
+        chunk = RemoveTwoConsecutiveUnderscores( boost::move( chunk ) );
+
+        display_string_ += chunk;
+        completion_chunks_.push_back( boost::move(
+                                       CompletionChunk( chunk, true ) ) );
+
+        break;
+
+      case CXCompletionChunk_ResultType:
+        result_type_ += ChunkToString( completion_string, chunk_number );
+        break;
+
+      case CXCompletionChunk_Informative:
+        display_string_ += ChunkToString( completion_string, chunk_number );
+        break;
+    }
   }
 }
 

--- a/cpp/ycm/ClangCompleter/CompletionData.h
+++ b/cpp/ycm/ClangCompleter/CompletionData.h
@@ -20,6 +20,7 @@
 
 #include "standard.h"
 #include <string>
+#include <vector>
 #include <clang-c/Index.h>
 
 namespace YouCompleteMe {
@@ -38,50 +39,59 @@ enum CompletionKind {
   UNKNOWN
 };
 
+struct CompletionChunk {
+  CompletionChunk() {}
+  CompletionChunk( const std::string &chunk, bool placeholder = false ): chunk_( chunk ), placeholder_( placeholder ) {}
+
+  std::string Chunk() const {
+    return chunk_;
+  }
+
+  bool operator== ( const CompletionChunk &other ) const {
+    return
+      chunk_ == other.chunk_ &&
+      placeholder_ == other.placeholder_;
+  }
+
+  std::string chunk_;
+
+  bool placeholder_;
+
+};
+
 // This class holds pieces of information about a single completion coming from
-// clang. These pieces are shown in Vim's UI in different ways.
-//
-// Normally, the completion menu looks like this (without square brackets):
-//
-//   [main completion text]  [kind]  [extra menu info]
-//   [main completion text]  [kind]  [extra menu info]
-//   [main completion text]  [kind]  [extra menu info]
-//    ... (etc.) ...
-//
-// The user can also enable a "preview" window that will show extra information
-// about a completion at the top of the buffer.
+// clang. These pieces are shown in clients' UI in different ways.
 struct CompletionData {
   CompletionData() {}
   CompletionData( const CXCompletionResult &completion_result );
 
-  // What should actually be inserted into the buffer. For a function like
-  // "int foo(int x)", this is just "foo". Same for a data member like "foo_":
-  // we insert just "foo_".
-  std::string TextToInsertInBuffer() const {
-    return original_string_;
+  // Text that users would be expected to type to get this completion result.
+  // It is used for filtering and sorting.
+  std::string TypedString() const {
+    return typed_string_;
   }
 
+  // Text that is displayed for users.
   // Currently, here we show the full function signature (without the return
   // type) if the current completion is a function or just the raw TypedText if
   // the completion is, say, a data member. So for a function like "int foo(int
   // x)", this would be "foo(int x)". For a data member like "count_", it would
   // be just "count_".
-  std::string MainCompletionText() const {
-    return everything_except_return_type_;
+  std::string DisplayString() const {
+    return display_string_;
   }
 
-  // This is extra info shown in the pop-up completion menu, after the
-  // completion text and the kind. Currently we put the return type of the
-  // function here, if any.
-  std::string ExtraMenuInfo() const {
-    return return_type_;
+  // What should actually be inserted into the buffer. For a function like
+  // "int foo(int x)", the CompletionChunk for "for(" and ")" are not
+  // placeholders and that for "int x" is a placeholder where users should
+  // insert actual code.
+  std::vector<CompletionChunk> CompletionChunks() const {
+    return completion_chunks_;
   }
 
-  // This is used to show extra information in vim's preview window. This is the
-  // window that vim usually shows at the top of the buffer. This should be used
-  // for extra information about the completion.
-  std::string DetailedInfoForPreviewWindow() const {
-    return detailed_info_;
+  // This is the type the completion expression would have.
+  std::string ResultType() const {
+    return result_type_;
   }
 
   std::string DocString() const {
@@ -91,35 +101,27 @@ struct CompletionData {
   bool operator== ( const CompletionData &other ) const {
     return
       kind_ == other.kind_ &&
-      everything_except_return_type_ == other.everything_except_return_type_ &&
-      return_type_ == other.return_type_ &&
-      original_string_ == other.original_string_;
-    // detailed_info_ doesn't matter
+      typed_string_ == other.typed_string_ &&
+      result_type_ == other.result_type_ &&
+      display_string_ == other.display_string_;
   }
-
-  std::string detailed_info_;
-
-  std::string return_type_;
 
   CompletionKind kind_;
 
-  // The original, raw completion string. For a function like "int foo(int x)",
-  // the original string is "foo". For a member data variable like "foo_", this
-  // is just "foo_". This corresponds to clang's TypedText chunk of the
-  // completion string.
-  std::string original_string_;
+  std::string typed_string_;
 
-  std::string everything_except_return_type_;
+  std::string display_string_;
+
+  std::vector<CompletionChunk> completion_chunks_;
+
+  std::string result_type_;
 
   std::string doc_string_;
 
 private:
 
-  void ExtractDataFromChunk( CXCompletionString completion_string,
-                             uint chunk_num,
-                             bool &saw_left_paren,
-                             bool &saw_function_params,
-                             bool &saw_placeholder);
+  void ExtractDataFromString( CXCompletionString completion_string );
+
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -116,12 +116,18 @@ BOOST_PYTHON_MODULE(ycm_core)
     .value( "UNKNOWN", UNKNOWN )
     .export_values();
 
+  class_< CompletionChunk >( "CompletionChunk" )
+    .def( "Chunk", &CompletionChunk::Chunk )
+    .def_readonly( "placeholder_", &CompletionChunk::placeholder_ );
+
+  class_< std::vector< CompletionChunk > >( "CompletionChunkVector" )
+    .def( vector_indexing_suite< std::vector< CompletionChunk > >() );
+
   class_< CompletionData >( "CompletionData" )
-    .def( "TextToInsertInBuffer", &CompletionData::TextToInsertInBuffer )
-    .def( "MainCompletionText", &CompletionData::MainCompletionText )
-    .def( "ExtraMenuInfo", &CompletionData::ExtraMenuInfo )
-    .def( "DetailedInfoForPreviewWindow",
-          &CompletionData::DetailedInfoForPreviewWindow )
+    .def( "TypedString", &CompletionData::TypedString )
+    .def( "DisplayString", &CompletionData::DisplayString )
+    .def( "CompletionChunks", &CompletionData::CompletionChunks )
+    .def( "ResultType", &CompletionData::ResultType )
     .def( "DocString", &CompletionData::DocString )
     .def_readonly( "kind_", &CompletionData::kind_ );
 

--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -55,7 +55,7 @@ class IdentifierCompleter( GeneralCompleter ):
     completions = _RemoveSmallCandidates(
       completions, self.user_options[ 'min_num_identifier_candidate_chars' ] )
 
-    return [ responses.BuildCompletionData( x ) for x in completions ]
+    return [ responses.BuildSimpleCompletionData( x ) for x in completions ]
 
 
   def AddIdentifier( self, identifier, request_data ):

--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -208,8 +208,8 @@ class Completer( object ):
     sort_property = ''
     if 'word' in candidates[ 0 ]:
       sort_property = 'word'
-    elif 'insertion_text' in candidates[ 0 ]:
-      sort_property = 'insertion_text'
+    elif 'typed_string' in candidates[ 0 ]:
+      sort_property = 'typed_string'
 
     matches = FilterAndSortCandidates( candidates,
                                        sort_property,

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -327,14 +327,21 @@ class ClangCompleter( Completer ):
     return self._flags.FlagsForFile( filename, client_data = client_data )
 
 
+def ConvertCompletionChunk( completion_chunk ):
+  return responses.BuildCompletionChunk(
+    chunk = completion_chunk.Chunk(),
+    placeholder = completion_chunk.placeholder_ )
+
+
 def ConvertCompletionData( completion_data ):
   return responses.BuildCompletionData(
-    insertion_text = completion_data.TextToInsertInBuffer(),
-    menu_text = completion_data.MainCompletionText(),
-    extra_menu_info = completion_data.ExtraMenuInfo(),
+    completion_chunks = [ ConvertCompletionChunk( chunk )
+                            for chunk in completion_data.CompletionChunks() ],
+    typed_string = completion_data.TypedString(),
+    display_string = completion_data.DisplayString(),
+    result_type = completion_data.ResultType(),
     kind = completion_data.kind_.name,
-    detailed_info = completion_data.DetailedInfoForPreviewWindow(),
-    extra_data = { 'doc_string': completion_data.DocString() } if completion_data.DocString() else None )
+    doc_string = completion_data.DocString() )
 
 
 def DiagnosticsToDiagStructure( diagnostics ):

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -126,13 +126,11 @@ class CsharpCompleter( Completer ):
 
 
   def ComputeCandidatesInner( self, request_data ):
-    return [ responses.BuildCompletionData(
-                completion[ 'CompletionText' ],
-                completion[ 'DisplayText' ],
-                completion[ 'Description' ],
-                None,
-                None,
-                { "required_namespace_import" :
+    return [ responses.BuildSimpleCompletionData(
+                completion_string = completion[ 'CompletionText' ],
+                display_string = completion[ 'DisplayText' ],
+                doc_string = completion[ 'Description' ],
+                extra_data = { "required_namespace_import" :
                    completion[ 'RequiredNamespaceImport' ] } )
              for completion in self._GetCompletions( request_data ) ]
 

--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -159,7 +159,7 @@ def _GenerateCandidatesForPaths( absolute_paths ):
   # Keep original ordering
   for basename in basenames:
     completion_dicts.append(
-      responses.BuildCompletionData( basename,
-                                     EXTRA_INFO_MAP[ extra_info[ basename ] ] ) )
+      responses.BuildSimpleCompletionData( completion_string = basename,
+                                           kind = EXTRA_INFO_MAP[ extra_info[ basename ] ] ) )
 
   return completion_dicts

--- a/ycmd/completers/general/tests/filename_completer_test.py
+++ b/ycmd/completers/general/tests/filename_completer_test.py
@@ -54,7 +54,7 @@ class FilenameCompleter_test( object ):
     request[ 'file_data' ][ PATH_TO_TEST_FILE ][ 'contents' ] = contents
     request = RequestWrap( request )
     candidates = self._filename_completer.ComputeCandidatesInner( request )
-    return [ ( c[ 'insertion_text' ], c[ 'extra_menu_info' ] )
+    return [ ( c[ 'typed_string' ], c[ 'kind' ] )
             for c in candidates ]
 
 

--- a/ycmd/completers/general/ultisnips_completer.py
+++ b/ycmd/completers/general/ultisnips_completer.py
@@ -47,8 +47,8 @@ class UltiSnipsCompleter( GeneralCompleter ):
   def OnBufferVisit( self, request_data ):
     raw_candidates = request_data.get( 'ultisnips_snippets', [] )
     self._candidates = [
-        responses.BuildCompletionData(
-            str( snip[ 'trigger' ] ),
-            str( '<snip> ' + snip[ 'description' ].encode( 'utf-8' ) ) )
+        responses.BuildSimpleCompletionData(
+            completion_string = str( snip[ 'trigger' ] ),
+            display_string = str( '<snip> ' + snip[ 'description' ].encode( 'utf-8' ) ) )
         for snip in raw_candidates ]
 

--- a/ycmd/completers/go/gocode_completer.py
+++ b/ycmd/completers/go/gocode_completer.py
@@ -132,10 +132,9 @@ def _ComputeOffset( contents, line, col ):
 
 
 def _ConvertCompletionData( completion_data ):
-  return responses.BuildCompletionData(
-    insertion_text = completion_data[ 'name' ],
-    menu_text = completion_data[ 'name' ],
-    extra_menu_info = completion_data[ 'type' ],
+  return responses.BuildSimpleCompletionData(
+    completion_string = completion_data[ 'name' ],
+    result_type = completion_data[ 'type' ],
     kind = completion_data[ 'class' ])
 
 

--- a/ycmd/completers/go/tests/gocode_completer_test.py
+++ b/ycmd/completers/go/tests/gocode_completer_test.py
@@ -84,10 +84,14 @@ class GoCodeCompleter_test( object ):
     result = self._completer.ComputeCandidatesInner(self._BuildRequest(10, 40))
     eq_(mock.cmd, ['THE_BINARY', '-f=json', 'autocomplete', PATH_TO_TEST_FILE, "292"])
     eq_(result, [{
-        'menu_text': u'Prefix',
-        'insertion_text': u'Prefix',
-        'extra_menu_info': u'func() string',
-        'kind': u'func'
+      'typed_string': u'Prefix',
+      'kind': u'func',
+      'display_string': u'Prefix',
+      'completion_chunks': [{
+        'placeholder': False,
+        'chunk': u'Prefix'
+      }],
+      'result_type': u'func() string'
     }])
 
   # Test gocode failure.

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -75,11 +75,11 @@ class JediCompleter( Completer ):
 
   def ComputeCandidatesInner( self, request_data ):
     script = self._GetJediScript( request_data )
-    return [ responses.BuildCompletionData(
-                ToUtf8IfNeeded( completion.name ),
-                ToUtf8IfNeeded( completion.description ),
-                ToUtf8IfNeeded( completion.docstring() ),
-                extra_data = self._GetExtraData( completion ) )
+    return [ responses.BuildSimpleCompletionData(
+               completion_string = ToUtf8IfNeeded( completion.name ),
+               display_string = ToUtf8IfNeeded( completion.description ),
+               doc_string = ToUtf8IfNeeded( completion.docstring() ),
+               extra_data = self._GetExtraData( completion ) )
              for completion in script.completions() ]
 
   def DefinedSubcommands( self ):

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -81,24 +81,54 @@ def BuildDisplayMessageResponse( text ):
   }
 
 
-def BuildCompletionData( insertion_text,
-                         extra_menu_info = None,
-                         detailed_info = None,
-                         menu_text = None,
-                         kind = None,
-                         extra_data = None ):
-  completion_data = {
-    'insertion_text': insertion_text
+def BuildCompletionChunk( chunk,
+                         placeholder = False ):
+  return {
+    'chunk': chunk,
+    'placeholder': placeholder,
   }
 
-  if extra_menu_info:
-    completion_data[ 'extra_menu_info' ] = extra_menu_info
-  if menu_text:
-    completion_data[ 'menu_text' ] = menu_text
-  if detailed_info:
-    completion_data[ 'detailed_info' ] = detailed_info
+def BuildSimpleCompletionData ( completion_string,
+                                typed_string = None,
+                                display_string = None,
+                                result_type = None,
+                                kind = None,
+                                doc_string = None,
+                                extra_data = None ):
+  return BuildCompletionData(
+    completion_chunks = [ BuildCompletionChunk( completion_string ) ],
+    typed_string = typed_string,
+    display_string = display_string,
+    result_type = result_type,
+    kind = kind,
+    doc_string = doc_string,
+    extra_data = extra_data )
+
+
+def BuildCompletionData( completion_chunks,
+                         typed_string = None,
+                         display_string = None,
+                         result_type = None,
+                         kind = None,
+                         doc_string = None,
+                         extra_data = None ):
+  if typed_string == None:
+    typed_string = completion_chunks[0]['chunk']
+  if display_string == None:
+    display_string = ''.join( map( lambda chunk: chunk[ 'chunk' ], completion_chunks ) )
+
+  completion_data = {
+    'completion_chunks': completion_chunks,
+    'typed_string': typed_string,
+    'display_string': display_string,
+  }
+
+  if result_type:
+    completion_data[ 'result_type' ] = result_type
   if kind:
     completion_data[ 'kind' ] = kind
+  if doc_string:
+    completion_data[ 'doc_string' ] = doc_string
   if extra_data:
     completion_data[ 'extra_data' ] = extra_data
   return completion_data

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -29,7 +29,7 @@ from nose.tools import eq_, with_setup
 from hamcrest import ( assert_that, has_item, has_items, has_entry,
                        contains_inanyorder, empty, greater_than,
                        contains_string )
-from ..responses import ( BuildCompletionData, UnknownExtraConf,
+from ..responses import ( BuildSimpleCompletionData, UnknownExtraConf,
                           NoExtraConfDetected )
 from .. import handlers
 import bottle
@@ -38,8 +38,8 @@ bottle.debug( True )
 
 
 # TODO: Make the other tests use this helper too instead of BuildCompletionData
-def CompletionEntryMatcher( insertion_text ):
-  return has_entry( 'insertion_text', insertion_text )
+def CompletionEntryMatcher( typed_string ):
+  return has_entry( 'typed_string', typed_string )
 
 
 def CompletionLocationMatcher( location_type, value ):
@@ -77,8 +77,8 @@ def GetCompletions_IdentifierCompleter_Works_test():
                                   column_num = 3 )
   response_data = app.post_json( '/completions', completion_data ).json
 
-  eq_( [ BuildCompletionData( 'foo' ),
-         BuildCompletionData( 'foogoo' ) ], response_data[ 'completions' ] )
+  eq_( [ BuildSimpleCompletionData( 'foo' ),
+         BuildSimpleCompletionData( 'foogoo' ) ], response_data[ 'completions' ] )
   eq_( 1, response_data[ 'completion_start_column' ] )
 
 
@@ -111,8 +111,8 @@ def GetCompletions_IdentifierCompleter_WorksForSpecialIdentifierChars_test():
                                   column_num = 3 )
   response_data = app.post_json( '/completions', completion_data ).json
 
-  eq_( [ BuildCompletionData( 'font-size' ),
-         BuildCompletionData( 'font-family' ) ],
+  eq_( [ BuildSimpleCompletionData( 'font-size' ),
+         BuildSimpleCompletionData( 'font-family' ) ],
        response_data[ 'completions' ] )
 
 
@@ -625,8 +625,8 @@ def GetCompletions_IdentifierCompleter_SyntaxKeywordsAdded_test():
   completion_data = BuildRequest( contents =  'oo ',
                                   column_num = 3 )
 
-  eq_( [ BuildCompletionData( 'foo' ),
-         BuildCompletionData( 'zoo' ) ],
+  eq_( [ BuildSimpleCompletionData( 'foo' ),
+         BuildSimpleCompletionData( 'zoo' ) ],
        app.post_json( '/completions', completion_data ).json[ 'completions' ] )
 
 
@@ -645,8 +645,8 @@ def GetCompletions_UltiSnipsCompleter_Works_test():
   completion_data = BuildRequest( contents =  'oo ',
                                   column_num = 3 )
 
-  eq_( [ BuildCompletionData( 'foo', '<snip> bar' ),
-         BuildCompletionData( 'zoo', '<snip> goo' ) ],
+  eq_( [ BuildSimpleCompletionData( 'foo', display_string = '<snip> bar' ),
+         BuildSimpleCompletionData( 'zoo', display_string = '<snip> goo' ) ],
        app.post_json( '/completions', completion_data ).json[ 'completions' ] )
 
 
@@ -708,7 +708,7 @@ def GetCompletions_JediCompleter_UnicodeDescription_test():
   results = app.post_json( '/completions',
                            completion_data ).json[ 'completions' ]
   assert_that( results, has_item(
-                          has_entry( 'detailed_info',
+                          has_entry( 'doc_string',
                             contains_string( u'aafäö' ) ) ) )
 
 
@@ -726,5 +726,5 @@ def GetCompletions_GoCodeCompleter_test():
   results = app.post_json( '/completions',
                            completion_data ).json[ 'completions' ]
   assert_that( results, has_item(
-                          has_entry( 'insertion_text',
+                          has_entry( 'typed_string',
                             contains_string( u'Logger' ) ) ) )


### PR DESCRIPTION
See also https://github.com/Valloric/ycmd/pull/124

I have removed all unnecessary changes and it looks much cleaner now.

> Completion objects have these properties:
* `typed_string`<br />Text that users would be expected to type to get this completion result. 
* `display_string`<br />Text that is displayed for users.
* `completion_chunks`<br />An array of completion chunk objects.
* `result_type`<br />Such as 'int', 'void', 'unsigned long'.
* `kind`<br />Such as 'function', 'class', 'variable'.
* `doc_string`<br />Doc string.
* `extra_data`<br />An object contains completer-specific data.

> Completion chunk objects have these properties:
* `chunk`<br />String value of the chunk.
* `placeholder`<br />Bool value that indicates whether this chunk should be inserted directly as a literal string or as a placeholder for users to insert code.

> Two examples are below.
```
{
  "typed_string": "vector",
  "display_string": "vector<typename _Tp, typename _Alloc>",
  "kind": "CLASS",
  "completion_chunks": [
    { "chunk": "vector<", "placeholder": false },
    { "chunk": "typename _Tp", "placeholder": true },
    { "chunk": ", ", "placeholder": false },
    { "chunk": "typename _Alloc", "placeholder": true },
    { "chunk": ">", "placeholder": false }
  ]
}
{
  "typed_string": "withArg2:withArg3:",
  "display_string": "test:withArg2:(int) withArg3:(int)",
  "result_type": "void",
  "kind": "FUNCTION",
  "completion_chunks": [
    { "chunk": "withArg2:", "placeholder": false },
    { "chunk": "(int)", "placeholder": true },
    { "chunk": " withArg3:", "placeholder": false },
    { "chunk": "(int)", "placeholder": true }
  ]
}
```

(CLA signed)