### PR TITLE
ycmd: Add detailed_info to Go completion results.

### DIFF
--- a/ycmd/completers/go/gocode_completer.py
+++ b/ycmd/completers/go/gocode_completer.py
@@ -196,7 +196,7 @@ def _ConvertCompletionData( completion_data ):
     menu_text = completion_data[ 'name' ],
     extra_menu_info = completion_data[ 'type' ],
     kind = completion_data[ 'class' ],
-    detailed_info = ' '.join([
+    detailed_info = ' '.join( [
         completion_data[ 'name' ],
         completion_data[ 'type' ],
-        completion_data[ 'class' ]]))
+        completion_data[ 'class' ] ] ) )

--- a/ycmd/completers/go/gocode_completer.py
+++ b/ycmd/completers/go/gocode_completer.py
@@ -197,6 +197,6 @@ def _ConvertCompletionData( completion_data ):
     extra_menu_info = completion_data[ 'type' ],
     kind = completion_data[ 'class' ],
     detailed_info = ' '.join([
-        completion_data['name'],
-        completion_data['type'],
-        completion_data['class']]))
+        completion_data[ 'name' ],
+        completion_data[ 'type' ],
+        completion_data[ 'class' ]]))

--- a/ycmd/completers/go/gocode_completer.py
+++ b/ycmd/completers/go/gocode_completer.py
@@ -195,4 +195,8 @@ def _ConvertCompletionData( completion_data ):
     insertion_text = completion_data[ 'name' ],
     menu_text = completion_data[ 'name' ],
     extra_menu_info = completion_data[ 'type' ],
-    kind = completion_data[ 'class' ] )
+    kind = completion_data[ 'class' ],
+    detailed_info = ' '.join([
+        completion_data['name'],
+        completion_data['type'],
+        completion_data['class']]))

--- a/ycmd/completers/go/tests/gocode_completer_test.py
+++ b/ycmd/completers/go/tests/gocode_completer_test.py
@@ -112,6 +112,7 @@ class GoCodeCompleter_test( object ):
         'menu_text': u'Prefix',
         'insertion_text': u'Prefix',
         'extra_menu_info': u'func() string',
+        'detailed_info': u'Prefix func() string func',
         'kind': u'func'
     } ] )
 


### PR DESCRIPTION
This adds support for the Go completer to populate the preview window. 

https://groups.google.com/forum/#!searchin/ycm-users/preview$20window$20go/ycm-users/FMMoZBqZSrs/mTKP1uHjxmoJ

I've signed the CLA.