### PR TITLE
Encode contents in Typescript completer

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -144,7 +144,7 @@ class TypeScriptCompleter( Completer ):
     filename = request_data[ 'filepath' ]
     contents = request_data[ 'file_data' ][ filename ][ 'contents' ]
     tmpfile = NamedTemporaryFile( delete=False )
-    tmpfile.write( contents )
+    tmpfile.write( utils.ToUtf8IfNeeded( contents ) )
     tmpfile.close()
     seq = self._SendRequest( 'reload', {
       'file':    filename,

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -908,7 +908,7 @@ def GetCompletions_TypeScriptCompleter_test():
                                   filetype = 'typescript',
                                   contents = contents,
                                   force_semantic = True,
-                                  line_num = 11,
+                                  line_num = 12,
                                   column_num = 6 )
 
   results = app.post_json( '/completions',

--- a/ycmd/tests/testdata/test.ts
+++ b/ycmd/tests/testdata/test.ts
@@ -1,5 +1,6 @@
 
 class Foo {
+  // Unicode string: 说话
   methodA() {}
   methodB() {}
   methodC() {}
@@ -7,7 +8,7 @@ class Foo {
 
 var foo = new Foo();
 
-// line 11, column 6
+// line 12, column 6
 foo.m
 
 


### PR DESCRIPTION
Contents should be encoded to UTF-8 if containing non-ascii characters before writing it to a temporary file in Typescript completer.

Fix issue Valloric/YouCompleteMe#1616.

CLA signed.