### PR TITLE
POC Cross-TranslationUnit GoToDefinition support

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -181,7 +181,12 @@ Location ClangCompleter::GetDefinitionLocation(
     return Location();
   }
 
-  return unit->GetDefinitionLocation( line, column, unsaved_files, reparse );
+  Location loc = unit->GetDefinitionLocation( line, column, unsaved_files, reparse );
+  if ( loc.IsValid() )
+      return loc;
+
+  std::string usr = unit->GetDefinitionUSR( line, column );
+  return translation_unit_store_.LocationForUsr(usr);
 }
 
 std::string ClangCompleter::GetTypeAtLocation(

--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -128,6 +128,25 @@ ClangCompleter::CandidatesForLocationInFile(
 }
 
 
+bool ClangCompleter::IsLocationOnDefinition(
+  const std::string &filename,
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  const std::vector< std::string > &flags,
+  bool reparse ) {
+  ReleaseGil unlock;
+  shared_ptr< TranslationUnit > unit =
+    translation_unit_store_.GetOrCreate( filename, unsaved_files, flags );
+
+  if ( !unit ) {
+    return false;
+  }
+
+  return unit->IsLocationOnDefinition( line, column, unsaved_files, reparse );
+}
+
+
 Location ClangCompleter::GetDeclarationLocation(
   const std::string &filename,
   int line,

--- a/cpp/ycm/ClangCompleter/ClangCompleter.h
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.h
@@ -59,6 +59,14 @@ public:
     const std::vector< UnsavedFile > &unsaved_files,
     const std::vector< std::string > &flags );
 
+  bool IsLocationOnDefinition(
+    const std::string &filename,
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    const std::vector< std::string > &flags,
+    bool reparse = true );
+
   Location GetDeclarationLocation(
     const std::string &filename,
     int line,

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -59,7 +59,8 @@ remove_pointer< CXCodeCompleteResults >::type > CodeCompleteResultsWrap;
 
 TranslationUnit::TranslationUnit()
   : filename_( "" ),
-    clang_translation_unit_( NULL ) {
+    clang_translation_unit_( NULL ),
+    clang_index_( NULL ) {
 }
 
 TranslationUnit::TranslationUnit(
@@ -68,7 +69,8 @@ TranslationUnit::TranslationUnit(
   const std::vector< std::string > &flags,
   CXIndex clang_index )
   : filename_( filename ),
-    clang_translation_unit_( NULL ) {
+    clang_translation_unit_( NULL ),
+    clang_index_( clang_index ) {
   std::vector< const char * > pointer_flags;
   pointer_flags.reserve( flags.size() );
 
@@ -105,6 +107,8 @@ TranslationUnit::~TranslationUnit() {
 
 void TranslationUnit::Destroy() {
   unique_lock< mutex > lock( clang_access_mutex_ );
+
+  usrs_.clear();
 
   if ( clang_translation_unit_ ) {
     clang_disposeTranslationUnit( clang_translation_unit_ );
@@ -262,6 +266,35 @@ Location TranslationUnit::GetDefinitionLocation(
   return Location( clang_getCursorLocation( definition_cursor ) );
 }
 
+std::string TranslationUnit::GetDefinitionUSR( int line, int column ) {
+  unique_lock< mutex > lock( clang_access_mutex_ );
+
+  if ( !clang_translation_unit_ )
+    return std::string();
+
+  CXCursor cursor = GetCursor( line, column );
+
+  if ( !CursorIsValid( cursor ) )
+    return std::string();
+
+  CXCursor referenced_cursor = clang_getCursorReferenced( cursor );
+
+  if ( !CursorIsValid( referenced_cursor ) )
+    return std::string();
+
+  return CXStringToString( clang_getCursorUSR( referenced_cursor ) );
+}
+
+Location TranslationUnit::GetLocationForUSR( const std::string& usr ) const {
+  unique_lock< mutex > lock( usrs_mutex_ );
+  USRs::const_iterator it = usrs_.find( usr );
+
+  if ( it == usrs_.end() )
+    return Location();
+
+  return it->second;
+}
+
 std::string TranslationUnit::GetTypeAtLocation(
   int line,
   int column,
@@ -361,6 +394,19 @@ void TranslationUnit::Reparse(
   Reparse( unsaved_files, options );
 }
 
+void TranslationUnit::IndexerDeclarationCallback( CXClientData rawData, const CXIdxDeclInfo* decl ) {
+  if ( decl->entityInfo->kind == CXIdxEntity_CXXNamespace )
+    return;
+
+  if ( !clang_Location_isFromMainFile(clang_indexLoc_getCXSourceLocation( decl->loc ) ) )
+    return;
+
+  if ( !decl->isDefinition )
+    return;
+
+  USRs* usrs = static_cast<USRs*>( rawData );
+  (*usrs)[decl->entityInfo->USR] = Location( clang_indexLoc_getCXSourceLocation( decl->loc ) );
+};
 
 // Argument taken as non-const ref because we need to be able to pass a
 // non-const pointer to clang. This function (and clang too) will not modify the
@@ -389,6 +435,25 @@ void TranslationUnit::Reparse( std::vector< CXUnsavedFile > &unsaved_files,
   }
 
   UpdateLatestDiagnostics();
+
+  IndexerCallbacks callbacks = IndexerCallbacks();
+  callbacks.indexDeclaration = IndexerDeclarationCallback;
+
+  USRs usrsLocal;
+  CXIndexAction action = clang_IndexAction_create( clang_index_ );
+  clang_indexTranslationUnit( action,
+                              &usrsLocal,
+                              &callbacks,
+                              sizeof(callbacks),
+                              CXIndexOpt_SuppressWarnings | CXIndexOpt_SkipParsedBodiesInSession,
+                              clang_translation_unit_);
+
+  clang_IndexAction_dispose( action );
+
+  {
+      unique_lock< mutex > lock( usrs_mutex_ );
+      usrsLocal.swap( usrs_ );
+  }
 }
 
 void TranslationUnit::UpdateLatestDiagnostics() {

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -184,6 +184,27 @@ std::vector< CompletionData > TranslationUnit::CandidatesForLocation(
   return candidates;
 }
 
+bool TranslationUnit::IsLocationOnDefinition(
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  bool reparse ) {
+  if ( reparse )
+    Reparse( unsaved_files );
+
+  unique_lock< mutex > lock( clang_access_mutex_ );
+
+  if ( !clang_translation_unit_ )
+    return false;
+
+  CXCursor cursor = GetCursor( line, column );
+
+  if ( !CursorIsValid( cursor ) )
+    return false;
+
+  return clang_isCursorDefinition( cursor );
+}
+
 Location TranslationUnit::GetDeclarationLocation(
   int line,
   int column,

--- a/cpp/ycm/ClangCompleter/TranslationUnit.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.h
@@ -66,6 +66,12 @@ public:
     int column,
     const std::vector< UnsavedFile > &unsaved_files );
 
+  YCM_DLL_EXPORT bool IsLocationOnDefinition(
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    bool reparse = true );
+
   YCM_DLL_EXPORT Location GetDeclarationLocation(
     int line,
     int column,

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
@@ -115,6 +115,20 @@ shared_ptr< TranslationUnit > TranslationUnitStore::Get(
   return GetNoLock( filename );
 }
 
+Location TranslationUnitStore::LocationForUsr(const std::string& usr) {
+  lock_guard< mutex > lock( filename_to_translation_unit_and_flags_mutex_ );
+  for (TranslationUnitForFilename::const_iterator
+           it(filename_to_translation_unit_.begin()),
+           end(filename_to_translation_unit_.end());
+        it != end;
+        ++it) {
+    Location location = it->second->GetLocationForUSR(usr);
+    if (location.IsValid())
+      return location;
+  }
+
+  return Location();
+}
 
 bool TranslationUnitStore::Remove( const std::string &filename ) {
   lock_guard< mutex > lock( filename_to_translation_unit_and_flags_mutex_ );

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.h
@@ -57,6 +57,8 @@ public:
   // not. You might end up getting a stale TU.
   boost::shared_ptr< TranslationUnit > Get( const std::string &filename );
 
+  Location LocationForUsr(const std::string& usr);
+
   bool Remove( const std::string &filename );
 
   void RemoveAll();

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -92,6 +92,7 @@ BOOST_PYTHON_MODULE(ycm_core)
     .def( vector_indexing_suite< std::vector< UnsavedFile > >() );
 
   class_< ClangCompleter, boost::noncopyable >( "ClangCompleter" )
+    .def( "IsLocationOnDefinition", &ClangCompleter::IsLocationOnDefinition )
     .def( "GetDeclarationLocation", &ClangCompleter::GetDeclarationLocation )
     .def( "GetDefinitionLocation", &ClangCompleter::GetDefinitionLocation )
     .def( "DeleteCachesForFile", &ClangCompleter::DeleteCachesForFile )

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -145,10 +145,12 @@ class Clang_Subcommands_test( Clang_Handlers_test ):
       { 'request': [24, 16], 'response': [ 2, 11] },
       # sic: Local::out_of_line -> definition of Local::out_of_line
       { 'request': [25, 27], 'response': [14, 13] }, # sic
-      # sic: GoToDeclaration on definition of out_of_line moves to itself
-      { 'request': [14, 13], 'response': [14, 13] }, # sic
-      # main -> definition of main (not declaration)
-      { 'request': [21,  7], 'response': [21, 5] }, # sic
+      # GoTo on definition of out_of_line moves to declaration
+      { 'request': [14, 13], 'response': [11, 10] },
+      # GoTo in middle of definition of out_of_line moves to definition
+      { 'request': [14, 20], 'response': [11, 10] },
+      # definition of main -> declaration of main
+      { 'request': [21,  7], 'response': [19, 5] }, # sic
     ]
 
     for test in tests:
@@ -171,10 +173,12 @@ class Clang_Subcommands_test( Clang_Handlers_test ):
       { 'request': [24, 16], 'response': [ 2, 11] },
       # sic: Local::out_of_line -> definition of Local::out_of_line
       { 'request': [25, 27], 'response': [14, 13] }, # sic
-      # sic: GoToDeclaration on definition of out_of_line moves to itself
-      { 'request': [14, 13], 'response': [14, 13] }, # sic
-      # main -> definition of main (not declaration)
-      { 'request': [21,  7], 'response': [21, 5] }, # sic
+      # GoToImprecise on definition of out_of_line moves to definition
+      { 'request': [14, 13], 'response': [11, 10] },
+      # GoToImprecise in middle of definition of out_of_line moves to definition
+      { 'request': [14, 20], 'response': [11, 10] },
+      # definition of main -> declaration of main
+      { 'request': [21,  7], 'response': [19, 5] }, # sic
     ]
 
     for test in tests:


### PR DESCRIPTION
This is an initial POC of cross-TU support for GoToDefinition. It works by extracting the USRs (clang's Unified Symbol Resolution) for each definition in the file after parsing the TU. If GoToDefinition fails on the TU, it will query all TUs in the TUStore to see if they contain the definition.

There is currently no support for serializing this information. This means that it can only go to definitions in files that are currently open and have been parsed since the last restart of the server.

This is on top of and complements well with #178 and #179. In my use case, I often want to go to the actual definition, but I'd also like a way to get to the documentation if there is any.

I am putting up a PR before writing tests to get initial feedback on if this is desired functionality and if you have a more preferred way of achieving it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/180)
<!-- Reviewable:end -->
