### PR TITLE
[Windows support] Normalize paths in _PathsToAllParentFolders

### DIFF
--- a/ycmd/extra_conf_store.py
+++ b/ycmd/extra_conf_store.py
@@ -180,7 +180,7 @@ def _PathsToAllParentFolders( filename ):
 
   def PathFolderComponents( filename ):
     folders = []
-    path = os.path.dirname( filename )
+    path = os.path.normpath( os.path.dirname( filename ) )
     while True:
       path, folder = os.path.split( path )
       if folder:

--- a/ycmd/tests/extra_conf_store_test.py
+++ b/ycmd/tests/extra_conf_store_test.py
@@ -19,20 +19,29 @@
 
 from nose.tools import eq_
 from ycmd.extra_conf_store import _PathsToAllParentFolders
+import os.path
 
 
 def PathsToAllParentFolders_Basic_test():
-  eq_( [ '/home/user/projects', '/home/user', '/home', '/' ],
-       list( _PathsToAllParentFolders( '/home/user/projects/test.c' ) ) )
+  eq_( [
+    os.path.normpath( '/home/user/projects' ),
+    os.path.normpath( '/home/user' ),
+    os.path.normpath( '/home' ),
+    os.path.normpath( '/' )
+  ], list( _PathsToAllParentFolders( '/home/user/projects/test.c' ) ) )
+
 
 def PathsToAllParentFolders_FileAtRoot_test():
-  eq_( [ '/' ],
+  eq_( [ os.path.normpath( '/' ) ],
        list( _PathsToAllParentFolders( '/test.c' ) ) )
+
 
 # We can't use backwards slashes in the paths because then the test would fail
 # on Unix machines
 def PathsToAllParentFolders_WindowsPath_test():
-  eq_( [ r'C:/foo/goo/zoo', r'C:/foo/goo', r'C:/foo', 'C:' ],
-       list( _PathsToAllParentFolders( r'C:/foo/goo/zoo/test.c' ) ) )
-
-
+  eq_( [
+    os.path.normpath( r'C:/foo/goo/zoo' ),
+    os.path.normpath( r'C:/foo/goo' ),
+    os.path.normpath( r'C:/foo' ),
+    os.path.normpath( r'C:/' )
+  ], list( _PathsToAllParentFolders( r'C:/foo/goo/zoo/test.c' ) ) )


### PR DESCRIPTION
We need to normalize paths in _PathsToAllParentFolders function to convert all `/` separators to `\` on Windows. We do the same in the tests since results are platform dependent.

Fix 2 tests (2 failures) on Windows: `PathsToAllParentFolders_Basic` and `PathsToAllParentFolders_WindowsPath`.