### PR TITLE
[Windows support] Join path components in a portable way

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -37,7 +37,8 @@ INVALID_FILE_MESSAGE = 'File is invalid.'
 NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 PATH_TO_OMNISHARP_BINARY = os.path.join(
   os.path.abspath( os.path.dirname( __file__ ) ),
-  '../../../third_party/OmniSharpServer/OmniSharp/bin/Release/OmniSharp.exe' )
+  '..', '..', '..', 'third_party', 'OmniSharpServer',
+  'OmniSharp', 'bin', 'Release', 'OmniSharp.exe' )
 
 
 # TODO: Handle this better than dummy classes

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -26,7 +26,7 @@ except ImportError as e:
     'Error importing ycm_core. Are you sure you have placed a '
     'version 3.2+ libclang.[so|dll|dylib] in folder "{0}"? '
     'See the Installation Guide in the docs. Full error: {1}'.format(
-      path.realpath( path.join( path.abspath( __file__ ), '../..' ) ),
+      path.realpath( path.join( path.abspath( __file__ ), '..', '..' ) ),
       str( e ) ) )
 
 import atexit

--- a/ycmd/tests/diagnostics_test.py
+++ b/ycmd/tests/diagnostics_test.py
@@ -152,7 +152,7 @@ def Diagnostics_CsCompleter_ZeroBasedLineAndColumn_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/Program.cs' )
+  filepath = PathToTestFile( 'testy', 'Program.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -199,10 +199,10 @@ def Diagnostics_CsCompleter_MultipleSolution_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepaths = [ PathToTestFile( 'testy/Program.cs' ),
-                PathToTestFile( 'testy-multiple-solutions/'
-                                'solution-named-like-folder/'
-                                'testy/'
+  filepaths = [ PathToTestFile( 'testy', 'Program.cs' ),
+                PathToTestFile( 'testy-multiple-solutions',
+                                'solution-named-like-folder',
+                                'testy',
                                 'Program.cs' ) ]
   lines = [ 11, 10 ]
   for filepath, line in zip( filepaths, lines ):
@@ -309,7 +309,7 @@ def GetDetailedDiagnostic_CsCompleter_Works_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/Program.cs' )
+  filepath = PathToTestFile( 'testy', 'Program.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -78,8 +78,8 @@ def GetCompletions_RunTest( test ):
   """
   app = TestApp( handlers.app )
   app.post_json( '/load_extra_conf_file',
-                 { 'filepath': PathToTestFile(
-                                  'general_fallback/.ycm_extra_conf.py' ) } )
+                 { 'filepath': PathToTestFile( 'general_fallback',
+                                               '.ycm_extra_conf.py' ) } )
 
   contents = open( test[ 'request' ][ 'filepath' ] ).read()
 
@@ -188,7 +188,7 @@ def GetCompletions_ClangCompleter_Forced_With_No_Trigger_test():
     'description': 'semantic completion with force query=DO_SO',
     'request': {
       'filetype':   'cpp',
-      'filepath':   PathToTestFile( 'general_fallback/lang_cpp.cc' ),
+      'filepath':   PathToTestFile( 'general_fallback', 'lang_cpp.cc' ),
       'line_num':   54,
       'column_num': 8,
       'extra_conf_data': { '&filetype': 'cpp' },
@@ -213,7 +213,7 @@ def GetCompletions_ClangCompleter_Fallback_NoSuggestions_test():
     'description': 'Triggered, fallback but no query so no completions',
     'request': {
       'filetype':   'c',
-      'filepath':   PathToTestFile( 'general_fallback/lang_c.c' ),
+      'filepath':   PathToTestFile( 'general_fallback', 'lang_c.c' ),
       'line_num':   29,
       'column_num': 21,
       'extra_conf_data': { '&filetype': 'c' },
@@ -236,7 +236,7 @@ def GetCompletions_ClangCompleter_Fallback_NoSuggestions_MinCh_test():
                    ' (query="a")',
     'request': {
       'filetype':   'cpp',
-      'filepath':   PathToTestFile( 'general_fallback/lang_cpp.cc' ),
+      'filepath':   PathToTestFile( 'general_fallback', 'lang_cpp.cc' ),
       'line_num':   21,
       'column_num': 22,
       'extra_conf_data': { '&filetype': 'cpp' },
@@ -258,7 +258,7 @@ def GetCompletions_ClangCompleter_Fallback_Suggestions_test():
     'description': '. after macro with some query text (.a_)',
     'request': {
       'filetype':   'c',
-      'filepath':   PathToTestFile( 'general_fallback/lang_c.c' ),
+      'filepath':   PathToTestFile( 'general_fallback', 'lang_c.c' ),
       'line_num':   29,
       'column_num': 23,
       'extra_conf_data': { '&filetype': 'c' },
@@ -282,7 +282,7 @@ def GetCompletions_ClangCompleter_Fallback_Exception_test():
     'description': '. on struct returns identifier because of error',
     'request': {
       'filetype':   'c',
-      'filepath':   PathToTestFile( 'general_fallback/lang_c.c' ),
+      'filepath':   PathToTestFile( 'general_fallback', 'lang_c.c' ),
       'line_num':   62,
       'column_num': 20,
       'extra_conf_data': { '&filetype': 'c', 'throw': 'testy' },
@@ -307,7 +307,7 @@ def GetCompletions_ClangCompleter_Forced_NoFallback_test():
     'description': '-> after macro with forced semantic',
     'request': {
       'filetype':   'c',
-      'filepath':   PathToTestFile( 'general_fallback/lang_c.c' ),
+      'filepath':   PathToTestFile( 'general_fallback', 'lang_c.c' ),
       'line_num':   41,
       'column_num': 30,
       'extra_conf_data': { '&filetype': 'c' },
@@ -329,7 +329,7 @@ def GetCompletions_JediCompleter_NoSuggestions_Fallback_test():
     'description': 'param jedi does not know about (id). query="a_p"',
     'request': {
       'filetype':   'python',
-      'filepath':   PathToTestFile( 'general_fallback/lang_python.py' ),
+      'filepath':   PathToTestFile( 'general_fallback', 'lang_python.py' ),
       'line_num':   28,
       'column_num': 20,
       'extra_conf_data': { '&filetype': 'python' },
@@ -359,7 +359,7 @@ def GetCompletions_ClangCompleter_Filtered_No_Results_Fallback_test():
     'description': '. on struct returns IDs after query=do_',
     'request': {
       'filetype':   'c',
-      'filepath':   PathToTestFile( 'general_fallback/lang_c.c' ),
+      'filepath':   PathToTestFile( 'general_fallback', 'lang_c.c' ),
       'line_num':   71,
       'column_num': 18,
       'extra_conf_data': { '&filetype': 'c' },
@@ -386,7 +386,7 @@ def GetCompletions_CsCompleter_Works_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/Program.cs' )
+  filepath = PathToTestFile( 'testy', 'Program.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -415,10 +415,10 @@ def GetCompletions_CsCompleter_MultipleSolution_Works_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepaths = [ PathToTestFile( 'testy/Program.cs' ),
-                PathToTestFile( 'testy-multiple-solutions/'
-                                'solution-named-like-folder/'
-                                'testy/'
+  filepaths = [ PathToTestFile( 'testy', 'Program.cs' ),
+                PathToTestFile( 'testy-multiple-solutions',
+                                'solution-named-like-folder',
+                                'testy',
                                 'Program.cs' ) ]
   lines = [ 10, 9 ]
   for filepath, line in zip( filepaths, lines ):
@@ -450,7 +450,7 @@ def GetCompletions_CsCompleter_PathWithSpace_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'неприличное слово/Program.cs' )
+  filepath = PathToTestFile( 'неприличное слово', 'Program.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -479,7 +479,7 @@ def GetCompletions_CsCompleter_HasBothImportsAndNonImport_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/ImportTest.cs' )
+  filepath = PathToTestFile( 'testy', 'ImportTest.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -510,7 +510,7 @@ def GetCompletions_CsCompleter_ImportsOrderedAfter_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/ImportTest.cs' )
+  filepath = PathToTestFile( 'testy', 'ImportTest.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -545,7 +545,7 @@ def GetCompletions_CsCompleter_ForcedReturnsResults_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/ContinuousTest.cs' )
+  filepath = PathToTestFile( 'testy', 'ContinuousTest.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -575,7 +575,7 @@ def GetCompletions_CsCompleter_NonForcedReturnsNoResults_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/ContinuousTest.cs' )
+  filepath = PathToTestFile( 'testy', 'ContinuousTest.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -611,7 +611,7 @@ def GetCompletions_CsCompleter_ForcedDividesCache_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/ContinuousTest.cs' )
+  filepath = PathToTestFile( 'testy', 'ContinuousTest.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -659,7 +659,7 @@ def GetCompletions_CsCompleter_ReloadSolutionWorks_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/Program.cs' )
+  filepath = PathToTestFile( 'testy', 'Program.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -683,10 +683,10 @@ def GetCompletions_CsCompleter_ReloadSolution_MultipleSolution_Works_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepaths = [ PathToTestFile( 'testy/Program.cs' ),
-                PathToTestFile( 'testy-multiple-solutions/'
-                                'solution-named-like-folder/'
-                                'testy/'
+  filepaths = [ PathToTestFile( 'testy', 'Program.cs' ),
+                PathToTestFile( 'testy-multiple-solutions',
+                                'solution-named-like-folder',
+                                'testy',
                                 'Program.cs' ) ]
   for filepath in filepaths:
     contents = open( filepath ).read()
@@ -729,12 +729,13 @@ def GetCompletions_CsCompleter_UsesSubfolderHint_test():
   app = TestApp( handlers.app )
   _CsCompleter_SolutionSelectCheck( app,
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-named-like-folder/'
-                                      'testy/Program.cs'),
+                                      'testy-multiple-solutions',
+                                      'solution-named-like-folder',
+                                      'testy',
+                                      'Program.cs' ),
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-named-like-folder/'
+                                      'testy-multiple-solutions',
+                                      'solution-named-like-folder',
                                       'testy.sln' ) )
 
 @with_setup( Setup )
@@ -742,12 +743,13 @@ def GetCompletions_CsCompleter_UsesSuperfolderHint_test():
   app = TestApp( handlers.app )
   _CsCompleter_SolutionSelectCheck( app,
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-named-like-folder/'
-                                      'not-testy/Program.cs' ),
+                                      'testy-multiple-solutions',
+                                      'solution-named-like-folder',
+                                      'not-testy',
+                                      'Program.cs' ),
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-named-like-folder/'
+                                      'testy-multiple-solutions',
+                                      'solution-named-like-folder',
                                       'solution-named-like-folder.sln' ) )
 
 @with_setup( Setup )
@@ -755,18 +757,19 @@ def GetCompletions_CsCompleter_ExtraConfStoreAbsolute_test():
   app = TestApp( handlers.app )
   _CsCompleter_SolutionSelectCheck( app,
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-not-named-like-folder/'
-                                      'extra-conf-abs/'
-                                      'testy/Program.cs' ),
+                                      'testy-multiple-solutions',
+                                      'solution-not-named-like-folder',
+                                      'extra-conf-abs',
+                                      'testy',
+                                      'Program.cs' ),
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-not-named-like-folder/'
+                                      'testy-multiple-solutions',
+                                      'solution-not-named-like-folder',
                                       'testy2.sln' ),
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-not-named-like-folder/'
-                                      'extra-conf-abs/'
+                                      'testy-multiple-solutions',
+                                      'solution-not-named-like-folder',
+                                      'extra-conf-abs',
                                       '.ycm_extra_conf.py' ) )
 
 @with_setup( Setup )
@@ -774,19 +777,20 @@ def GetCompletions_CsCompleter_ExtraConfStoreRelative_test():
   app = TestApp( handlers.app )
   _CsCompleter_SolutionSelectCheck( app,
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-not-named-like-folder/'
-                                      'extra-conf-rel/'
-                                      'testy/Program.cs' ),
+                                      'testy-multiple-solutions',
+                                      'solution-not-named-like-folder',
+                                      'extra-conf-rel',
+                                      'testy',
+                                      'Program.cs' ),
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-not-named-like-folder/'
-                                      'extra-conf-rel/'
+                                      'testy-multiple-solutions',
+                                      'solution-not-named-like-folder',
+                                      'extra-conf-rel',
                                       'testy2.sln' ),
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-not-named-like-folder/'
-                                      'extra-conf-rel/'
+                                      'testy-multiple-solutions',
+                                      'solution-not-named-like-folder',
+                                      'extra-conf-rel',
                                       '.ycm_extra_conf.py' ) )
 
 @with_setup( Setup )
@@ -794,20 +798,21 @@ def GetCompletions_CsCompleter_ExtraConfStoreNonexisting_test():
   app = TestApp( handlers.app )
   _CsCompleter_SolutionSelectCheck( app,
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-not-named-like-folder/'
-                                      'extra-conf-bad/'
-                                      'testy/Program.cs' ),
+                                      'testy-multiple-solutions',
+                                      'solution-not-named-like-folder',
+                                      'extra-conf-bad',
+                                      'testy',
+                                      'Program.cs' ),
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-not-named-like-folder/'
-                                      'extra-conf-bad/'
+                                      'testy-multiple-solutions',
+                                      'solution-not-named-like-folder',
+                                      'extra-conf-bad',
                                       'testy2.sln' ),
                                     PathToTestFile(
-                                      'testy-multiple-solutions/'
-                                      'solution-not-named-like-folder/'
-                                      'extra-conf-bad/'
-                                      'testy/'
+                                      'testy-multiple-solutions',
+                                      'solution-not-named-like-folder',
+                                      'extra-conf-bad',
+                                      'testy',
                                       '.ycm_extra_conf.py' ) )
 
 @with_setup( Setup )
@@ -815,9 +820,9 @@ def GetCompletions_CsCompleter_DoesntStartWithAmbiguousMultipleSolutions_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( ( 'testy-multiple-solutions/'
-                              'solution-not-named-like-folder/'
-                              'testy/Program.cs' ) )
+  filepath = PathToTestFile( 'testy-multiple-solutions',
+                             'solution-not-named-like-folder',
+                             'testy', 'Program.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -964,10 +969,10 @@ def GetCompletions_ClangCompleter_WorksWhenExtraConfExplicitlyAllowed_test():
 def GetCompletions_ClangCompleter_ExceptionWhenNoFlagsFromExtraConf_test():
   app = TestApp( handlers.app )
   app.post_json( '/load_extra_conf_file',
-                 { 'filepath': PathToTestFile(
-                     'noflags/.ycm_extra_conf.py' ) } )
+                 { 'filepath': PathToTestFile( 'noflags',
+                                               '.ycm_extra_conf.py' ) } )
 
-  filepath = PathToTestFile( 'noflags/basic.cpp' )
+  filepath = PathToTestFile( 'noflags', 'basic.cpp' )
 
   completion_data = BuildRequest( filepath = filepath,
                                   filetype = 'cpp',
@@ -1033,10 +1038,10 @@ def GetCompletions_ForceSemantic_Works_test():
 def GetCompletions_ClangCompleter_ClientDataGivenToExtraConf_test():
   app = TestApp( handlers.app )
   app.post_json( '/load_extra_conf_file',
-                 { 'filepath': PathToTestFile(
-                                  'client_data/.ycm_extra_conf.py' ) } )
+                 { 'filepath': PathToTestFile( 'client_data',
+                                               '.ycm_extra_conf.py' ) } )
 
-  filepath = PathToTestFile( 'client_data/main.cpp' )
+  filepath = PathToTestFile( 'client_data', 'main.cpp' )
   completion_data = BuildRequest( filepath = filepath,
                                   filetype = 'cpp',
                                   contents = open( filepath ).read(),
@@ -1055,9 +1060,9 @@ def GetCompletions_ClangCompleter_ClientDataGivenToExtraConf_test():
 def GetCompletions_FilenameCompleter_ClientDataGivenToExtraConf_test():
   app = TestApp( handlers.app )
   app.post_json( '/load_extra_conf_file',
-                 { 'filepath': PathToTestFile(
-                                  'client_data/.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'client_data/include.cpp' )
+                 { 'filepath': PathToTestFile( 'client_data',
+                                               '.ycm_extra_conf.py' ) } )
+  filepath = PathToTestFile( 'client_data', 'include.cpp' )
   completion_data = BuildRequest( filepath = filepath,
                                   filetype = 'cpp',
                                   contents = open( filepath ).read(),

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -653,7 +653,7 @@ def RunCompleterCommand_GoTo_CsCompleter_Works_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/GotoTestCase.cs' )
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -672,7 +672,7 @@ def RunCompleterCommand_GoTo_CsCompleter_Works_test():
                             filepath = filepath )
 
   eq_( {
-        'filepath': PathToTestFile( 'testy/Program.cs' ),
+        'filepath': PathToTestFile( 'testy', 'Program.cs' ),
         'line_num': 7,
         'column_num': 3
       },
@@ -686,7 +686,7 @@ def RunCompleterCommand_GoToImplementation_CsCompleter_Works_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/GotoTestCase.cs' )
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -705,7 +705,7 @@ def RunCompleterCommand_GoToImplementation_CsCompleter_Works_test():
                             filepath = filepath )
 
   eq_( {
-        'filepath': PathToTestFile( 'testy/GotoTestCase.cs' ),
+        'filepath': PathToTestFile( 'testy', 'GotoTestCase.cs' ),
         'line_num': 30,
         'column_num': 3
       },
@@ -719,7 +719,7 @@ def RunCompleterCommand_GoToImplementation_CsCompleter_NoImplementation_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/GotoTestCase.cs' )
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -754,7 +754,7 @@ def RunCompleterCommand_GoToImplementation_CsCompleter_InvalidLocation_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/GotoTestCase.cs' )
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -789,7 +789,7 @@ def RunCompleterCommand_GoToImplementationElseDeclaration_CsCompleter_NoImplemen
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/GotoTestCase.cs' )
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -808,7 +808,7 @@ def RunCompleterCommand_GoToImplementationElseDeclaration_CsCompleter_NoImplemen
                             filepath = filepath )
 
   eq_( {
-        'filepath': PathToTestFile( 'testy/GotoTestCase.cs' ),
+        'filepath': PathToTestFile( 'testy', 'GotoTestCase.cs' ),
         'line_num': 35,
         'column_num': 3
       },
@@ -822,7 +822,7 @@ def RunCompleterCommand_GoToImplementationElseDeclaration_CsCompleter_SingleImpl
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/GotoTestCase.cs' )
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -841,7 +841,7 @@ def RunCompleterCommand_GoToImplementationElseDeclaration_CsCompleter_SingleImpl
                             filepath = filepath )
 
   eq_( {
-        'filepath': PathToTestFile( 'testy/GotoTestCase.cs' ),
+        'filepath': PathToTestFile( 'testy', 'GotoTestCase.cs' ),
         'line_num': 30,
         'column_num': 3
       },
@@ -855,7 +855,7 @@ def RunCompleterCommand_GoToImplementationElseDeclaration_CsCompleter_MultipleIm
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/GotoTestCase.cs' )
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -874,11 +874,11 @@ def RunCompleterCommand_GoToImplementationElseDeclaration_CsCompleter_MultipleIm
                             filepath = filepath )
 
   eq_( [{
-        'filepath': PathToTestFile( 'testy/GotoTestCase.cs' ),
+        'filepath': PathToTestFile( 'testy', 'GotoTestCase.cs' ),
         'line_num': 43,
         'column_num': 3
       }, {
-        'filepath': PathToTestFile( 'testy/GotoTestCase.cs' ),
+        'filepath': PathToTestFile( 'testy', 'GotoTestCase.cs' ),
         'line_num': 48,
         'column_num': 3
       }],
@@ -892,7 +892,7 @@ def RunCompleterCommand_GetType_CsCompleter_EmptyMessage_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/GetTypeTestCase.cs' )
+  filepath = PathToTestFile( 'testy', 'GetTypeTestCase.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -923,7 +923,7 @@ def RunCompleterCommand_GetType_CsCompleter_VariableDeclaration_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/GetTypeTestCase.cs' )
+  filepath = PathToTestFile( 'testy', 'GetTypeTestCase.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',
@@ -1209,7 +1209,7 @@ def RunCompleterCommand_StopServer_CsCompleter_NoErrorIfNotStarted_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/GotoTestCase.cs' )
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
   StopOmniSharpServer( app, filepath )
   # Success = no raise
 
@@ -1225,7 +1225,7 @@ def _RunCompleterCommand_StopServer_CsCompleter_KeepLogFiles( keeping_log_files 
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'testy/GotoTestCase.cs' )
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -63,8 +63,8 @@ def PathToTestDataDir():
   return os.path.join( dir_of_current_script, 'testdata' )
 
 
-def PathToTestFile( test_basename ):
-  return os.path.join( PathToTestDataDir(), test_basename )
+def PathToTestFile( *args ):
+  return os.path.join( PathToTestDataDir(), *args )
 
 
 def StopOmniSharpServer( app, filename ):


### PR DESCRIPTION
Use the `os.path.join` function to join each component of a path (instead of using the `/` separator).

Fix 15 tests (11 failures and 4 errors) on Windows (listed in the commit message).