### PR TITLE
[Windows support] Fix absolute paths in tests

### DIFF
--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -56,7 +56,7 @@ foo()
                             filepath = '/foo.py' )
 
   eq_( {
-         'filepath': '/foo.py',
+         'filepath': os.path.abspath( '/foo.py' ),
          'line_num': 2,
          'column_num': 5
        },
@@ -78,7 +78,7 @@ def RunCompleterCommand_GoTo_Clang_ZeroBasedLineAndColumn_test():
                             filetype = 'cpp' )
 
   eq_( {
-        'filepath': '/foo',
+        'filepath': os.path.abspath( '/foo' ),
         'line_num': 2,
         'column_num': 8
       },
@@ -99,7 +99,7 @@ def _RunCompleterCommand_GoTo_all_Clang(filename, command, test):
     'filetype'          : 'cpp'
   }
   common_response = {
-    'filepath'  : '/foo',
+    'filepath'  : os.path.abspath( '/foo' ),
   }
 
   request = common_request


### PR DESCRIPTION
`ycmd` returns absolute platform-dependent paths in requests (example: `/foo.py` on Linux and `c:\\foo.py` on Windows) so we need to do the same in the tests.

Fix 26 tests (26 failures) on Windows (listed in the commit message).