### PR TITLE
Support environment variable substitution in filename completer

### DIFF
--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -38,11 +38,11 @@ class FilenameCompleter( Completer ):
     self._flags = Flags()
 
     self._path_regex = re.compile( """
-      # 1 or more 'D:/'-like token or '/' or '~' or './' or '../'
-      (?:[A-z]+:/|[/~]|\./|\.+/)+
+      # 1 or more 'D:/'-like token or '/' or '~' or './' or '../' or '$var/'
+      (?:[A-z]+:/|[/~]|\./|\.+/|\$[A-Za-z0-9{}_]+/)+
 
-      # any alphanumeric symbal and space literal
-      (?:[ /a-zA-Z0-9()$+_~.\x80-\xff-\[\]]|
+      # any alphanumeric, symbol or space literal
+      (?:[ /a-zA-Z0-9(){}$+_~.\x80-\xff-\[\]]|
 
       # skip any special symbols
       [^\x20-\x7E]|
@@ -98,7 +98,8 @@ class FilenameCompleter( Completer ):
                                     utf8_filepath ) )
 
     path_match = self._path_regex.search( line )
-    path_dir = os.path.expanduser( path_match.group() ) if path_match else ''
+    path_dir = os.path.expanduser( 
+                os.path.expandvars( path_match.group() ) ) if path_match else ''
 
     return _GenerateCandidatesForPaths(
       _GetPathsStandardCase(

--- a/ycmd/completers/general/tests/filename_completer_test.py
+++ b/ycmd/completers/general/tests/filename_completer_test.py
@@ -111,3 +111,125 @@ class FilenameCompleter_test( object ):
           ( 'Qt',       '[Dir]' ),
           ( 'QtGui',    '[Dir]' ),
         ], data )
+
+  def EnvVar_AtStart_File_test( self ):
+    os.environ[ 'YCM_TEST_DATA_DIR' ] = DATA_DIR
+    data = sorted( self._CompletionResultsForLine(
+                            'set x = $YCM_TEST_DATA_DIR/include/QtGui/' ) )
+
+    os.environ.pop( 'YCM_TEST_DATA_DIR' )
+    eq_( [ ( 'QDialog', '[File]' ), ( 'QWidget', '[File]' ) ], data )
+
+
+  def EnvVar_AtStart_File_Partial_test( self ):
+    # The reason all entries in the directory are returned is that the
+    # RequestWrapper tells the completer to effectively return results for
+    # $YCM_TEST_DIR/testdata/filename_completer/ and the client filters based
+    # on the additional characters.
+    os.environ[ 'YCM_TEST_DIR' ] = TEST_DIR
+    data = sorted( self._CompletionResultsForLine(
+                    'set x = $YCM_TEST_DIR/testdata/filename_completer/te' ) )
+    os.environ.pop( 'YCM_TEST_DIR' )
+
+    eq_( [
+          ( u'foo漢字.txt', '[File]' ),
+          ( 'include',    '[Dir]' ),
+          ( 'test.cpp',   '[File]' ),
+          ( 'test.hpp',   '[File]' ),
+        ], data )
+
+  def EnvVar_AtStart_Dir_test( self ):
+    os.environ[ 'YCMTESTDIR' ] = TEST_DIR
+
+    data = sorted( self._CompletionResultsForLine(
+                            'set x = $YCMTESTDIR/testdata/' ) )
+
+    os.environ.pop( 'YCMTESTDIR' )
+
+    eq_( [ ('filename_completer', '[Dir]') ], data )
+
+  def EnvVar_AtStart_Dir_Partial_test( self ):
+    os.environ[ 'ycm_test_dir' ] = TEST_DIR
+    data = sorted( self._CompletionResultsForLine(
+                            'set x = $ycm_test_dir/testdata/fil' ) )
+
+    os.environ.pop( 'ycm_test_dir' )
+    eq_( [ ('filename_completer', '[Dir]') ], data )
+
+  def EnvVar_InMiddle_File_test( self ):
+    os.environ[ 'YCM_TEST_filename_completer' ] = 'filename_completer'
+    data = sorted( self._CompletionResultsForLine(
+      'set x = ' + TEST_DIR + '/testdata/$YCM_TEST_filename_completer/' ) )
+    os.environ.pop( 'YCM_TEST_filename_completer' )
+    eq_( [
+          ( u'foo漢字.txt', '[File]' ),
+          ( 'include',    '[Dir]' ),
+          ( 'test.cpp',   '[File]' ),
+          ( 'test.hpp',   '[File]' ),
+        ], data )
+
+  def EnvVar_InMiddle_File_Partial_test( self ):
+    os.environ[ 'YCM_TEST_filename_c0mpleter' ] = 'filename_completer'
+    data = sorted( self._CompletionResultsForLine(
+      'set x = ' + TEST_DIR + '/testdata/$YCM_TEST_filename_c0mpleter/te' ) )
+    os.environ.pop( 'YCM_TEST_filename_c0mpleter' )
+    eq_( [
+          ( u'foo漢字.txt', '[File]' ),
+          ( 'include',    '[Dir]' ),
+          ( 'test.cpp',   '[File]' ),
+          ( 'test.hpp',   '[File]' ),
+        ], data )
+
+  def EnvVar_InMiddle_Dir_test( self ):
+    os.environ[ 'YCM_TEST_td' ] = 'testd'
+    data = sorted( self._CompletionResultsForLine(
+                    'set x = ' + TEST_DIR + '/${YCM_TEST_td}ata/' ) )
+
+    os.environ.pop( 'YCM_TEST_td' )
+    eq_( [ ('filename_completer', '[Dir]') ], data )
+
+  def EnvVar_InMiddle_Dir_Partial_test( self ):
+    os.environ[ 'YCM_TEST_td' ] = 'tdata'
+    data = sorted( self._CompletionResultsForLine(
+                    'set x = ' + TEST_DIR + '/tes${YCM_TEST_td}/' ) )
+    os.environ.pop( 'YCM_TEST_td' )
+
+    eq_( [ ('filename_completer', '[Dir]') ], data )
+
+  def EnvVar_Undefined_test( self ):
+    data = sorted( self._CompletionResultsForLine(
+                    'set x = ' + TEST_DIR + '/testdata${YCM_TEST_td}/' ) )
+
+    eq_( [ ], data )
+
+  def EnvVar_Empty_Matches_test( self ):
+    os.environ[ 'YCM_empty_var' ] = ''
+    data = sorted( self._CompletionResultsForLine(
+                    'set x = ' + TEST_DIR + '/testdata${YCM_empty_var}/' ) )
+    os.environ.pop( 'YCM_empty_var' )
+
+    eq_( [ ('filename_completer', '[Dir]') ], data )
+
+  def EnvVar_Undefined_Garbage_test( self ):
+    os.environ[ 'YCM_TEST_td' ] = 'testdata'
+    data = sorted( self._CompletionResultsForLine(
+                    'set x = ' + TEST_DIR + '/$YCM_TEST_td}/' ) )
+
+    os.environ.pop( 'YCM_TEST_td' )
+    eq_( [ ], data )
+
+  def EnvVar_Undefined_Garbage_2_test( self ):
+    os.environ[ 'YCM_TEST_td' ] = 'testdata'
+    data = sorted( self._CompletionResultsForLine(
+                    'set x = ' + TEST_DIR + '/${YCM_TEST_td/' ) )
+
+    os.environ.pop( 'YCM_TEST_td' )
+    eq_( [ ], data )
+
+  def EnvVar_Undefined_Garbage_3_test( self ):
+    os.environ[ 'YCM_TEST_td' ] = 'testdata'
+    data = sorted( self._CompletionResultsForLine(
+                    'set x = ' + TEST_DIR + '/$ YCM_TEST_td/' ) )
+
+    os.environ.pop( 'YCM_TEST_td' )
+    eq_( [ ], data )


### PR DESCRIPTION
In response to https://github.com/Valloric/YouCompleteMe/issues/1600, this change allows the filename completer to expand environment variables when offering completions.

This works with the following types of path:

```
$HOME/something
$HOME/something/$something_else
$h0mE/something/etc.
/home/$USER/somewhere
/home/${USER}/somewhere_${USER}_knows_about
etc.
```

That is, variables containing 1 or more alpha, numeric, underscore or `{` and `}` chars.

I have signed the CLA.