### PR TITLE
Use CREATE_NO_WINDOW flag on Windows instead of shell = True

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -251,19 +251,17 @@ class CsharpCompleter( Completer ):
 
     self._ChooseOmnisharpPort()
 
-    # we need to pass the command to Popen as a string since we're passing
-    # shell=True (as recommended by Python's doc)
-    command = ' '.join( [ PATH_TO_OMNISHARP_BINARY,
-                         '-p',
-                         str( self._omnisharp_port ),
-                         '-s',
-                         u'"{0}"'.format( path_to_solutionfile ) ] )
+    command = [ PATH_TO_OMNISHARP_BINARY,
+                '-p',
+                str( self._omnisharp_port ),
+                '-s',
+                u'{0}'.format( path_to_solutionfile ) ]
 
     if not utils.OnWindows() and not utils.OnCygwin():
-      command = u'mono ' + command
+      command.insert( 0, 'mono' )
 
     if utils.OnCygwin():
-      command = command + ' --client-path-mode Cygwin'
+      command.extend( [ '--client-path-mode', 'Cygwin' ] )
 
     filename_format = os.path.join( utils.PathToTempDir(),
                                     u'omnisharp_{port}_{sln}_{std}.log' )
@@ -276,10 +274,8 @@ class CsharpCompleter( Completer ):
 
     with open( self._filename_stderr, 'w' ) as fstderr:
       with open( self._filename_stdout, 'w' ) as fstdout:
-        # shell=True is needed for Windows so OmniSharp does not spawn
-        # in a new visible window
         self._omnisharp_phandle = utils.SafePopen(
-            command, stdout = fstdout, stderr = fstderr, shell = True )
+            command, stdout = fstdout, stderr = fstderr )
 
     self._solution_path = path_to_solutionfile
 

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -31,6 +31,9 @@ import collections
 
 WIN_PYTHON27_PATH = 'C:\python27\pythonw.exe'
 WIN_PYTHON26_PATH = 'C:\python26\pythonw.exe'
+# Creation flag to disable creating a console window on Windows. See
+# https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863.aspx
+CREATE_NO_WINDOW = 0x08000000
 
 
 def SanitizeQuery( query ):
@@ -239,11 +242,14 @@ def ForceSemanticCompletion( request_data ):
            bool( request_data[ 'force_semantic' ] ) )
 
 
-# A wrapper for subprocess.Popen that works around a Popen bug on Windows.
+# A wrapper for subprocess.Popen that fixes quirks on Windows.
 def SafePopen( *args, **kwargs ):
-  if kwargs.get( 'stdin' ) is None:
-    # We need this on Windows otherwise bad things happen. See issue #637.
-    kwargs[ 'stdin' ] = subprocess.PIPE if OnWindows() else None
+  if OnWindows():
+    # We need this otherwise bad things happen. See issue #637.
+    if kwargs.get( 'stdin' ) is None:
+      kwargs[ 'stdin' ] = subprocess.PIPE
+    # Do not create a console window
+    kwargs[ 'creationflags' ] = CREATE_NO_WINDOW
 
   return subprocess.Popen( *args, **kwargs )
 

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -29,8 +29,8 @@ from distutils.spawn import find_executable
 import subprocess
 import collections
 
-WIN_PYTHON27_PATH = 'C:\python27\pythonw.exe'
-WIN_PYTHON26_PATH = 'C:\python26\pythonw.exe'
+WIN_PYTHON27_PATH = 'C:\python27\python.exe'
+WIN_PYTHON26_PATH = 'C:\python26\python.exe'
 # Creation flag to disable creating a console window on Windows. See
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863.aspx
 CREATE_NO_WINDOW = 0x08000000
@@ -151,10 +151,6 @@ def PathToPythonInterpreter():
   # Arch Linux) have made the... interesting decision to point /usr/bin/python
   # to python3.
   python_names = [ 'python2', 'python' ]
-  if OnWindows():
-    # On Windows, 'pythonw' doesn't pop-up a console window like running
-    # 'python' does.
-    python_names.insert( 0, 'pythonw' )
 
   path_to_python = PathToFirstExistingExecutable( python_names )
   if path_to_python:


### PR DESCRIPTION
In the C# completer, the `shell` option is set to `True` when starting the `OmniSharp` server to disable the creation of a console window on Windows. This is working but there are some issues:
 - this option can be a [security hazard](https://docs.python.org/2/library/subprocess.html#frequently-used-arguments).
 - this is useless on other platforms.
 - the creation of a console window is not specific to the `OmniSharp` server.

This PR fixes these issues by using the [CREATE_NO_WINDOW](https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863(v=vs.85).aspx) flag on Windows directly in the `SafePopen` function. No more pesky console window when starting any process!

A side-effect of this change is that the `pythonw` executable is no longer needed on Windows. Strangely enough, this makes the start of `gvim` smoother (no loading cursor when starting it).

CLA signed.