### PR TITLE
Remove minimum lines restriction for C-family and C# files

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -27,14 +27,10 @@ from ycmd.completers.cpp.flags import Flags, PrepareFlagsForClang
 from ycmd.completers.cpp.ephemeral_values_set import EphemeralValuesSet
 
 CLANG_FILETYPES = set( [ 'c', 'cpp', 'objc', 'objcpp' ] )
-MIN_LINES_IN_FILE_TO_PARSE = 5
 PARSING_FILE_MESSAGE = 'Still parsing file, no completions yet.'
 NO_COMPILE_FLAGS_MESSAGE = 'Still no compile flags, no completions yet.'
 INVALID_FILE_MESSAGE = 'File is invalid.'
 NO_COMPLETIONS_MESSAGE = 'No completions found; errors in the file?'
-FILE_TOO_SHORT_MESSAGE = (
-  'File is less than {0} lines long; not compiling.'.format(
-    MIN_LINES_IN_FILE_TO_PARSE ) )
 NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 PRAGMA_DIAG_TEXT_TO_IGNORE = '#pragma once in main file'
 TOO_MANY_ERRORS_DIAG_TEXT_TO_IGNORE = 'too many errors emitted, stopping now'
@@ -254,10 +250,6 @@ class ClangCompleter( Completer ):
 
   def OnFileReadyToParse( self, request_data ):
     filename = request_data[ 'filepath' ]
-    contents = request_data[ 'file_data' ][ filename ][ 'contents' ]
-    if contents.count( '\n' ) < MIN_LINES_IN_FILE_TO_PARSE:
-      raise ValueError( FILE_TOO_SHORT_MESSAGE )
-
     if not filename:
       raise ValueError( INVALID_FILE_MESSAGE )
 

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -32,11 +32,7 @@ import solutiondetection
 SERVER_NOT_FOUND_MSG = ( 'OmniSharp server binary not found at {0}. ' +
                          'Did you compile it? You can do so by running ' +
                          '"./install.sh --omnisharp-completer".' )
-MIN_LINES_IN_FILE_TO_PARSE = 5
 INVALID_FILE_MESSAGE = 'File is invalid.'
-FILE_TOO_SHORT_MESSAGE = (
-  'File is less than {0} lines long; not parsing.'.format(
-    MIN_LINES_IN_FILE_TO_PARSE ) )
 NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 PATH_TO_OMNISHARP_BINARY = os.path.join(
   os.path.abspath( os.path.dirname( __file__ ) ),
@@ -301,10 +297,6 @@ class CsharpSolutionCompleter:
 
   def CodeCheck( self, request_data ):
     filename = request_data[ 'filepath' ]
-    contents = request_data[ 'file_data' ][ filename ][ 'contents' ]
-    if contents.count( '\n' ) < MIN_LINES_IN_FILE_TO_PARSE:
-      raise ValueError( FILE_TOO_SHORT_MESSAGE )
-
     if not filename:
       raise ValueError( INVALID_FILE_MESSAGE )
 


### PR DESCRIPTION
Following the discussion of PR Valloric/YouCompleteMe#1545, this is an attempt to remove the 5 minimum lines restriction when compiling C-family files. This also removes the restriction for C# files (these lines were certainly copied from the Clang completer).

I did not see any lines restriction in [omnisharp-vim](https://github.com/OmniSharp/omnisharp-vim) repository so the change is safe for C# (I also tested it). For C-family files, I did not encountered issues but more testing may be needed.

Pros:
 - message is annoying
 - ~~remove the 'hit-enter' prompt in Vim when editing a new file~~ PR Valloric/YouCompleteMe#1545 made this irrelevant
 - choice of the minimum number of lines is arbitrary
 - less confusion when testing ycmd on C-family and C# files
 - ~~[one-liner program](https://en.wikipedia.org/wiki/One-liner_program#C)~~

Cons:
 - not worth compiling
 - not a huge issue

CLA signed.