### PR TITLE
Fall back to general completions when semantic engine has no suggestions

### DIFF
--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -55,7 +55,12 @@ class IdentifierCompleter( GeneralCompleter ):
     completions = _RemoveSmallCandidates(
       completions, self.user_options[ 'min_num_identifier_candidate_chars' ] )
 
-    return [ responses.BuildCompletionData( x ) for x in completions ]
+    def ConvertCompletionData( x ):
+        return responses.BuildCompletionData(
+                insertion_text = x,
+                extra_menu_info='[ID]' )
+
+    return [ ConvertCompletionData( x ) for x in completions ]
 
 
   def AddIdentifier( self, identifier, request_data ):

--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -100,7 +100,7 @@ class FilenameCompleter( Completer ):
                                     client_data ) )
 
     path_match = self._path_regex.search( line )
-    path_dir = os.path.expanduser( 
+    path_dir = os.path.expanduser(
                 os.path.expandvars( path_match.group() ) ) if path_match else ''
 
     return _GenerateCandidatesForPaths(

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -34,6 +34,7 @@ import logging
 import json
 import bottle
 import httplib
+import traceback
 from bottle import request, response
 import server_state
 from ycmd import user_options_store
@@ -89,17 +90,40 @@ def RunCompleterCommand():
 def GetCompletions():
   _logger.info( 'Received completion request' )
   request_data = RequestWrap( request.json )
-  do_filetype_completion = _server_state.ShouldUseFiletypeCompleter(
-    request_data )
+  ( do_filetype_completion, forced_filetype_completion ) = (
+                    _server_state.ShouldUseFiletypeCompleter(request_data ) )
   _logger.debug( 'Using filetype completion: %s', do_filetype_completion )
-  filetypes = request_data[ 'filetypes' ]
-  completer = ( _server_state.GetFiletypeCompleter( filetypes ) if
-                do_filetype_completion else
-                _server_state.GetGeneralCompleter() )
 
-  return _JsonResponse( BuildCompletionResponse(
-      completer.ComputeCandidates( request_data ),
-      request_data.CompletionStartColumn() ) )
+  errors = None
+  completions = None
+
+  if do_filetype_completion:
+    try:
+      completions = ( _server_state.GetFiletypeCompleter(
+                                  request_data[ 'filetypes' ] )
+                                 .ComputeCandidates( request_data ) )
+
+    except Exception as exception:
+      if forced_filetype_completion:
+        # user explicitly asked for semantic completion, so just pass the error
+        # back
+        raise
+      else:
+        # store the error to be returned with results from the identifier
+        # completer
+        stack = traceback.format_exc()
+        _logger.error( 'Exception from semantic completer (using general): ' +
+                        "".join( stack ) )
+        errors = [ BuildExceptionResponse( exception, stack ) ]
+
+  if not completions and not forced_filetype_completion:
+    completions = ( _server_state.GetGeneralCompleter()
+                                 .ComputeCandidates( request_data ) )
+
+  return _JsonResponse(
+      BuildCompletionResponse( completions if completions else [],
+                               request_data.CompletionStartColumn(),
+                               errors = errors ) )
 
 
 @app.get( '/healthy' )

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -104,10 +104,13 @@ def BuildCompletionData( insertion_text,
   return completion_data
 
 
-def BuildCompletionResponse( completion_datas, start_column ):
+def BuildCompletionResponse( completion_datas,
+                             start_column,
+                             errors=None ):
   return {
     'completions': completion_datas,
-    'completion_start_column': start_column
+    'completion_start_column': start_column,
+    'errors': errors if errors else [],
   }
 
 def BuildLocationData( location ):

--- a/ycmd/server_state.py
+++ b/ycmd/server_state.py
@@ -99,12 +99,30 @@ class ServerState( object ):
 
 
   def ShouldUseFiletypeCompleter( self, request_data ):
+    """
+    Determines whether or not the semantic completer should be called, and
+    returns an indication of the reason why. Specifically, returns a tuple:
+    ( should_use_completer_now, was_semantic_completion_forced ), where:
+     - should_use_completer_now: if True, the semantic engine should be used
+     - was_semantic_completion_forced: if True, the user requested "forced"
+                                       semantic completion
+
+    was_semantic_completion_forced is always False if should_use_completer_now
+    is False
+    """
     filetypes = request_data[ 'filetypes' ]
     if self.FiletypeCompletionUsable( filetypes ):
-      return ( ForceSemanticCompletion( request_data ) or
-               self.GetFiletypeCompleter( filetypes ).ShouldUseNow(
-                 request_data ) )
-    return False
+      if ForceSemanticCompletion( request_data ):
+        # use semantic, and it was forced
+        return ( True, True )
+      else:
+        # was not forced. check the conditions for triggering
+        return ( self.GetFiletypeCompleter( filetypes ).ShouldUseNow(
+                   request_data ), False )
+
+    # don't use semantic, ignore whether or not the user requested forced
+    # completion
+    return ( False, False )
 
 
   def GetGeneralCompleter( self ):

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -27,14 +27,15 @@ from .test_utils import ( Setup, BuildRequest, PathToTestFile,
 from webtest import TestApp, AppError
 from nose.tools import eq_, with_setup
 from hamcrest import ( assert_that, has_item, has_items, has_entry, has_entries,
-                       contains_inanyorder, empty, greater_than,
+                       contains, contains_inanyorder, empty, greater_than,
                        contains_string )
 from ..responses import  UnknownExtraConf, NoExtraConfDetected
 from .. import handlers
+from ..completers.cpp.clang_completer import NO_COMPLETIONS_MESSAGE
 import bottle
+import pprint
 
 bottle.debug( True )
-
 
 def CompletionEntryMatcher( insertion_text, extra_menu_info = None ):
   match = { 'insertion_text': insertion_text }
@@ -48,6 +49,69 @@ def CompletionLocationMatcher( location_type, value ):
                     has_entry( 'location',
                                has_entry( location_type, value ) ) )
 
+
+def ErrorMatcher( cls, msg ):
+  return has_entries( {
+    'exception' : has_entry( 'TYPE', cls.__name__ ),
+    'message': msg,
+  } )
+
+NO_COMPLETIONS_ERROR = ErrorMatcher( RuntimeError, NO_COMPLETIONS_MESSAGE )
+
+@with_setup( Setup )
+def GetCompletions_RunTest( test ):
+  """
+  Method to run a simple completion test and verify the result
+
+  Note: uses the .ycm_extra_conf from general_fallback/ which:
+   - supports cpp, c and objc
+   - requires extra_conf_data containing 'filetype&' = the filetype
+
+  this should be sufficient for many standard test cases
+
+  test is a dictionary containing:
+    'request': kwargs for BuildRequest
+    'expect': {
+       'response': server response code (e.g. httplib.OK)
+       'data': matcher for the server response json
+    }
+  """
+  app = TestApp( handlers.app )
+  app.post_json( '/load_extra_conf_file',
+                 { 'filepath': PathToTestFile(
+                                  'general_fallback/.ycm_extra_conf.py' ) } )
+
+  contents = open( test[ 'request' ][ 'filepath' ] ).read()
+
+  def CombineRequest( request, data ):
+    kw = request
+    request.update( data )
+    return BuildRequest( **kw )
+
+  # Because we aren't testing this command, we *always* ignore errors. This is
+  # mainly because we (may) want to test scenarios where the completer throws
+  # an exception and the easiest way to do that is to throw from within the
+  # FlagsForFile function.
+  app.post_json( '/event_notification',
+                 CombineRequest( test[ 'request' ], {
+                                   'event_name': 'FileReadyToParse',
+                                   'contents': contents,
+                                 } ),
+                 expect_errors = True )
+
+  # We also ignore errors here, but then we check the response code ourself.
+  # This is to allow testing of requests returning errors.
+  response = app.post_json( '/completions',
+                            CombineRequest( test[ 'request' ], {
+                              'contents': contents
+                            } ),
+                            expect_errors = True )
+
+  print 'completer response: ' + pprint.pformat( response.json )
+
+  eq_( response.status_code, test[ 'expect' ][ 'response' ] )
+
+  assert_that( response.json, test[ 'expect' ][ 'data' ] )
 
 @with_setup( Setup )
 def GetCompletions_RequestValidation_NoLineNumException_test():
@@ -80,8 +144,8 @@ def GetCompletions_IdentifierCompleter_Works_test():
 
   eq_( 1, response_data[ 'completion_start_column' ] )
   assert_that( response_data[ 'completions' ],
-               has_items( CompletionEntryMatcher( 'foo' ),
-                          CompletionEntryMatcher( 'foogoo' ) ) )
+               has_items( CompletionEntryMatcher( 'foo', '[ID]' ),
+                          CompletionEntryMatcher( 'foogoo', '[ID]' ) ) )
 
 
 @with_setup( Setup )
@@ -115,9 +179,207 @@ def GetCompletions_IdentifierCompleter_WorksForSpecialIdentifierChars_test():
                            completion_data ).json[ 'completions' ]
 
   assert_that( results,
-               has_items( CompletionEntryMatcher( 'font-size' ),
-                          CompletionEntryMatcher( 'font-family' ) ) )
+               has_items( CompletionEntryMatcher( 'font-size', '[ID]' ),
+                          CompletionEntryMatcher( 'font-family', '[ID]' ) ) )
 
