### PR TITLE
When GoTo fails to find the definition, don't reparse when finding declaration

### DIFF
--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -214,7 +214,12 @@ Location TranslationUnit::GetDeclarationLocation(
   if ( !CursorIsValid( referenced_cursor ) )
     return Location();
 
-  return Location( clang_getCursorLocation( referenced_cursor ) );
+  CXCursor canonical_cursor = clang_getCanonicalCursor( referenced_cursor );
+
+  if ( !CursorIsValid( canonical_cursor ) )
+    return Location( clang_getCursorLocation( referenced_cursor ) );
+
+  return Location( clang_getCursorLocation( canonical_cursor ) );
 }
 
 Location TranslationUnit::GetDefinitionLocation(

--- a/cpp/ycm/tests/ClangCompleter/TranslationUnit_test.cpp
+++ b/cpp/ycm/tests/ClangCompleter/TranslationUnit_test.cpp
@@ -70,7 +70,7 @@ TEST_F( TranslationUnitTest, GoToDefinitionWorks ) {
                         clang_index_ );
 
   Location location = unit.GetDefinitionLocation(
-                        15,
+                        17,
                         3,
                         std::vector< UnsavedFile >() );
 
@@ -89,7 +89,7 @@ TEST_F( TranslationUnitTest, GoToDefinitionFails ) {
                         clang_index_ );
 
   Location location = unit.GetDefinitionLocation(
-                        17,
+                        19,
                         3,
                         std::vector< UnsavedFile >() );
 
@@ -106,12 +106,31 @@ TEST_F( TranslationUnitTest, GoToDeclarationWorks ) {
                         clang_index_ );
 
   Location location = unit.GetDeclarationLocation(
-                        17,
+                        19,
                         3,
                         std::vector< UnsavedFile >() );
 
   EXPECT_EQ( 12, location.line_number_ );
   EXPECT_EQ( 8, location.column_number_ );
+  EXPECT_TRUE( !location.filename_.empty() );
+}
+
+TEST_F( TranslationUnitTest, GoToDeclarationWorksOnDefinition ) {
+  fs::path path_to_testdata = fs::current_path() / fs::path( "testdata" );
+  fs::path test_file = path_to_testdata / fs::path( "goto.cpp" );
+
+  TranslationUnit unit( test_file.string(),
+                        std::vector< UnsavedFile >(),
+                        std::vector< std::string >(),
+                        clang_index_ );
+
+  Location location = unit.GetDeclarationLocation(
+                        16,
+                        6,
+                        std::vector< UnsavedFile >() );
+
+  EXPECT_EQ( 14, location.line_number_ );
+  EXPECT_EQ( 6, location.column_number_ );
   EXPECT_TRUE( !location.filename_.empty() );
 }
 

