### PR TITLE
Use client working directory if supplied for filename completer

### DIFF
--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -103,11 +103,16 @@ class FilenameCompleter( Completer ):
     path_dir = os.path.expanduser(
                 os.path.expandvars( path_match.group() ) ) if path_match else ''
 
+    # If the client supplied its working directory, use that instead of the
+    # working directory of ycmd
+    working_dir = request_data.get( 'working_dir' )
+
     return _GenerateCandidatesForPaths(
       _GetPathsStandardCase(
         path_dir,
         self.user_options[ 'filepath_completion_use_working_dir' ],
-        utf8_filepath ) )
+        utf8_filepath,
+        working_dir) )
 
 
   def GetPathsIncludeCase( self, path_dir, include_current_file_dir, filepath,
@@ -133,19 +138,47 @@ class FilenameCompleter( Completer ):
     return sorted( set( paths ) )
 
 
-def _GetPathsStandardCase( path_dir, use_working_dir, filepath ):
-  if not use_working_dir and not path_dir.startswith( '/' ):
-    path_dir = os.path.join( os.path.dirname( filepath ),
-                             path_dir )
+def _GetAbsolutePathForCompletions( path_dir,
+                                    use_working_dir,
+                                    filepath,
+                                    working_dir ):
+  """
+  Returns the absolute path for which completion suggestions should be returned
+  (in the standard case).
+  """
+
+  if path_dir.startswith( '/' ):
+    # Looks like an absolute path already, return it
+    return path_dir
+  elif use_working_dir:
+    # Return paths relative to the working directory of the client, if
+    # supplied, otherwise relative to the current working directory of this
+    # process
+    if working_dir:
+      return os.path.join( working_dir, path_dir )
+    else:
+      return os.path.join( os.getcwd(), path_dir )
+  else:
+    # Return paths relative to the file
+    return os.path.join( os.path.join( os.path.dirname( filepath ) ),
+                         path_dir )
+
+
+def _GetPathsStandardCase( path_dir, use_working_dir, filepath, working_dir ):
+
+  absolute_path_dir = _GetAbsolutePathForCompletions( path_dir,
+                                                      use_working_dir,
+                                                      filepath,
+                                                      working_dir )
 
   try:
     # We need to pass a unicode string to get unicode strings out of
     # listdir.
-    relative_paths = os.listdir( ToUnicodeIfNeeded( path_dir ) )
+    relative_paths = os.listdir( ToUnicodeIfNeeded( absolute_path_dir ) )
   except:
     relative_paths = []
 
-  return ( os.path.join( path_dir, relative_path )
+  return ( os.path.join( absolute_path_dir, relative_path )
            for relative_path in relative_paths )
 
 


### PR DESCRIPTION
Background
====

Fixes: https://github.com/Valloric/YouCompleteMe/issues/1655

The documentation for YouCompleteMe says:

>The g:ycm_filepath_completion_use_working_dir option

> By default, YCM's filepath completion will interpret relative paths like ../ as being relative to the folder of the file of the currently active buffer. Setting this option will force YCM to always interpret relative paths as being relative to Vim's current working directory.

> Default: 0

>  let g:ycm_filepath_completion_use_working_dir = 0

But previously, only the working directory of `ycmd` was used. This meant that operations like changing the working directory of the client were not reflected in completion suggestions.

What this change does
====

The client can now (optionally) pass a `working_dir` property to the '/completions' request which is respected by the filename completer (and potentially any other completer should it be useful). If `working_dir` is not supplied, the previous behaviour remains.

API Changes
====

The `/completions` request data now allows an optional `working_dir` parameter containing the _absolute path_ to the working directory of the client.

Testing
====

Added new tests to the `filename_completer_test`. See also trivial manual test cases on the linked issue. The one remaining question is about the performance of the `os.getcwd` call on each request, but it probably pales into insignificance compared to the performance of the vimscript, and in particular the IO operations performed by the filename completer itself.

This only addresses the 'standard' case for filename completer, as the 'include' case already has its own logic for relative paths and there are already auto tests for that.

Related
====

There is a related (trivial) change to YouCompleteMe: https://github.com/Valloric/YouCompleteMe/pull/1659