### PR TITLE
cygwin fix

### DIFF
--- a/cpp/BoostParts/boost/python/detail/wrap_python.hpp
+++ b/cpp/BoostParts/boost/python/detail/wrap_python.hpp
@@ -82,8 +82,8 @@
 // Some things we need in order to get Python.h to work with compilers other
 // than MSVC on Win32
 //
-#if defined(_WIN32) || defined(__CYGWIN__)
-# if defined(__GNUC__) && defined(__CYGWIN__)
+#if defined(_WIN32)
+# if defined(__GNUC__)
 
 #  define SIZEOF_LONG 4
 


### PR DESCRIPTION
This fixes the following build error in the current version of cygwin:

```
[ 15%] Building CXX object BoostParts/CMakeFiles/BoostParts.dir/libs/python/src/converter/registry.cpp.o
BoostParts/CMakeFiles/BoostParts.dir/build.make:491: recipe for target 'BoostParts/CMakeFiles/BoostParts.dir/libs/python/src/converter/builtin_converters.cpp.o' failed
In file included from /usr/include/python2.7/Python.h:58:0,
                 from /cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp/BoostParts/boost/python/detail/wrap_python.hpp:142,
                 from /cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp/BoostParts/boost/python/detail/prefix.hpp:13,
                 from /cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp/BoostParts/boost/python/type_id.hpp:8,
                 from /cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp/BoostParts/boost/python/converter/registry.hpp:7,
                 from /cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp/BoostParts/libs/python/src/converter/registry.cpp:5:
/usr/include/python2.7/pyport.h:886:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
 #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
  ^
BoostParts/CMakeFiles/BoostParts.dir/build.make:514: recipe for target 'BoostParts/CMakeFiles/BoostParts.dir/libs/python/src/converter/from_python.cpp.o' failed
make[3]: *** [BoostParts/CMakeFiles/BoostParts.dir/libs/python/src/converter/from_python.cpp.o] Error 1
BoostParts/CMakeFiles/BoostParts.dir/build.make:537: recipe for target 'BoostParts/CMakeFiles/BoostParts.dir/libs/python/src/converter/registry.cpp.o' failed
make[3]: *** [BoostParts/CMakeFiles/BoostParts.dir/libs/python/src/converter/registry.cpp.o] Error 1
CMakeFiles/Makefile2:75: recipe for target 'BoostParts/CMakeFiles/BoostParts.dir/all' failed
make[2]: *** [BoostParts/CMakeFiles/BoostParts.dir/all] Error 2
CMakeFiles/Makefile2:209: recipe for target 'ycm/CMakeFiles/ycm_support_libs.dir/rule' failed
make[1]: *** [ycm/CMakeFiles/ycm_support_libs.dir/rule] Error 2
Makefile:149: recipe for target 'ycm_support_libs' failed
make: *** [ycm_support_libs] Error 2
Traceback (most recent call last):
  File "/cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/build.py", line 196, in <module>
    Main()
  File "/cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/build.py", line 189, in Main
    BuildYcmdLibs( GetCmakeArgs( args ) )
  File "/cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/build.py", line 152, in BuildYcmdLibs
    _err = sys.stderr )
  File "/cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/third_party/sh/sh.py", line 1021, in __call__
    return RunningCommand(cmd, call_args, stdin, stdout, stderr)
  File "/cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/third_party/sh/sh.py", line 486, in __init__
    self.wait()
  File "/cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/third_party/sh/sh.py", line 500, in wait
    self.handle_command_exit_code(exit_code)
  File "/cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/third_party/sh/sh.py", line 516, in handle_command_exit_code
    raise exc(self.ran, self.process.stdout, self.process.stderr)
sh.ErrorReturnCode_2:

  RAN: '/usr/bin/make -j 8 ycm_support_libs'

  STDOUT:


  STDERR:
```

I assume the __CYGWIN__ stuff was to work around a problem with older versions of cygwin?