### PR TITLE
[Windows support] Convert paths to short path name on Windows

### DIFF
--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -450,7 +450,7 @@ def GetCompletions_CsCompleter_PathWithSpace_test():
   app = TestApp( handlers.app )
   app.post_json( '/ignore_extra_conf_file',
                  { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-  filepath = PathToTestFile( 'неприличное слово', 'Program.cs' )
+  filepath = PathToTestFile( u'неприличное слово', 'Program.cs' )
   contents = open( filepath ).read()
   event_data = BuildRequest( filepath = filepath,
                              filetype = 'cs',


### PR DESCRIPTION
Python 2 fails to execute a command with unicode characters on Windows. In ycmd case, only paths in command are likely to contain such characters so the trick is to convert them to short path name (also called 8.3 path or DOS path) which only contains ascii characters.

Fix GetCompletions_CsCompleter_PathWithSpace test.


