### PR TITLE
Add StartServer and StopServer commands to GoCode completer

### DIFF
--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -23,7 +23,7 @@ SetUpPythonPath()
 import httplib
 from .test_utils import ( Setup, BuildRequest, PathToTestFile,
                           ChangeSpecificOptions, StopOmniSharpServer,
-                          WaitUntilOmniSharpServerReady )
+                          WaitUntilOmniSharpServerReady, StopGoCodeServer )
 from webtest import TestApp, AppError
 from nose.tools import eq_, with_setup
 from hamcrest import ( assert_that, has_item, has_items, has_entry,
@@ -728,3 +728,5 @@ def GetCompletions_GoCodeCompleter_test():
   assert_that( results, has_item(
                           has_entry( 'insertion_text',
                             contains_string( u'Logger' ) ) ) )
+
+  StopGoCodeServer( app )

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -98,3 +98,8 @@ def WaitUntilOmniSharpServerReady( app ):
     raise RuntimeError( "Timeout waiting for OmniSharpServer" )
 
 
+def StopGoCodeServer( app ):
+  app.post_json( '/run_completer_command',
+                 BuildRequest( completer_target = 'filetype_default',
+                               command_arguments = ['StopServer'],
+                               filetype = 'go' ) )


### PR DESCRIPTION
cc @ekfriis

This PR adds commands to start and stop the `GoCode` server. This allows us to:
 - manually start and stop the `GoCode` server in the client.
 - stop the `GoCode` server when `ycmd` is terminated.
 - stop the `GoCode` server at the end of the `GetCompletions_GoCodeCompleter` test.
 - start the `GoCode` server (or do nothing if the server is already started) when the file is ready. This avoids getting a timeout when triggering semantic completion for the first time.

I did some refactoring by creating a `_GoCode` method to execute `gocode` with given parameters.

CLA signed.
