### PR TITLE
Add possibility to /ready for specific subserver

### DIFF
--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -114,10 +114,17 @@ def GetHealthy():
 @app.get( '/ready' )
 def GetReady():
   _logger.info( 'Received ready request' )
+  if request.query.subserver:
+    filetype = request.query.subserver
+    return _JsonResponse( _IsSubserverReady( filetype ) )
   if request.query.include_subservers:
-    cs_completer = _server_state.GetFiletypeCompleter( ['cs'] )
-    return _JsonResponse( cs_completer.ServerIsReady() )
+    return _JsonResponse( _IsSubserverReady( 'cs' ) )
   return _JsonResponse( True )
+
+
+def _IsSubserverReady( filetype ):
+  completer = _server_state.GetFiletypeCompleter( [filetype] )
+  return completer.ServerIsReady()
 
 
 @app.post( '/semantic_completion_available' )

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -82,7 +82,7 @@ def WaitUntilOmniSharpServerReady( app, filename ):
   # If running on Travis CI, keep trying forever. Travis will kill the worker
   # after 10 mins if nothing happens.
   while retries > 0 or OnTravis():
-    result = app.get( '/ready', { 'include_subservers': 1 } ).json
+    result = app.get( '/ready', { 'subserver': 'cs' } ).json
     if result:
       success = True;
       break


### PR DESCRIPTION
I'm working on using my http wrapper for jedi ([JediHTTP](/vheon/JediHTTP)). While working on it I needed something like `WaitUntilJediHTTPIsReady` without depending on OmniSharpServer, so the `include_subservers` that currently works for `/ready` wasn't useful. This will simplify the testing of the readiness of server-backed semantic engine.