### PR TITLE
Fix Gocode path on Windows

### DIFF
--- a/ycmd/completers/go/gocode_completer.py
+++ b/ycmd/completers/go/gocode_completer.py
@@ -27,51 +27,33 @@ from ycmd import utils
 from ycmd.completers.completer import Completer
 
 GO_FILETYPES = set( [ 'go' ] )
-COMPLETION_ERROR_MESSAGE = "Gocode shell call failed."
-PARSE_ERROR_MESSAGE = "Gocode returned invalid JSON response."
-NO_COMPLETIONS_MESSAGE = "Gocode returned empty JSON response."
-GOCODE_PANIC_MESSAGE = "Gocode panicked trying to find completions, "\
-    +"you likely have a syntax error."
+BINARY_NOT_FOUND_MESSAGE = ( 'Gocode binary not found. Did you build it? ' +
+                             'You can do so by running ' +
+                             '"./install.sh --gocode-completer".' )
+COMPLETION_ERROR_MESSAGE = 'Gocode shell call failed.'
+PARSE_ERROR_MESSAGE = 'Gocode returned invalid JSON response.'
+NO_COMPLETIONS_MESSAGE = 'Gocode returned empty JSON response.'
+GOCODE_PANIC_MESSAGE = ( 'Gocode panicked trying to find completions, ' +
+                         'you likely have a syntax error.' )
 PATH_TO_GOCODE_BINARY = os.path.join(
   os.path.abspath( os.path.dirname( __file__ ) ),
-  '../../../third_party/gocode/gocode' )
+  '..', '..', '..', 'third_party', 'gocode',
+  'gocode' + ( '.exe' if utils.OnWindows() else '' ) )
 
 _logger = logging.getLogger( __name__ )
-
-
-def FindGoCodeBinary( user_options ):
-  ''' Find the path to the gocode binary.
-
-  TODO(ekfriis): Test.
-
-  If 'gocode_binary_path' in the options is blank,
-  use the version installed with YCM, if it exists,
-  then the one on the path, if not.
-
-  If the 'gocode_binary_path' is specified, use it
-  as an absolute path.
-
-  If the resolved binary exists, return the path,
-  otherwise return None.
-  '''
-  if user_options.get( 'gocode_binary_path' ):
-    # The user has explicitly specified a path.
-    if os.path.exists( user_options[ 'gocode_binary_path' ] ):
-      return user_options[ 'gocode_binary_path' ]
-    else:
-      return None
-  # Try to use the bundled binary or one on the path.
-  if os.path.exists( PATH_TO_GOCODE_BINARY ):
-    return PATH_TO_GOCODE_BINARY
-  return utils.PathToFirstExistingExecutable( [ 'gocode' ] )
-
 
 
 class GoCodeCompleter( Completer ):
   def __init__( self, user_options ):
     super( GoCodeCompleter, self ).__init__( user_options )
     self._popener = utils.SafePopen # Overridden in test.
-    self._binary = FindGoCodeBinary( user_options )
+    self._binary = self.FindGoCodeBinary( user_options )
+
+    if not self._binary:
+      _logger.error( BINARY_NOT_FOUND_MESSAGE )
+      raise RuntimeError( BINARY_NOT_FOUND_MESSAGE )
+
+    _logger.info( 'Enabling go completion using %s binary', self._binary )
 
 
   def SupportedFiletypes( self ):
@@ -85,17 +67,17 @@ class GoCodeCompleter( Completer ):
       return
 
     contents = utils.ToUtf8IfNeeded(
-        request_data['file_data'][ filename ][ 'contents' ] )
+        request_data[ 'file_data' ][ filename ][ 'contents' ] )
     offset = _ComputeOffset( contents, request_data[ 'line_num' ],
                             request_data[ 'column_num' ] )
 
-    cmd = [self._binary, '-f=json', 'autocomplete', filename, str( offset )]
+    cmd = [ self._binary, '-f=json', 'autocomplete', filename, str( offset ) ]
     proc = self._popener( cmd, stdin=subprocess.PIPE,
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE )
     stdoutdata, stderrdata = proc.communicate( contents )
     if proc.returncode:
       _logger.error( COMPLETION_ERROR_MESSAGE + " code %i stderr: %s",
-                    proc.returncode, stderrdata)
+                    proc.returncode, stderrdata )
       raise RuntimeError( COMPLETION_ERROR_MESSAGE )
 
     try:
