### PR TITLE
Default timeout should be none

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -515,7 +515,7 @@ class CsharpSolutionCompleter:
     return 'http://localhost:' + str( self._omnisharp_port )
 
 
-  def _GetResponse( self, handler, parameters = {}, timeout = 2 ):
+  def _GetResponse( self, handler, parameters = {}, timeout = None ):
     """ Handle communication with server """
     target = urlparse.urljoin( self._ServerLocation(), handler )
     response = requests.post( target, data = parameters, timeout = timeout )


### PR DESCRIPTION
The default timeout in requests is actually None. We should use that to maintain
backward compatibility.

This is probably why https://github.com/Valloric/ycmd/pull/152 failed.