### PR TITLE
C# StopServer improvements

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -355,11 +355,13 @@ class CsharpSolutionCompleter:
 
   def _StopServer( self ):
     """ Stop the OmniSharp server """
-    self._GetResponse( '/stopserver' )
-
     # Give OmniSharp 5 seconds to cleanly stop, then kill it if it's still up
     still_running = True
     for _ in range( 5 ):
+      try:
+        self._GetResponse( '/stopserver' )
+      except:
+        pass
       still_running = self.ServerIsRunning()
       if not still_running:
         break
@@ -371,8 +373,10 @@ class CsharpSolutionCompleter:
     self._omnisharp_port = None
     self._omnisharp_phandle = None
     if ( not self._keep_logfiles ):
-      os.unlink( self._filename_stdout );
-      os.unlink( self._filename_stderr );
+      if self._filename_stdout:
+        os.unlink( self._filename_stdout );
+      if self._filename_stderr:
+        os.unlink( self._filename_stderr );
     self._logger.info( 'Stopping OmniSharp server' )
 
 

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -357,10 +357,10 @@ class CsharpSolutionCompleter:
     """ Stop the OmniSharp server """
     self._logger.info( 'Stopping OmniSharp server' )
 
-    still_running = self._TryToStopServer()
+    self._TryToStopServer()
 
     # Kill it if it's still up
-    if still_running:
+    if not self.ServerTerminated() and self._omnisharp_phandle is not None:
       self._logger.info( 'Killing OmniSharp server' )
       self._omnisharp_phandle.kill()
 
@@ -376,11 +376,9 @@ class CsharpSolutionCompleter:
       except:
         pass
       for _ in range( 10 ):
-        if not self.ServerIsRunning():
-          return False
+        if self.ServerTerminated():
+          return
         time.sleep( .1 )
-
-    return True
 
 
   def _CleanupAfterServerStop( self ):

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -727,6 +727,16 @@ def RunCompleterCommand_GetType_CsCompleter_Constant_test():
 
 
 @with_setup( Setup )
+def RunCompleterCommand_StopServer_CsCompleter_NoErrorIfNotStarted_test():
+  app = TestApp( handlers.app )
+  app.post_json( '/ignore_extra_conf_file',
+                 { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
+  filepath = PathToTestFile( 'testy/GotoTestCase.cs' )
+  StopOmniSharpServer( app, filepath )
+  # Success = no raise
+
+
+@with_setup( Setup )
 def RunCompleterCommand_StopServer_CsCompleter_KeepLogFiles_test():
   yield  _RunCompleterCommand_StopServer_CsCompleter_KeepLogFiles, True
   yield  _RunCompleterCommand_StopServer_CsCompleter_KeepLogFiles, False


### PR DESCRIPTION
Sometimes ``StopServer`` fails. For example, if the server died,
it will fail with connection refused error.  Ignore error sending the
``StopServer`` requests, and retrying sending it every time we wait.
Similarly, if the server hasn't been started, logs files will be ``None``,
which will cause an error. Only delete log files if they exist.

This change made ``StopServer`` slower, thus there is a second change.

If the server is not running, both ``/stopserver`` and ``/checkalivestatus``
will sometime spin for the default network timeout of 2 seconds. This
normally doesn't matter, but in the tests, we spin up and shutdown
Omnisharp many times, and this accordingly adds many seconds to the
test suite run time. Similarly, the sleep time between still-running
checks in ``StopServer`` is a second, which is much longer than needed.

Add a timeout parameter to ``SentRequest``, and set the timeout to .1
seconds for ``/stopserver`` and .2 seconds for ``/checkalivestatus`` and
friends. Remove the no-longer-used silent parameter at the same time.
Instead calling ``ServerIsRunning`` once with a second wait between
each call of ``StopServer``, call it 10 times with a .1 wait between them.

These changes then required refactoring due to complexity limits.


I have signed the CLA.