### PR TITLE
Allow use of CMake 2.8.11 on CentOS/RHEL 7.x

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -20,7 +20,13 @@ if ( DEFINED ENV{TRAVIS} )
   # Travis for, the old version of CMake that it has is good enough.
   cmake_minimum_required( VERSION 2.8 )
 else()
-  cmake_minimum_required( VERSION 2.8.12 )
+  if ( APPLE )
+    # OSX requires CMake >= 2.8.12, see YCM issue #1439
+    cmake_minimum_required( VERSION 2.8.12 )
+  else()
+    # CMake 2.8.11 is the latest available version on RHEL/CentOS 7
+    cmake_minimum_required( VERSION 2.8.11 )
+  endif()
 endif()
 
 


### PR DESCRIPTION
Hi,

CMake 2.8.12 was required due to YouCompleteMe issue #1439 which seems to be limited to OSX Yosemite. Requiring this version of CMake breaks compilation on CentOS / RHEL7 which comes with CMake 2.8.11 but compiles ycmd without issue.

I've adjusted `cpp/CMakeLists.txt` to detect CentOS/RHEL 7 and allow the use of CMake 2.8.11. All other operating systems and distributions will still require 2.8.12.

Thanks