### PR TITLE
Make minimum required cmake version as 2.8.11

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -20,7 +20,7 @@ if ( DEFINED ENV{TRAVIS} )
   # Travis for, the old version of CMake that it has is good enough.
   cmake_minimum_required( VERSION 2.8 )
 else()
-  cmake_minimum_required( VERSION 2.8.12 )
+  cmake_minimum_required( VERSION 2.8.11 )
 endif()
 
 


### PR DESCRIPTION
Because CentOS 7 contains 2.8.11. This modification makes easier to install on CentOS 7.
And I guess this file doesn't depend on 2.8.12 feature.