### PR TITLE
use release omnisharp

### DIFF
--- a/build.py
+++ b/build.py
@@ -165,7 +165,7 @@ def BuildOmniSharp():
     sys.exit( 'msbuild or xbuild is required to build Omnisharp' )
 
   sh.cd( p.join( DIR_OF_THIS_SCRIPT, 'third_party/OmniSharpServer' ) )
-  sh.Command( build_command )( _out = sys.stdout )
+  sh.Command( build_command )( "/property:Configuration=Release", _out = sys.stdout )
 
 
 def BuildGoCode():

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -37,7 +37,7 @@ INVALID_FILE_MESSAGE = 'File is invalid.'
 NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 PATH_TO_OMNISHARP_BINARY = os.path.join(
   os.path.abspath( os.path.dirname( __file__ ) ),
-  '../../../third_party/OmniSharpServer/OmniSharp/bin/Debug/OmniSharp.exe' )
+  '../../../third_party/OmniSharpServer/OmniSharp/bin/Release/OmniSharp.exe' )
 
 
 # TODO: Handle this better than dummy classes


### PR DESCRIPTION
Using the release configuration of OmniSharp.

*** There are currently bugs with the Release configuration that need to be fixed with https://github.com/OmniSharp/omnisharp-server/pull/206, so this shouldn't be merged until the OmniSharp fix is merged and the submodule updated.  I'll update this PR if/when that happens.