### PR TITLE
Handle serializing objects without __dict__

### DIFF
--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -194,9 +194,12 @@ def _JsonResponse( data ):
 
 
 def _UniversalSerialize( obj ):
-  serialized = obj.__dict__.copy()
-  serialized[ 'TYPE' ] = type( obj ).__name__
-  return serialized
+  try:
+    serialized = obj.__dict__.copy()
+    serialized[ 'TYPE' ] = type( obj ).__name__
+    return serialized
+  except AttributeError:
+    return str( obj )
 
 
 def _GetCompleterForRequestData( request_data ):


### PR DESCRIPTION
I encountered this with a network exception. Instead of receiving the
network exception, I received a AttributeError that __dict__ did not
exist in obj.

Instead of crashing, fallback to str in this case.

I have signed the CLA.