--- a/cpp/ycm/tests/testdata/goto.cpp
+++ b/cpp/ycm/tests/testdata/goto.cpp
@@ -11,6 +11,8 @@ struct Bar {
 struct Foo;
 struct Zoo;
 
+void func();
+
 void func() {
   Foo foo;
   foo.bar = 5;

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -206,7 +206,7 @@ class ClangCompleter( Completer ):
   def _GoTo( self, request_data ):
     location = self._LocationForGoTo( 'GetDefinitionLocation', request_data )
     if not location or not location.IsValid() or _LocationMatchesRequest(location, request_data):
-      location = self._LocationForGoTo( 'GetDeclarationLocation', request_data )
+      location = self._LocationForGoTo( 'GetDeclarationLocation', request_data, reparse = False )
     if not location or not location.IsValid():
       raise RuntimeError( 'Can\'t jump to definition or declaration.' )
     return _ResponseForLocation( location )

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -36,6 +36,11 @@ PRAGMA_DIAG_TEXT_TO_IGNORE = '#pragma once in main file'
 TOO_MANY_ERRORS_DIAG_TEXT_TO_IGNORE = 'too many errors emitted, stopping now'
 
 
+def _LocationMatchesRequest(location, request_data):
+  return (location.filename_ == request_data['filepath'] and
+          location.line_number_ == request_data['line_num'] and
+          location.column_number_ == request_data['column_num'])
+
 class ClangCompleter( Completer ):
   def __init__( self, user_options ):
     super( ClangCompleter, self ).__init__( user_options )
@@ -200,7 +205,7 @@ class ClangCompleter( Completer ):
 
   def _GoTo( self, request_data ):
     location = self._LocationForGoTo( 'GetDefinitionLocation', request_data )
-    if not location or not location.IsValid():
+    if not location or not location.IsValid() or _LocationMatchesRequest(location, request_data):
       location = self._LocationForGoTo( 'GetDeclarationLocation', request_data )
     if not location or not location.IsValid():
       raise RuntimeError( 'Can\'t jump to definition or declaration.' )
@@ -211,7 +216,7 @@ class ClangCompleter( Completer ):
     location = self._LocationForGoTo( 'GetDefinitionLocation',
                                       request_data,
                                       reparse = False )
-    if not location or not location.IsValid():
+    if not location or not location.IsValid() or _LocationMatchesRequest(location, request_data):
       location = self._LocationForGoTo( 'GetDeclarationLocation',
                                         request_data,
                                         reparse = False )

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -114,10 +114,6 @@ def _RunCompleterCommand_GoTo_all_Clang(filename, command, test):
 @with_setup( Setup )
 def RunCompleterCommand_GoTo_all_Clang_test():
   # GoToDeclaration
-  #
-  # the semantics of this seem the wrong way round to me. GoToDeclaration should
-  # go to where a method is declared, not where it is defined.
-  #
   tests = [
     # Local::x -> declaration of x
     { 'request': [24,25], 'response': [5 ,9 ] },
@@ -125,12 +121,12 @@ def RunCompleterCommand_GoTo_all_Clang_test():
     { 'request': [25,29], 'response': [7 ,10] },
     # Local -> declaration of Local
     { 'request': [25,19], 'response': [3 ,11] },
-    # sic: Local::out_of_line -> definition of Local::out_of_line
-    { 'request': [26,30], 'response': [15,13 ] }, # sic
-    # sic: GoToDeclaration on definition of out_of_line moves to itself
-    { 'request': [15,13], 'response': [15,13] }, # sic
-    # main -> definition of main (not declaration)
-    { 'request': [22,7 ], 'response': [22,5] }, # sic
+    # Local::out_of_line -> declaration of Local::out_of_line
+    { 'request': [26,30], 'response': [12,10] },
+    # GoToDeclaration on definition of out_of_line moves to declaration
+    { 'request': [15,13], 'response': [12,10] },
+    # main -> declaration of main
+    { 'request': [22,7 ], 'response': [20,5] },
   ]
 
   for test in tests:

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -175,8 +175,8 @@ def RunCompleterCommand_GoTo_all_Clang_test():
     { 'request': [25,19], 'response': [3 ,11] },
     # sic: Local::out_of_line -> definition of Local::out_of_line
     { 'request': [26,30], 'response': [15,13 ] }, # sic
-    # sic: GoToDeclaration on definition of out_of_line moves to itself
-    { 'request': [15,13], 'response': [15,13] }, # sic
+    # GoTo on definition of out_of_line moves to declaration
+    { 'request': [15,13], 'response': [12,10] },
     # main -> definition of main (not declaration)
     { 'request': [22,7 ], 'response': [22,5] }, # sic
   ]
@@ -201,8 +201,8 @@ def RunCompleterCommand_GoTo_all_Clang_test():
     { 'request': [25,19], 'response': [3 ,11] },
     # sic: Local::out_of_line -> definition of Local::out_of_line
     { 'request': [26,30], 'response': [15,13 ] }, # sic
-    # sic: GoToDeclaration on definition of out_of_line moves to itself
-    { 'request': [15,13], 'response': [15,13] }, # sic
+    #  GoToImprecise on definition of out_of_line moves to declaration
+    { 'request': [15,13], 'response': [12,10] },
     # main -> definition of main (not declaration)
     { 'request': [22,7 ], 'response': [22,5] }, # sic
   ]


### PR DESCRIPTION
It just reparsed when looking for the definition, and nothing could have changed since then since this is a blocking operation.

This is on top of my #179 PR since both change nearby lines. If you want this one and not the others, it is a simple manual fix.