### PR TITLE
Make ClangCompleter's GoTo(Imprecise) commands on definition go to declaration

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -128,6 +128,25 @@ ClangCompleter::CandidatesForLocationInFile(
 }
 
 
+bool ClangCompleter::IsLocationOnDefinition(
+  const std::string &filename,
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  const std::vector< std::string > &flags,
+  bool reparse ) {
+  ReleaseGil unlock;
+  shared_ptr< TranslationUnit > unit =
+    translation_unit_store_.GetOrCreate( filename, unsaved_files, flags );
+
+  if ( !unit ) {
+    return false;
+  }
+
+  return unit->IsLocationOnDefinition( line, column, unsaved_files, reparse );
+}
+
+
 Location ClangCompleter::GetDeclarationLocation(
   const std::string &filename,
   int line,

--- a/cpp/ycm/ClangCompleter/ClangCompleter.h
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.h
@@ -59,6 +59,14 @@ public:
     const std::vector< UnsavedFile > &unsaved_files,
     const std::vector< std::string > &flags );
 
+  bool IsLocationOnDefinition(
+    const std::string &filename,
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    const std::vector< std::string > &flags,
+    bool reparse = true );
+
   Location GetDeclarationLocation(
     const std::string &filename,
     int line,

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -184,6 +184,27 @@ std::vector< CompletionData > TranslationUnit::CandidatesForLocation(
   return candidates;
 }
 
+bool TranslationUnit::IsLocationOnDefinition(
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  bool reparse ) {
+  if ( reparse )
+    Reparse( unsaved_files );
+
+  unique_lock< mutex > lock( clang_access_mutex_ );
+
+  if ( !clang_translation_unit_ )
+    return false;
+
+  CXCursor cursor = GetCursor( line, column );
+
+  if ( !CursorIsValid( cursor ) )
+    return false;
+
+  return clang_isCursorDefinition( cursor );
+}
+
 Location TranslationUnit::GetDeclarationLocation(
   int line,
   int column,

--- a/cpp/ycm/ClangCompleter/TranslationUnit.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.h
@@ -66,6 +66,12 @@ public:
     int column,
     const std::vector< UnsavedFile > &unsaved_files );
 
+  YCM_DLL_EXPORT bool IsLocationOnDefinition(
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    bool reparse = true );
+
   YCM_DLL_EXPORT Location GetDeclarationLocation(
     int line,
     int column,

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -92,6 +92,7 @@ BOOST_PYTHON_MODULE(ycm_core)
     .def( vector_indexing_suite< std::vector< UnsavedFile > >() );
 
   class_< ClangCompleter, boost::noncopyable >( "ClangCompleter" )
+    .def( "IsLocationOnDefinition", &ClangCompleter::IsLocationOnDefinition )
     .def( "GetDeclarationLocation", &ClangCompleter::GetDeclarationLocation )
     .def( "GetDefinitionLocation", &ClangCompleter::GetDefinitionLocation )
     .def( "DeleteCachesForFile", &ClangCompleter::DeleteCachesForFile )

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -145,10 +145,12 @@ class Clang_Subcommands_test( Clang_Handlers_test ):
       { 'request': [24, 16], 'response': [ 2, 11] },
       # sic: Local::out_of_line -> definition of Local::out_of_line
       { 'request': [25, 27], 'response': [14, 13] }, # sic
-      # sic: GoToDeclaration on definition of out_of_line moves to itself
-      { 'request': [14, 13], 'response': [14, 13] }, # sic
-      # main -> definition of main (not declaration)
-      { 'request': [21,  7], 'response': [21, 5] }, # sic
+      # GoTo on definition of out_of_line moves to declaration
+      { 'request': [14, 13], 'response': [11, 10] },
+      # GoTo in middle of definition of out_of_line moves to definition
+      { 'request': [14, 20], 'response': [11, 10] },
+      # definition of main -> declaration of main
+      { 'request': [21,  7], 'response': [19, 5] }, # sic
     ]
 
     for test in tests:
@@ -171,10 +173,12 @@ class Clang_Subcommands_test( Clang_Handlers_test ):
       { 'request': [24, 16], 'response': [ 2, 11] },
       # sic: Local::out_of_line -> definition of Local::out_of_line
       { 'request': [25, 27], 'response': [14, 13] }, # sic
-      # sic: GoToDeclaration on definition of out_of_line moves to itself
-      { 'request': [14, 13], 'response': [14, 13] }, # sic
-      # main -> definition of main (not declaration)
-      { 'request': [21,  7], 'response': [21, 5] }, # sic
+      # GoToImprecise on definition of out_of_line moves to definition
+      { 'request': [14, 13], 'response': [11, 10] },
+      # GoToImprecise in middle of definition of out_of_line moves to definition
+      { 'request': [14, 20], 'response': [11, 10] },
+      # definition of main -> declaration of main
+      { 'request': [21,  7], 'response': [19, 5] }, # sic
     ]
 
     for test in tests:


### PR DESCRIPTION
This allows using a single key binding to GoTo (or GoToImprecise). If it
takes you to the definition, but you wanted to go to the declaration (eg,
because it has some useful comment), you just GoTo again.

This is on top of and depends on #178.

The current implementation only works if on the first character of the definition name. You will need to hit GoTo twice if in the middle. I think the solution to this would require making the C++ code aware of GoTo in addition to the GoTo forms it already handles. Let me know if you prefer that I do that.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/179)
<!-- Reviewable:end -->
