### PR TITLE
Pass client_data parameter to the FlagsForFile function of .ycm_extra_conf.py file for #include completion

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -97,8 +97,8 @@ class Flags( object ):
       return sanitized_flags
 
 
-  def UserIncludePaths( self, filename ):
-    flags = self.FlagsForFile( filename, False )
+  def UserIncludePaths( self, filename, client_data ):
+    flags = self.FlagsForFile( filename, client_data = client_data )
     if not flags:
       return []
 

--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -92,10 +92,12 @@ class FilenameCompleter( Completer ):
         # We do what GCC does for <> versus "":
         # http://gcc.gnu.org/onlinedocs/cpp/Include-Syntax.html
         include_current_file_dir = '<' not in include_match.group()
+        client_data = request_data.get( 'extra_conf_data', None )
         return _GenerateCandidatesForPaths(
           self.GetPathsIncludeCase( path_dir,
                                     include_current_file_dir,
-                                    utf8_filepath ) )
+                                    utf8_filepath,
+                                    client_data ) )
 
     path_match = self._path_regex.search( line )
     path_dir = os.path.expanduser( 
@@ -108,9 +110,10 @@ class FilenameCompleter( Completer ):
         utf8_filepath ) )
 
 
-  def GetPathsIncludeCase( self, path_dir, include_current_file_dir, filepath ):
+  def GetPathsIncludeCase( self, path_dir, include_current_file_dir, filepath,
+                           client_data ):
     paths = []
-    include_paths = self._flags.UserIncludePaths( filepath )
+    include_paths = self._flags.UserIncludePaths( filepath, client_data )
 
     if include_current_file_dir:
       include_paths.append( os.path.dirname( filepath ) )

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -771,6 +771,30 @@ def GetCompletions_ClangCompleter_ClientDataGivenToExtraConf_test():
 
 
 @with_setup( Setup )
+def GetCompletions_FilenameCompleter_ClientDataGivenToExtraConf_test():
+  app = TestApp( handlers.app )
+  app.post_json( '/load_extra_conf_file',
+                 { 'filepath': PathToTestFile(
+                                  'client_data/.ycm_extra_conf.py' ) } )
+  filepath = PathToTestFile( 'client_data/include.cpp' )
+  completion_data = BuildRequest( filepath = filepath,
+                                  filetype = 'cpp',
+                                  contents = open( filepath ).read(),
+                                  line_num = 1,
+                                  column_num = 11,
+                                  extra_conf_data = {
+                                    'flags': ['-x', 'c++']
+                                  })
+
+  results = app.post_json( '/completions',
+                           completion_data ).json[ 'completions' ]
+  assert_that( results,
+               has_item(
+                 CompletionEntryMatcher( 'include.hpp',
+                                         extra_menu_info = '[File]' ) ) )
+
+
+@with_setup( Setup )
 def GetCompletions_IdentifierCompleter_SyntaxKeywordsAdded_test():
   app = TestApp( handlers.app )
   event_data = BuildRequest( event_name = 'FileReadyToParse',

--- a/ycmd/tests/testdata/client_data/include.cpp
+++ b/ycmd/tests/testdata/client_data/include.cpp
@@ -1,0 +1,1 @@
+#include "


### PR DESCRIPTION
Fix issue Valloric/YouCompleteMe#1631.

Although it concerns C-family completions, it does not depend on the Clang completer but on the filename completer so I added the test to the (new) FilenameCompleter group.