+@with_setup( Setup )
+def GetCompletions_ClangCompleter_Forced_With_No_Trigger_test():
+  GetCompletions_RunTest( {
+    'description': 'semantic completion with force query=DO_SO',
+    'request': {
+      'filetype':   'cpp',
+      'filepath':   PathToTestFile( 'general_fallback/lang_cpp.cc' ),
+      'line_num':   54,
+      'column_num': 8,
+      'extra_conf_data': { '&filetype': 'cpp' },
+      'force_semantic': True,
+    },
+    'expect': {
+      'response': httplib.OK,
+      'data': has_entries( {
+        'completions': contains(
+          CompletionEntryMatcher( 'DO_SOMETHING_TO', 'void' ),
+          CompletionEntryMatcher( 'DO_SOMETHING_WITH', 'void' ),
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )  
+
+@with_setup( Setup )
+def GetCompletions_ClangCompleter_Fallback_NoSuggestions_test():
+  # TESTCASE1 (general_fallback/lang_c.c)
+  GetCompletions_RunTest( {
+    'description': 'Triggered, fallback but no query so no completions',
+    'request': {
+      'filetype':   'c',
+      'filepath':   PathToTestFile( 'general_fallback/lang_c.c' ),
+      'line_num':   29,
+      'column_num': 21,
+      'extra_conf_data': { '&filetype': 'c' },
+      'force_semantic': False,
+    },
+    'expect': {
+      'response': httplib.OK,
+      'data': has_entries( {
+        'completions': empty(),
+        'errors': has_item( NO_COMPLETIONS_ERROR ),
+      } )
+    },
+  } )
+
+@with_setup( Setup)
+def GetCompletions_ClangCompleter_Fallback_NoSuggestions_MinCh_test():
+  # TESTCASE1 (general_fallback/lang_cpp.cc)
+  GetCompletions_RunTest( {
+    'description': 'fallback general completion obeys min chars setting '
+                   ' (query="a")',
+    'request': {
+      'filetype':   'cpp',
+      'filepath':   PathToTestFile( 'general_fallback/lang_cpp.cc' ),
+      'line_num':   21,
+      'column_num': 22,
+      'extra_conf_data': { '&filetype': 'cpp' },
+      'force_semantic': False,
+    },
+    'expect': {
+      'response': httplib.OK,
+      'data': has_entries( {
+        'completions': empty(),
+        'errors': has_item( NO_COMPLETIONS_ERROR ),
+      } )
+    },
+  } )
+
+@with_setup( Setup)
+def GetCompletions_ClangCompleter_Fallback_Suggestions_test():
+  # TESTCASE1 (general_fallback/lang_c.c)
+  GetCompletions_RunTest( {
+    'description': '. after macro with some query text (.a_)',
+    'request': {
+      'filetype':   'c',
+      'filepath':   PathToTestFile( 'general_fallback/lang_c.c' ),
+      'line_num':   29,
+      'column_num': 23,
+      'extra_conf_data': { '&filetype': 'c' },
+      'force_semantic': False,
+    },
+    'expect': {
+      'response': httplib.OK,
+      'data': has_entries( {
+        'completions': has_item( CompletionEntryMatcher( 'a_parameter',
+                                                         '[ID]' ) ),
+        'errors': has_item( NO_COMPLETIONS_ERROR ),
+      } )
+    },
+  } )
+
+@with_setup( Setup )
+def GetCompletions_ClangCompleter_Fallback_Exception_test():
+  # TESTCASE4 (general_fallback/lang_c.c)
+  # extra conf throws exception
+  GetCompletions_RunTest( {
+    'description': '. on struct returns identifier because of error',
+    'request': {
+      'filetype':   'c',
+      'filepath':   PathToTestFile( 'general_fallback/lang_c.c' ),
+      'line_num':   62,
+      'column_num': 20,
+      'extra_conf_data': { '&filetype': 'c', 'throw': 'testy' },
+      'force_semantic': False,
+    },
+    'expect': {
+      'response': httplib.OK,
+      'data': has_entries( {
+        'completions': contains(
+          CompletionEntryMatcher( 'a_parameter', '[ID]' ),
+          CompletionEntryMatcher( 'another_parameter', '[ID]' ),
+        ),
+        'errors': has_item( ErrorMatcher( ValueError, 'testy' ) )
+      } )
+    },
+  } )
+
+@with_setup( Setup )
+def GetCompletions_ClangCompleter_Forced_NoFallback_test():
+  # TESTCASE2 (general_fallback/lang_c.c)
+  GetCompletions_RunTest( {
+    'description': '-> after macro with forced semantic',
+    'request': {
+      'filetype':   'c',
+      'filepath':   PathToTestFile( 'general_fallback/lang_c.c' ),
+      'line_num':   41,
+      'column_num': 30,
+      'extra_conf_data': { '&filetype': 'c' },
+      'force_semantic': True,
+    },
+    'expect': {
+      'response': httplib.INTERNAL_SERVER_ERROR,
+      'data': NO_COMPLETIONS_ERROR,
+    },
+  } )
+
+@with_setup( Setup )
+def GetCompletions_JediCompleter_NoSuggestions_Fallback_test():
+  # jedi completer doesn't raise NO_COMPLETIONS_MESSAGE, so this is a different
+  # code path to the ClangCompleter cases
+
+  # TESTCASE2 (general_fallback/lang_python.py)
+  GetCompletions_RunTest( {
+    'description': 'param jedi does not know about (id). query="a_p"',
+    'request': {
+      'filetype':   'python',
+      'filepath':   PathToTestFile( 'general_fallback/lang_python.py' ),
+      'line_num':   28,
+      'column_num': 20,
+      'extra_conf_data': { '&filetype': 'python' },
+      'force_semantic': False,
+    },
+    'expect': {
+      'response': httplib.OK,
+      'data': has_entries( {
+        'completions': contains(
+          CompletionEntryMatcher( 'a_parameter', '[ID]' ),
+          CompletionEntryMatcher( 'another_parameter', '[ID]' ),
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+@with_setup( Setup )
+def GetCompletions_ClangCompleter_Filtered_No_Results_Fallback_test():
+  # no errors because the semantic completer returned results, but they
+  # were filtered out by the query, so this is considered working OK
+  # (whereas no completions from the semantic engine is considered an
+  # error)
+
+  # TESTCASE5 (general_fallback/lang_cpp.cc)
+  GetCompletions_RunTest( {
+    'description': '. on struct returns IDs after query=do_',
+    'request': {
+      'filetype':   'c',
+      'filepath':   PathToTestFile( 'general_fallback/lang_c.c' ),
+      'line_num':   71,
+      'column_num': 18,
+      'extra_conf_data': { '&filetype': 'c' },
+      'force_semantic': False,
+    },
+    'expect': {
+      'response': httplib.OK,
+      'data': has_entries( {
+        'completions': contains_inanyorder(
+          # do_ is an identifier because it is already in the file when we
+          # load it
+          CompletionEntryMatcher( 'do_', '[ID]' ),
+          CompletionEntryMatcher( 'do_something', '[ID]' ),
+          CompletionEntryMatcher( 'do_another_thing', '[ID]' ),
+        ),
+        'errors': empty()
+      } )
+    },
+  } )
+  
 
 @with_setup( Setup )
 def GetCompletions_CsCompleter_Works_test():
@@ -330,9 +592,17 @@ def GetCompletions_CsCompleter_NonForcedReturnsNoResults_test():
                                   column_num = 21,
                                   force_semantic = False,
                                   query = 'Date' )
-  results = app.post_json( '/completions', completion_data ).json[ 'completions' ]
+  results = app.post_json( '/completions', completion_data ).json
 
-  assert_that( results, empty() )
+  # there are no semantic completions. However, we fall back to identifier
+  # completer in this case.
+  assert_that( results, has_entries( {
+    'completions' : has_item( has_entries( {
+      'insertion_text' : 'String',
+      'extra_menu_info': '[ID]',
+    } ) ),
+    'errors' : empty(),
+  } ) )
   StopOmniSharpServer( app, filepath )
 
 
@@ -358,9 +628,10 @@ def GetCompletions_CsCompleter_ForcedDividesCache_test():
                                   column_num = 21,
                                   force_semantic = True,
                                   query = 'Date' )
-  results = app.post_json( '/completions', completion_data ).json[ 'completions' ]
+  results = app.post_json( '/completions', completion_data ).json
 
-  assert_that( results, not(empty()) )
+  assert_that( results[ 'completions' ], not( empty() ) )
+  assert_that( results[ 'errors' ], empty() )
 
   completion_data = BuildRequest( filepath = filepath,
                                   filetype = 'cs',
@@ -369,9 +640,17 @@ def GetCompletions_CsCompleter_ForcedDividesCache_test():
                                   column_num = 21,
                                   force_semantic = False,
                                   query = 'Date' )
-  results = app.post_json( '/completions', completion_data ).json[ 'completions' ]
+  results = app.post_json( '/completions', completion_data ).json
 
-  assert_that( results, empty() )
+  # there are no semantic completions. However, we fall back to identifier
+  # completer in this case.
+  assert_that( results, has_entries( {
+    'completions' : has_item( has_entries( {
+      'insertion_text' : 'String',
+      'extra_menu_info': '[ID]',
+    } ) ),
+    'errors' : empty(),
+  } ) )
   StopOmniSharpServer( app, filepath )
 
 
@@ -689,20 +968,22 @@ def GetCompletions_ClangCompleter_ExceptionWhenNoFlagsFromExtraConf_test():
                      'noflags/.ycm_extra_conf.py' ) } )
 
   filepath = PathToTestFile( 'noflags/basic.cpp' )
+
   completion_data = BuildRequest( filepath = filepath,
                                   filetype = 'cpp',
                                   contents = open( filepath ).read(),
                                   line_num = 11,
-                                  column_num = 7 )
+                                  column_num = 7,
+                                  force_semantic = True )
 
   response = app.post_json( '/completions',
                             completion_data,
                             expect_errors = True )
   eq_( response.status_code, httplib.INTERNAL_SERVER_ERROR )
+
   assert_that( response.json,
                has_entry( 'exception',
                           has_entry( 'TYPE', RuntimeError.__name__ ) ) )
-
 
 @with_setup( Setup )
 def GetCompletions_ClangCompleter_ForceSemantic_OnlyFileteredCompletions_test():

--- a/ycmd/tests/testdata/general_fallback/.ycm_extra_conf.py
+++ b/ycmd/tests/testdata/general_fallback/.ycm_extra_conf.py
@@ -1,0 +1,36 @@
+ftopts = {
+  'cpp': [
+    '-Wall',
+    '-Wextra',
+    '-x', 'c++',
+    '-std=c++11',
+  ],
+  'c': [
+    '-Wall',
+    '-Wextra',
+    '-std=c99',
+    '-x', 'c',
+    '-I', '.',
+  ],
+  'objc': [
+    '-x', 'objective-c',
+    '-I', '.',
+  ],
+}
+
+def FlagsForFile(filename, **kwargs):
+  client_data = kwargs['client_data']
+  ft = client_data['&filetype']
+
+  try:
+    opts = ftopts[ft]
+  except:
+    opts = ftopts['cpp']
+
+  if 'throw' in client_data:
+    raise ValueError( client_data['throw'] )
+
+  return {
+    'flags': opts,
+    'do_cache': True
+  }

--- a/ycmd/tests/testdata/general_fallback/lang_c.c
+++ b/ycmd/tests/testdata/general_fallback/lang_c.c
@@ -1,0 +1,85 @@
+// Identifier completion makes sense for duck-typing.
+//
+// The purpose of this test is to both demonstrate the use-case and test the
+// functionality. Completions of "A.a_parameter" using the identifier
+// completer feels natural, whereas offering no suggestions feels broken
+
+typedef struct {
+  int a_parameter;
+  int another_parameter;
+} TTest;
+
+typedef struct {
+  int another_int;
+  int and_a_final_int;
+} TTest_Which_Is_Not_TTest;
+
+static void do_something( int );
+static void do_another_thing( int );
+
+// TESTCASE1: use of . on macro parameter. Macros used this way are compile-time
+// duck-typing. Note this in this particular instance, libclang actually
+// offers semantic completions if there is only call to this macro
+// (e.g. DO_SOMETHING_TO( a_test ) - clever little shrew), so we don't call it
+
+/*       1         2         3         4
+1234567890123456789012345678901234567890123456789 */
+#define DO_SOMETHING_TO( A )                   \
+  do {                                         \
+    do_something( A.a_parameter );             \
+    do_another_thing( A.another_parameter );   \
+  } while (0)
+
+// TESTCASE2: use of -> on macro parameter. Macros used this way are
+// compile-time duck-typing
+
+/*       1         2         3         4
+1234567890123456789012345678901234567890123456789 */
+#define DO_SOMETHING_VIA( P )                  \
+  do {                                         \
+    do_something( P->a_parameter );            \
+    do_another_thing( P->another_parameter );  \
+  } while (0)
+
+int main( int argc, char ** argv )
+{
+  TTest a_test;
+
+// TESTCASE3: use of -> on struct. This is an error, but the user might
+// subsequently change a_test to be a pointer. Assumption: user knows what they
+// are doing
+
+/*       1         2         3         4
+1234567890123456789012345678901234567890123456789 */
+  if ( a_test->anoth ) {
+    (void) 0;
+  }
+
+// TESTCASE4: use of . on struct. Gets semantic suggestions
+
+/*       1         2         3         4
+1234567890123456789012345678901234567890123456789 */
+  if ( a_test.a_parameter ) {
+    (void) 0;
+  }
+
+// TESTCASE5: use of . on struct for non-matching text. Again, probably an
+// error, but assume the user knows best, and might change it later.
+
+/*       1         2         3         4
+1234567890123456789012345678901234567890123456789 */
+  if ( a_test.do_ ) {
+    (void) 0;
+  }
+
+  TTest *p_test = &a_test;
+
+// TESTCASE6: use of -> on pointer. Semantic completions
+
+/*       1         2         3         4
+1234567890123456789012345678901234567890123456789 */
+  if ( p_test-> ) {
+
+  }
+
+}

--- a/ycmd/tests/testdata/general_fallback/lang_cpp.cc
+++ b/ycmd/tests/testdata/general_fallback/lang_cpp.cc
@@ -1,0 +1,55 @@
+namespace
+{
+  struct TTest
+  {
+    static void PrintDiagnostic();
+
+    int a_parameter;
+    int another_parameter;
+  }:
+
+  void do_something(int);
+  void do_another_thing(int);
+
+  // TESTCASE1: use of . on template argument. Templates used this way are
+  // compile-time duck typing
+  template<typename T>
+  void DO_SOMETHING_TO( T& t )
+  {
+/*       1         2         3         4
+1234567890123456789012345678901234567890123456789 */
+    do_something( t.a_parameter );
+  }
+
+  // TESTCASE2: use of -> on template argument. Templates used this way are
+  // compile-time duck typing
+  template<typename T>
+  void DO_SOMETHING_WITH( T* t )
+  {
+/*       1         2         3         4
+1234567890123456789012345678901234567890123456789 */
+    do_something( t->a_parameter );
+  }
+
+  // TESTCASE3: use of :: on template argument. Templates used this way are
+  // compile-time duck typing
+  template<typename T>
+  void PRINT_A_DIAGNOSTIC( )
+  {
+/*       1         2         3         4
+1234567890123456789012345678901234567890123456789 */
+    T::PrintDiagnostic();
+  }
+}
+
+int main (int , char **)
+{
+  // bonus test case (regression test) for identifier/forced semantic without
+  // trigger
+
+  TTest test;
+
+/*       1         2         3         4
+1234567890123456789012345678901234567890123456789 */
+  DO_SOMETHING_TO(test);
+}

--- a/ycmd/tests/testdata/general_fallback/lang_python.py
+++ b/ycmd/tests/testdata/general_fallback/lang_python.py
@@ -1,0 +1,37 @@
+class DoSomething:
+  def __init__(self):
+    self.this_is_well_known = 'too easy'
+    # Jedi is smart enough to spot self.a_parameter = 1, but not if we just hack
+    # it in some other method
+    hack(self)
+    pass
+
+def hack( obj ):
+  obj.a_parameter = 'secret'
+
+  def a_method( abc, **kwargs ):
+    print abc
+
+  obj.another_parameter = a_method
+
+def Main():
+  a_thing = DoSomething()
+
+  # TESTCASE1: param jedi knows about
+#       1         2         3         4
+#234567890123456789012345678901234567890123456789
+  print a_thing.this_is_well_known
+
+  # TESTCASE2: param jedi does not know about
+#        1         2         3         4
+#234567890123456789012345678901234567890123456789
+  print a_thing.a_parameter
+
+  # TESTCASE3: method jedi does not know about
+#       1         2         3         4
+#234567890123456789012345678901234567890123456789
+  a_thing.another_parameter( 'test' )
+
+# to ensure we can run this script to test the code actually makes sense!
+if __name__ == "__main__":
+  Main()


### PR DESCRIPTION
TL;DR
=====

- supply general completions (alongside any errors raised) when the semantic completer (`clang_completer`, `jedi_completer`, `omnisharp_completer`, etc.) returns no results for the query and semantic completion is not forced
- tag results from the identifier completer with `[ID]`
- add tests for the above cases

Background
=========

Submitted in reference to the following issues:

* https://github.com/Valloric/YouCompleteMe/issues/1506
* https://github.com/Valloric/YouCompleteMe/issues/1225
* https://github.com/Valloric/ycmd/issues/67

The semantic engine is called either if the user enters a semantic trigger, or if they _force_ semantic completion. There may be many reasons why the semantic engine might return no results, but most commonly:

* there are errors in the file, and the semantic engine cannot parse it
* the semantic engine is not sophisticated enough (or it is not possible) to present a meaningful, correct or complete set of semantic suggestions (e.g. c++ temples, c macros, python duck-typing)
* the user's query string does not match any semantic completion suggestion

Previously, in all of the above cases, YCMD would return either no suggestions, or an error. This could make it seem like YCMD was not functioning correctly. Indeed in some cases (as discussed in the issues) this can lead to awkward workflow problems.

API Changes
==========

The `get_completions` request may now optionally contain a list `errors` containing the details of 0 or more errors raised by the semantic completion engine in addition to (a possibly empty) list of completion suggestions. The contents of each entry is identical to the `get_completions` response when no completion suggestions are returned, and only an exception is returned. That is:

```
EXCEPTION :=
{
    'exception' : {
        'TYPE': "<python exeption type name>"
    },
    'message': "<error description>",
    'traceback': "<stack trace of where the exception was thrown>"
}

COMPLETION :=
{
    'insertion_text': "completion text to be inserted",
    'extra_menu_info': "additional display information, e.g. type, [ID], [file], <snip>",
    'menu_text': "alternative text to display in the menu, in place of insertion_text",
    'detailed_info': "additional info for separate display, such as documentation/overloads, etc."
    'kind': "character defining type of suggestion",
    'extra_data': "completer-specific additional data. currently not documented",
}

COMPLETION_SUGGESTIONS_RESPONSE :=
{
    'completions': [ <potentially empty list of COMPLETION> ],
    'completion_start_column': column index of start point for completion suggestion,
    'errors': [ <potentially empty list of EXCEPTION> ]
}

EXCEPTION_RESPONSE := EXCEPTION

GET_COMPLETIONS_RESPONSE := EXCEPTION_RESPONSE | COMPLETION_SUGGESTIONS_RESPONSE
```

Rationale
=======

YCMD's `README.md` says:

>There are two main use-cases for code-completion:
>
>1. The user knows which name they're looking for, they just don't want to type
>   the whole name.
>2. The user either doesn't know the name they need or isn't sure what the name
>   is. This is also known as the "API exploration" use-case.
>
>The first use case is the most common one and is trivially addressed with the
>identifier completion engine (which BTW is blazing fast). The second one needs
>semantic completion.

This change is pretty much 100% targeted at the first use-case.

I think it is arguable that it is in keeping with YCMD's ethos of 'the user knows what they want most of the time' that in all of the above listed cases for no semantic suggestions, offering identifier completions is better than offering nothing.

This behaviour works well for dynamic languages, in particular those using 'duck typing' or similar semantics, such as python. This naturally extends to compiled languages using compile-time duck typing (c++ templates, c macros).

However, it is totally legitimate concern that users typing a semantic trigger expect a certain amount of accuracy from the completion suggestions (the 2nd use case in README.md). This is particularly important in the case where the query string does not match any of the semantic completions supplied by the semantic engine, and we filter them out. In order to help with this mental model, we tag all identifier completions with `[ID]` in the completion menu. There is then a subtle, but clear indication that the suggestion is _not_ from the semantic engine. Existing "general" completer already tag their suggestions with `[File]`, `[Dir]` and `[snip]` etc.

What this change does
==================

When the semantic engine is called after a trigger (*not* after forced completion), and either no completion suggestions are returned or the completer throws an exception, we query the "general" completer (typically the identifier completer) and return those suggestions instead. 

In order to make this more obvious to the user, we mark suggestions from the
identifier completer with [ID] in completions menu. 

In order to preserve the behaviour of showing exceptions thrown by the completer to the user (e.g. in case they have an error in their `.ycm_extra_conf.py`, we return the exceptions as well as the identifier completions and print this exception to the log file.

Contentious issues
===============

As discussed on the above tracker issues, the general behaviour is somewhat divisive. I personally, having been using it for some time and *really* like it. I'm almost certainly going to maintain it in my fork. I thought about adding a switch (on by default), but thought I would avoid that because more switches is a _bad thing_(TM).

Also, this is a change in the YCMD API and as such requires minor changes in clients to display these additional errors. The `README.md` says that there is a SemVer API version, but i wan't able to find one other than the `CORE_VERSION`