### PR TITLE
Add a instruction for build on windows with visual studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,13 @@ cpp/BoostParts/libs/*/test
 
 # Exclude auto generated vim doc tags.
 doc/tags
+
+# Windows build
+ycmd_build/
+# Visual studio in debug mode generate ycmd_core.pdb and ycm_core.ilk
+*.pdb
+*.ilk
+# build llvm/clang on windows
+llvm-src/
+llvm_build/
+

--- a/Build_On_Windows.md
+++ b/Build_On_Windows.md
@@ -17,6 +17,8 @@ Note: the relative path base in following text is ycmd git source code folder.
 
 ###1.5. Quick
 
+Edit `_build_ycmd.bat`, and change `PYTHON_PATH` to a correct one.
+
 Click `_run_both.bat` and go out for a walk.
 
 ###2. Build llvm/clang
@@ -25,13 +27,16 @@ Run `_build_llvm.bat` (Where? the relative path base..)
 
 This batch gets llvm/clang source code and generate a Visual Studio 2013 project files. So it maybe takes less than 10 minutes. The source code with .svn takes 360+MB disk space.
 
-If no error, the batch should quit silently.go to `llvm-build`
+If no error, the batch should quit silently.
 
-Now go to `llvm-build` folder, open `LLVM.svn` and change **Debug** mode to **Release** mode. In Solution Explorer, go to `ALL_BUILD`, right click on `ALL_BUILD` and choose build. It take about quite a long time to finish the build. CPU is 100% during the build. The `llvm-build` folder takes about 6.65GB disk space.
+Now go to `llvm_build` folder, open `LLVM.svn` and change **Debug** mode to **Release** mode. In Solution Explorer, go to `ALL_BUILD`, right click on `ALL_BUILD` and choose build. It take about quite a long time to finish the build. CPU is 100% during the build. The `llvm_build` folder takes about 6.65GB disk space.
+
+If error happens when svn clone code, we should delete `llvm-src` and run it again.
 
 ###3. Build ycmd
 
 **Note**: Edit `_build_ycmd.bat`, and change `PYTHON_PATH` to a correct one.
+
 Run `_build_ycmd.bat`
 
 This batch generates `YouCompleteMe.sln` in ycmd_build folder. Open it with Visual Studio 2013. Change **Debug** mode to **Release** mode. In Solution Explorer, select `ycm_support_libs` and right click on it choose build. (Note `ycm_core_tests` and `gmock_main` `gtest_main` etc will fail, so we cannot build the whole solution.) Now you should find `libclang.dll` and `ycm_client_support.pyd` and `ycm_core.pyd`.
@@ -55,6 +60,10 @@ You can follow:
 https://bitbucket.org/Haroogan/vim-youcompleteme-for-windows/
 
 In my case, it is `C:\Program Files (x86)\Intel\iCLS Client\msvcr90.dll`. Remove `C:\Program Files (x86)\Intel\iCLS Client` from path. Now everything goes quite well.
+
+###5. Cleanup
+
+You can safely delete `llvm_build\Release\lib`.
 
 ###note
 

--- a/Build_On_Windows.md
+++ b/Build_On_Windows.md
@@ -23,14 +23,14 @@ This batch gets llvm/clang source code and generate a Visual Studio 2013 project
 
 If no error, the batch should quit silently.go to `llvm-build`
 
-Now go to `llvm-build` folder, open `LLVM.svn` and change Debug mode to Release mode. In Solution Explorer, go to `ALL_BUILD`, right click on `ALL_BUILD` and choose build. It take about quite a long time to finish the build. CPU is 100% during the build. The `llvm-build` folder takes about 6.65GB disk space.
+Now go to `llvm-build` folder, open `LLVM.svn` and change **Debug** mode to **Release** mode. In Solution Explorer, go to `ALL_BUILD`, right click on `ALL_BUILD` and choose build. It take about quite a long time to finish the build. CPU is 100% during the build. The `llvm-build` folder takes about 6.65GB disk space.
 
 ###3. Build ycmd
 
 **Note**: Edit `_build_ycmd.bat`, and change `PYTHON_PATH` to a correct one.
 Run `_build_ycmd.bat`
 
-This batch generates `YouCompleteMe.sln` in ycmd_build folder. Open it with Visual Studio 2013. In Solution Explorer, select `ycm_support_libs` and right click on it choose build. (Note `ycm_core_tests` and `gmock_main` `gtest_main` etc will fail, so we cannot build the whole solution.) Now you should find `libclang.dll` and `ycm_client_support.pyd` and `ycm_core.pyd`.
+This batch generates `YouCompleteMe.sln` in ycmd_build folder. Open it with Visual Studio 2013. Change **Debug** mode to **Release** mode. In Solution Explorer, select `ycm_support_libs` and right click on it choose build. (Note `ycm_core_tests` and `gmock_main` `gtest_main` etc will fail, so we cannot build the whole solution.) Now you should find `libclang.dll` and `ycm_client_support.pyd` and `ycm_core.pyd`.
 
 ###4. Test
 
@@ -50,7 +50,7 @@ You can follow:
 
 https://bitbucket.org/Haroogan/vim-youcompleteme-for-windows/
 
-In my case, it is `C:\Program Files (x86)\Intel\iCLS Client\msvcr90.dll`. Remove it from path. Now everything goes quite well.
+In my case, it is `C:\Program Files (x86)\Intel\iCLS Client\msvcr90.dll`. Remove `C:\Program Files (x86)\Intel\iCLS Client` from path. Now everything goes quite well.
 
 ###note
 

--- a/Build_On_Windows.md
+++ b/Build_On_Windows.md
@@ -1,0 +1,57 @@
+# How to build ycmd on Windows with Visual Studio
+
+Note: the relative path base in following text is ycmd git source code folder.
+
+
+1. Get the required tools.
+
+- Visual studio 2013 or later.
+
+- Subversion Get it from: http://subversion.apache.org/packages.html (TortoiseSVN is OK. We need svn.exe in PATH to build llvm/clang, and make sure svn.exe in cygwin not before it in PATH)
+
+- Python27 x64 (Python3 is not yet supported ) Get it at:  http://www.python.org/download
+
+- cmake (You should install it in the default `C:\Program Files (x86)\CMake`) Get it at: http://www.cmake.org/download
+
+- LLVM Windows binary (Not sure, this will provide a compiler with clang (clang-cl.exe) for Visual Studio,you can choose `LLVM-vs2013` in Visual Studio. If error happens when build llvm/clang, you should install it. It's only 36.8MB.) Get it at: http://llvm.org/releases/3.6.1/LLVM-3.6.1-win32.exe 
+
+2. Build llvm/clang
+
+Run `_build_llvm.bat` (Where? the relative path base..)
+
+This batch gets llvm/clang source code and generate a Visual Studio 2013 project files. So it maybe takes less than 10 minutes. The source code with .svn takes 360+MB disk space.
+
+If no error, the batch should quit silently.go to `llvm-build`
+
+Now go to `llvm-build` folder, open `LLVM.svn` and change Debug mode to Release mode. In Solution Explorer, go to `ALL_BUILD`, right click on `ALL_BUILD` and choose build. It take about quite a long time to finish the build. CPU is 100% during the build. The `llvm-build` folder takes about 6.65GB disk space.
+
+3. Build ycmd
+
+**Note**: Edit `_build_ycmd.bat`, and change `PYTHON_PATH` to a correct one.
+Run `_build_ycmd.bat`
+
+This batch generates `YouCompleteMe.sln` in ycmd_build folder. Open it with Visual Studio 2013. In Solution Explorer, select `ycm_support_libs` and right click on it choose build. (Note `ycm_core_tests` and `gmock_main` `gtest_main` etc will fail, so we cannot build the whole solution.) Now you should find `libclang.dll` and `ycm_client_support.pyd` and `ycm_core.pyd`.
+
+4. Test
+
+Open gvim.exe, you maybe see,
+```bash
+Runtime Error!
+
+Program: $VIM\gvim.exe
+
+R6034
+An application has made an attempt to load the C runtime
+library incorrectly.
+Please contact the application's support team for more
+information.
+```
+You can follow:
+
+https://bitbucket.org/Haroogan/vim-youcompleteme-for-windows/
+
+In my case, it is `C:\Program Files (x86)\Intel\iCLS Client\msvcr90.dll`. Remove it from path. Now everything goes quite well.
+
+Note: [Haroogan](https://bitbucket.org/Haroogan)'s build is MingW-w64 based, while this instructions are Visual Studio based(I successfully build gvim.exe with all latest python2/3 perl ruby lua support in Visual Studio. Because all latest vim llvm/clang python2/3 perl ruby lua source codes with no extra patches can be built in Visual Studio 2013 x64 mode.).
+
+This Visual studio build instructions contributed by [rexdf](http://github.com/rexdf).

--- a/Build_On_Windows.md
+++ b/Build_On_Windows.md
@@ -19,7 +19,9 @@ Note: the relative path base in following text is ycmd git source code folder.
 
 Edit `_build_ycmd.bat`, and change `PYTHON_PATH` to a correct one.
 
-Click `_run_both.bat` and go out for a walk.
+Click `_run_both.bat` and go out for a walk. (It takes about 2.40GB disk space.)
+
+The following is manual way.
 
 ###2. Build llvm/clang
 
@@ -63,7 +65,7 @@ In my case, it is `C:\Program Files (x86)\Intel\iCLS Client\msvcr90.dll`. Remove
 
 ###5. Cleanup
 
-You can safely delete `llvm_build\Release\lib`.
+You can safely delete `llvm_build\Release\lib`. If you don't need to build again, `llvm_build`,`llvm-src` and `ycmd_build` can be deleted. You maybe need clang.exe etc, so backup `llvm_build\Release` folder.
 
 ###note
 

--- a/Build_On_Windows.md
+++ b/Build_On_Windows.md
@@ -15,6 +15,10 @@ Note: the relative path base in following text is ycmd git source code folder.
 
 - LLVM Windows binary (Not sure, this will provide a compiler with clang (clang-cl.exe) for Visual Studio,you can choose `LLVM-vs2013` in Visual Studio. If error happens when build llvm/clang, you should install it. It's only 36.8MB.) Get it at: http://llvm.org/releases/3.6.1/LLVM-3.6.1-win32.exe 
 
+###1.5. Quick
+
+Click `_run_both.bat` and go out for a walk.
+
 ###2. Build llvm/clang
 
 Run `_build_llvm.bat` (Where? the relative path base..)

--- a/Build_On_Windows.md
+++ b/Build_On_Windows.md
@@ -3,7 +3,7 @@
 Note: the relative path base in following text is ycmd git source code folder.
 
 
-1. Get the required tools.
+###1. Get the required tools.
 
 - Visual studio 2013 or later.
 
@@ -15,7 +15,7 @@ Note: the relative path base in following text is ycmd git source code folder.
 
 - LLVM Windows binary (Not sure, this will provide a compiler with clang (clang-cl.exe) for Visual Studio,you can choose `LLVM-vs2013` in Visual Studio. If error happens when build llvm/clang, you should install it. It's only 36.8MB.) Get it at: http://llvm.org/releases/3.6.1/LLVM-3.6.1-win32.exe 
 
-2. Build llvm/clang
+###2. Build llvm/clang
 
 Run `_build_llvm.bat` (Where? the relative path base..)
 
@@ -25,14 +25,14 @@ If no error, the batch should quit silently.go to `llvm-build`
 
 Now go to `llvm-build` folder, open `LLVM.svn` and change Debug mode to Release mode. In Solution Explorer, go to `ALL_BUILD`, right click on `ALL_BUILD` and choose build. It take about quite a long time to finish the build. CPU is 100% during the build. The `llvm-build` folder takes about 6.65GB disk space.
 
-3. Build ycmd
+###3. Build ycmd
 
 **Note**: Edit `_build_ycmd.bat`, and change `PYTHON_PATH` to a correct one.
 Run `_build_ycmd.bat`
 
 This batch generates `YouCompleteMe.sln` in ycmd_build folder. Open it with Visual Studio 2013. In Solution Explorer, select `ycm_support_libs` and right click on it choose build. (Note `ycm_core_tests` and `gmock_main` `gtest_main` etc will fail, so we cannot build the whole solution.) Now you should find `libclang.dll` and `ycm_client_support.pyd` and `ycm_core.pyd`.
 
-4. Test
+###4. Test
 
 Open gvim.exe, you maybe see,
 ```bash
@@ -51,6 +51,8 @@ You can follow:
 https://bitbucket.org/Haroogan/vim-youcompleteme-for-windows/
 
 In my case, it is `C:\Program Files (x86)\Intel\iCLS Client\msvcr90.dll`. Remove it from path. Now everything goes quite well.
+
+###note
 
 Note: [Haroogan](https://bitbucket.org/Haroogan)'s build is MingW-w64 based, while this instructions are Visual Studio based(I successfully build gvim.exe with all latest python2/3 perl ruby lua support in Visual Studio. Because all latest vim llvm/clang python2/3 perl ruby lua source codes with no extra patches can be built in Visual Studio 2013 x64 mode.).
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ This should get you going.
 For more detailed instructions on building ycmd, see [YCM's
 instructions][ycm-install] (ignore the Vim-specific parts).
 
+If you want to build on windows visual studio, see [Build ycmd on Windows with Visual Studio](Build_On_Windows.md).
+
 API notes
 ---------
 

--- a/_build_llvm.bat
+++ b/_build_llvm.bat
@@ -26,7 +26,7 @@ IF [%1]==[] goto QUIT
 SET PATH=%PATH_BACKUP%
 call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
 
-devenv LLVM.sln /build release
+devenv LLVM.sln /build release /project ALL_BUILD
 
 IF ERRORLEVEL 1 goto ERROR
 IF ERRORLEVEL 0 goto QUIT

--- a/_build_llvm.bat
+++ b/_build_llvm.bat
@@ -13,7 +13,8 @@ cd ..\..
 if not exist llvm_build mkdir llvm_build
 cd llvm_build
 
-set PATH=C:\Program Files (x86)\CMake\bin;%path%
+set PATH_BACKUP=%path%
+set PATH=C:\Program Files (x86)\CMake\bin;
 
 REM open in Visual studio 2013 and build, it will take about 6.65GB disk space
 cmake -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 12 2013 Win64" ..\llvm-src
@@ -22,6 +23,7 @@ IF ERRORLEVEL 1 goto ERROR
 
 IF [%1]==[] goto QUIT
 
+SET PATH=%PATH_BACKUP%
 call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
 
 devenv LLVM.sln /build release

--- a/_build_llvm.bat
+++ b/_build_llvm.bat
@@ -1,0 +1,33 @@
+@echo off
+cd /d %~dp0
+
+REM Follow http://clang.llvm.org/get_started.html
+REM clone the latest llvm/clang source code take about 361MB disk space
+IF NOT EXIST llvm-src (
+svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm-src
+cd llvm-src\tools
+svn co http://llvm.org/svn/llvm-project/cfe/trunk clang
+cd ..\..
+)
+
+if not exist llvm_build mkdir llvm_build
+cd llvm_build
+
+set PATH=C:\Program Files (x86)\CMake\bin;
+
+REM open in Visual studio 2013 and build, it will take about 6.65GB disk space
+cmake -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 12 2013 Win64" ..\llvm-src
+
+
+IF ERRORLEVEL 1 goto ERROR
+IF ERRORLEVEL 0 goto QUIT
+
+:ERROR
+
+echo Error!
+
+pause
+
+:QUIT
+
+rem exit

--- a/_build_llvm.bat
+++ b/_build_llvm.bat
@@ -13,11 +13,18 @@ cd ..\..
 if not exist llvm_build mkdir llvm_build
 cd llvm_build
 
-set PATH=C:\Program Files (x86)\CMake\bin;
+set PATH=C:\Program Files (x86)\CMake\bin;%path%
 
 REM open in Visual studio 2013 and build, it will take about 6.65GB disk space
 cmake -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 12 2013 Win64" ..\llvm-src
 
+IF ERRORLEVEL 1 goto ERROR
+
+IF [%1]==[] goto QUIT
+
+call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
+
+devenv LLVM.sln /build release
 
 IF ERRORLEVEL 1 goto ERROR
 IF ERRORLEVEL 0 goto QUIT

--- a/_build_ycmd.bat
+++ b/_build_ycmd.bat
@@ -5,8 +5,8 @@ SET PYTHON_PATH=C:\Python27
 
 SET LLVM_PATH=%~dp0\llvm_build\Release
 
-xcopy %~dp0\llvm-src\include %LLVM_PATH%\include  /D /E /H /I /Y %*
-xcopy %~dp0\llvm-src\tools\clang\include %LLVM_PATH%\include  /D /E /H /I /Y %*
+xcopy %~dp0\llvm-src\include %LLVM_PATH%\include  /D /E /H /I /Y
+xcopy %~dp0\llvm-src\tools\clang\include %LLVM_PATH%\include  /D /E /H /I /Y
 
 set PATH_BACKUP=%path%
 SET PATH=C:\Program Files (x86)\CMake\bin;

--- a/_build_ycmd.bat
+++ b/_build_ycmd.bat
@@ -3,12 +3,15 @@ cd /d %~dp0
 
 SET PYTHON_PATH=C:\Python27
 
+SET LLVM_PATH=%~dp0\llvm_build\Release
+
+xcopy %~dp0\llvm-src\include %LLVM_PATH%\include  /D /E /H /I /Y %*
+xcopy %~dp0\llvm-src\tools\clang\include %LLVM_PATH%\include  /D /E /H /I /Y %*
+
 SET PATH=C:\Program Files (x86)\CMake\bin;
 
 if not exist ycmd_build mkdir ycmd_build
 cd ycmd_build
-
-SET LLVM_PATH=%~dp0\llvm_build\Release
 
 cmake -DPYTHON_EXECUTABLE=%PYTHON_PATH%\python.exe  -DPYTHON_INCLUDE_DIRS=%PYTHON_PATH%\include -DPYTHON_LIBRARIES=%PYTHON_PATH%\libs\python27.lib -DPATH_TO_LLVM_ROOT=%LLVM_PATH% -G "Visual Studio 12 2013 Win64" ..\cpp
 

--- a/_build_ycmd.bat
+++ b/_build_ycmd.bat
@@ -3,12 +3,12 @@ cd /d %~dp0
 
 SET PYTHON_PATH=C:\Python27
 
-set PATH=C:\Program Files (x86)\CMake\bin;
+SET PATH=C:\Program Files (x86)\CMake\bin;
 
 if not exist ycmd_build mkdir ycmd_build
 cd ycmd_build
 
-LLVM_PATH=%~dp0\llvm_build\Release
+SET LLVM_PATH=%~dp0\llvm_build\Release
 
 cmake -DPYTHON_EXECUTABLE=%PYTHON_PATH%\python.exe  -DPYTHON_INCLUDE_DIRS=%PYTHON_PATH%\include -DPYTHON_LIBRARIES=%PYTHON_PATH%\libs\python27.lib -DPATH_TO_LLVM_ROOT=%LLVM_PATH% -G "Visual Studio 12 2013 Win64" ..\cpp
 

--- a/_build_ycmd.bat
+++ b/_build_ycmd.bat
@@ -1,0 +1,26 @@
+@echo off
+cd /d %~dp0
+
+SET PYTHON_PATH=C:\Python27
+
+set PATH=C:\Program Files (x86)\CMake\bin;
+
+if not exist ycmd_build mkdir ycmd_build
+cd ycmd_build
+
+LLVM_PATH=%~dp0\llvm_build\Release
+
+cmake -DPYTHON_EXECUTABLE=%PYTHON_PATH%\python.exe  -DPYTHON_INCLUDE_DIRS=%PYTHON_PATH%\include -DPYTHON_LIBRARIES=%PYTHON_PATH%\libs\python27.lib -DPATH_TO_LLVM_ROOT=%LLVM_PATH% -G "Visual Studio 12 2013 Win64" ..\cpp
+
+IF ERRORLEVEL 1 goto ERROR
+IF ERRORLEVEL 0 goto QUIT
+
+:ERROR
+
+echo Error!
+
+pause
+
+:QUIT
+
+rem exit

--- a/_build_ycmd.bat
+++ b/_build_ycmd.bat
@@ -8,7 +8,8 @@ SET LLVM_PATH=%~dp0\llvm_build\Release
 xcopy %~dp0\llvm-src\include %LLVM_PATH%\include  /D /E /H /I /Y %*
 xcopy %~dp0\llvm-src\tools\clang\include %LLVM_PATH%\include  /D /E /H /I /Y %*
 
-SET PATH=C:\Program Files (x86)\CMake\bin;%path%
+set PATH_BACKUP=%path%
+SET PATH=C:\Program Files (x86)\CMake\bin;
 
 if not exist ycmd_build mkdir ycmd_build
 cd ycmd_build
@@ -19,6 +20,7 @@ IF ERRORLEVEL 1 goto ERROR
 
 IF [%1]==[] goto QUIT
 
+SET PATH=%PATH_BACKUP%
 call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
 
 devenv YouCompleteMe.sln /build release /project ycm_support_libs

--- a/_build_ycmd.bat
+++ b/_build_ycmd.bat
@@ -8,12 +8,20 @@ SET LLVM_PATH=%~dp0\llvm_build\Release
 xcopy %~dp0\llvm-src\include %LLVM_PATH%\include  /D /E /H /I /Y %*
 xcopy %~dp0\llvm-src\tools\clang\include %LLVM_PATH%\include  /D /E /H /I /Y %*
 
-SET PATH=C:\Program Files (x86)\CMake\bin;
+SET PATH=C:\Program Files (x86)\CMake\bin;%path%
 
 if not exist ycmd_build mkdir ycmd_build
 cd ycmd_build
 
 cmake -DPYTHON_EXECUTABLE=%PYTHON_PATH%\python.exe  -DPYTHON_INCLUDE_DIRS=%PYTHON_PATH%\include -DPYTHON_LIBRARIES=%PYTHON_PATH%\libs\python27.lib -DPATH_TO_LLVM_ROOT=%LLVM_PATH% -G "Visual Studio 12 2013 Win64" ..\cpp
+
+IF ERRORLEVEL 1 goto ERROR
+
+IF [%1]==[] goto QUIT
+
+call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
+
+devenv YouCompleteMe.sln /build release /project ycm_support_libs
 
 IF ERRORLEVEL 1 goto ERROR
 IF ERRORLEVEL 0 goto QUIT

--- a/_run_both.bat
+++ b/_run_both.bat
@@ -1,5 +1,7 @@
 @echo off
+cd /d %~dp0
 echo _build_llvm.bat
 _build_llvm.bat auto
+cd /d %~dp0
 echo _build_ycmd.bat
 _build_ycmd.bat auto

--- a/_run_both.bat
+++ b/_run_both.bat
@@ -1,0 +1,5 @@
+@echo off
+echo _build_llvm.bat
+_build_llvm.bat auto
+echo _build_ycmd.bat
+_build_ycmd.bat auto

--- a/_run_both.bat
+++ b/_run_both.bat
@@ -1,7 +1,7 @@
 @echo off
 cd /d %~dp0
 echo _build_llvm.bat
-_build_llvm.bat auto
+call _build_llvm.bat auto
 cd /d %~dp0
 echo _build_ycmd.bat
-_build_ycmd.bat auto
+call _build_ycmd.bat auto

--- a/cpp/BoostParts/CMakeLists.txt
+++ b/cpp/BoostParts/CMakeLists.txt
@@ -26,8 +26,20 @@ cmake_minimum_required( VERSION 2.8 )
 
 project( BoostParts )
 
-set( Python_ADDITIONAL_VERSIONS 2.7 2.6 )
-find_package( PythonLibs 2.6 REQUIRED )
+if( NOT WIN32 )
+    set( Python_ADDITIONAL_VERSIONS 2.7 2.6 )
+    find_package( PythonLibs 2.6 REQUIRED )
+else()
+    if( NOT ( DEFINED PYTHON_INCLUDE_DIRS ) OR
+        NOT ( DEFINED PYTHON_LIBRARIES ) )
+      set( Python_ADDITIONAL_VERSIONS 2.7 2.6 )
+      find_package( PythonLibs 2.6 )
+      if( NOT PYTHONLIBS_FOUND)
+        message( FATAL_ERROR
+            "PYTHON_LIBRARIES and PYTHON_LIBRARIES is needed" )
+      endif()
+    endif()
+endif()
 
 if ( NOT PYTHONLIBS_VERSION_STRING VERSION_LESS "3.0.0" )
   message( FATAL_ERROR

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -21,8 +21,21 @@ project( ycm_support_libs )
 set( CLIENT_LIB "ycm_client_support" )
 set( SERVER_LIB "ycm_core" )
 
-set( Python_ADDITIONAL_VERSIONS 2.7 2.6 )
-find_package( PythonLibs 2.6 REQUIRED )
+if( NOT WIN32 )
+    set( Python_ADDITIONAL_VERSIONS 2.7 2.6 )
+    find_package( PythonLibs 2.6 REQUIRED )
+else()
+    if( NOT ( DEFINED PYTHON_INCLUDE_DIRS ) OR
+        NOT ( DEFINED PYTHON_LIBRARIES ) OR
+        NOT ( DEFINED PYTHON_EXECUTABLE ) )
+      set( Python_ADDITIONAL_VERSIONS 2.7 2.6 )
+      find_package( PythonLibs 2.6 )
+      if( NOT PYTHONLIBS_FOUND)
+        message( FATAL_ERROR
+            "PYTHON_LIBRARIES and PYTHON_LIBRARIES and PYTHON_EXECUTABLE is needed" )
+      endif()
+    endif()
+endif()
 # The version of PythonInterp controls the version of boost.python which
 # is pulled in later, otherwise the highest python version is used
 find_package( PythonInterp 2.6 REQUIRED )


### PR DESCRIPTION
```cmake
if( NOT WIN32 )
    set( Python_ADDITIONAL_VERSIONS 2.7 2.6 )
    find_package( PythonLibs 2.6 REQUIRED )
else()
    if( NOT ( DEFINED PYTHON_INCLUDE_DIRS ) OR
        NOT ( DEFINED PYTHON_LIBRARIES ) OR
        NOT ( DEFINED PYTHON_EXECUTABLE ) )
      set( Python_ADDITIONAL_VERSIONS 2.7 2.6 )
      find_package( PythonLibs 2.6 )
      if( NOT PYTHONLIBS_FOUND)
        message( FATAL_ERROR
            "PYTHON_LIBRARIES and PYTHON_LIBRARIES and PYTHON_EXECUTABLE is needed" )
      endif()
    endif()
endif()
```

The above code is to support pass in `PYTHON_INCLUDE_DIRS` etc.

Because my system python2 is python279 x86 version and cmake read python version from Windows Registry, it's difficult to build on my system. While the build progress only need Python.h and python27.lib etc.

And I provide two batches to build llvm/clang latest 3.7.0 svn source code and ycmd. Build_On_Windows.md is a building instructions in details.