### PR TITLE
[Windows support] Remove sh dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "third_party/requests"]
 	path = third_party/requests
 	url = https://github.com/kennethreitz/requests
-[submodule "third_party/sh"]
-	path = third_party/sh
-	url = https://github.com/amoffat/sh
 [submodule "third_party/gocode"]
 	path = third_party/gocode
 	url = https://github.com/nsf/gocode.git


### PR DESCRIPTION
Using sh module on Windows returns the following error:
```
ImportError: sh 1.11 is currently only supported on linux and osx. please install pbs 0.110 (http://pypi.python.org/pypi/pbs) for windows support.
```
so we drop it in favor of native and portable python functions.

We use the `--build` option of `cmake` to build the target because `make` is not available on Windows.