@@ -107,10 +89,36 @@ class GoCodeCompleter( Completer ):
       _logger.error( NO_COMPLETIONS_MESSAGE )
       raise RuntimeError( NO_COMPLETIONS_MESSAGE )
     for result in resultdata[1]:
-      if result.get('class') == "PANIC":
+      if result.get( 'class' ) == "PANIC":
         raise RuntimeError( GOCODE_PANIC_MESSAGE )
 
     return [ _ConvertCompletionData( x ) for x in resultdata[1] ]
+
+
+  def FindGoCodeBinary( self, user_options ):
+    ''' Find the path to the gocode binary.
+
+    If 'gocode_binary_path' in the options is blank,
+    use the version installed with YCM, if it exists,
+    then the one on the path, if not.
+
+    If the 'gocode_binary_path' is specified, use it
+    as an absolute path.
+
+    If the resolved binary exists, return the path,
+    otherwise return None.
+    '''
+    if user_options.get( 'gocode_binary_path' ):
+      # The user has explicitly specified a path.
+      if os.path.isfile( user_options[ 'gocode_binary_path' ] ):
+        return user_options[ 'gocode_binary_path' ]
+      else:
+        return None
+    # Try to use the bundled binary or one on the path.
+    if os.path.isfile( PATH_TO_GOCODE_BINARY ):
+      return PATH_TO_GOCODE_BINARY
+    return utils.PathToFirstExistingExecutable( [ 'gocode' ] )
+
 
 
 # Compute the byte offset in the file given the line and column.
@@ -126,8 +134,8 @@ def _ComputeOffset( contents, line, col ):
     if byte == '\n':
       curline += 1
       curcol = 1
-  _logger.error( "GoCode completer - could not compute byte offset " +
-                "corresponding to L%i C%i", line, col )
+  _logger.error( 'GoCode completer - could not compute byte offset ' +
+                 'corresponding to L%i C%i', line, col )
   return -1
 
 
@@ -136,6 +144,4 @@ def _ConvertCompletionData( completion_data ):
     insertion_text = completion_data[ 'name' ],
     menu_text = completion_data[ 'name' ],
     extra_menu_info = completion_data[ 'type' ],
-    kind = completion_data[ 'class' ])
-
-
+    kind = completion_data[ 'class' ] )

--- a/ycmd/completers/go/hook.py
+++ b/ycmd/completers/go/hook.py
@@ -17,17 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
-from ycmd.completers.go.gocode_completer import \
-    GoCodeCompleter, FindGoCodeBinary
-
-_logger = logging.getLogger( __name__ )
+from ycmd.completers.go.gocode_completer import GoCodeCompleter
 
 def GetCompleter( user_options ):
-  binary = FindGoCodeBinary( user_options )
-  if binary:
-    _logger.info("Enabling go completion using %s", binary)
-    return GoCodeCompleter( user_options )
-  _logger.info("Could not find gocode binary, no go completion.")
-  return None
-
+  return GoCodeCompleter( user_options )


### PR DESCRIPTION
This pull request fixes the default Gocode path on Windows by adding the `.exe` extension and using `os.path.join` for the full path. Otherwise, python does not find `gocode.exe` and there is no completion (and no exception raised).

There are other changes:
  - the logic in `hook.py` was moved to the `GoCodeCompleter` class. This avoids calling `FindGoCodeBinary` two times. An exception is raised when no binary is found (like in the `CsCompleter` class). 
  - `FindGoCodeBinary` is now a method of the `GoCodeCompleter` class since not used elsewhere. `os.path.exists` was replaced by `os.path.isfile`.
  - Add test for `FindGoCodeBinary` method (it does not test finding `gocode` binary in the `PATH`).
  - Fix code style and clean-up code.

There are still problems on Windows but it will be for another PR.

CLA signed.