### PR TITLE
Fix flaky regular expression comparison test

### DIFF
--- a/ycmd/completers/completer_utils_test.py
+++ b/ycmd/completers/completer_utils_test.py
@@ -22,19 +22,27 @@ from nose.tools import eq_, ok_
 from ycmd.completers import completer_utils as cu
 
 
+def _extractPatternsFromFiletypeTriggerDict( triggerDict ):
+  copy = triggerDict.copy()
+  for key, values in triggerDict.items():
+    copy[ key ] = set( [ sre_pattern.pattern for sre_pattern in values ] )
+  return copy
+
 def FiletypeTriggerDictFromSpec_Works_test():
+
   eq_( defaultdict( set, {
-         'foo': set( [ cu._PrepareTrigger( 'zoo'),
-                       cu._PrepareTrigger( 'bar' ) ] ),
-         'goo': set( [ cu._PrepareTrigger( 'moo' ) ] ),
-         'moo': set( [ cu._PrepareTrigger( 'moo' ) ] ),
-         'qux': set( [ cu._PrepareTrigger( 'q' ) ] )
+         'foo': set( [ cu._PrepareTrigger( 'zoo').pattern,
+                       cu._PrepareTrigger( 'bar' ).pattern ] ),
+         'goo': set( [ cu._PrepareTrigger( 'moo' ).pattern ] ),
+         'moo': set( [ cu._PrepareTrigger( 'moo' ).pattern ] ),
+         'qux': set( [ cu._PrepareTrigger( 'q' ).pattern ] )
        } ),
-       cu._FiletypeTriggerDictFromSpec( {
-         'foo': ['zoo', 'bar'],
-         'goo,moo': ['moo'],
-         'qux': ['q']
-       } ) )
+       _extractPatternsFromFiletypeTriggerDict(
+         cu._FiletypeTriggerDictFromSpec( {
+           'foo': ['zoo', 'bar'],
+           'goo,moo': ['moo'],
+           'qux': ['q']
+       } ) ) )
 
 
 def FiletypeDictUnion_Works_test():

--- a/ycmd/completers/completer_utils_test.py
+++ b/ycmd/completers/completer_utils_test.py
@@ -22,14 +22,17 @@ from nose.tools import eq_, ok_
 from ycmd.completers import completer_utils as cu
 
 
-def _extractPatternsFromFiletypeTriggerDict( triggerDict ):
+def _ExtractPatternsFromFiletypeTriggerDict( triggerDict ):
+  """Returns a copy of the dictionary with the _sre.SRE_Pattern instances in 
+  each set value replaced with the pattern strings. Needed for equality test of
+  two filetype trigger dictionaries."""
   copy = triggerDict.copy()
   for key, values in triggerDict.items():
     copy[ key ] = set( [ sre_pattern.pattern for sre_pattern in values ] )
   return copy
 
-def FiletypeTriggerDictFromSpec_Works_test():
 
+def FiletypeTriggerDictFromSpec_Works_test():
   eq_( defaultdict( set, {
          'foo': set( [ cu._PrepareTrigger( 'zoo').pattern,
                        cu._PrepareTrigger( 'bar' ).pattern ] ),
@@ -37,7 +40,7 @@ def FiletypeTriggerDictFromSpec_Works_test():
          'moo': set( [ cu._PrepareTrigger( 'moo' ).pattern ] ),
          'qux': set( [ cu._PrepareTrigger( 'q' ).pattern ] )
        } ),
-       _extractPatternsFromFiletypeTriggerDict(
+       _ExtractPatternsFromFiletypeTriggerDict(
          cu._FiletypeTriggerDictFromSpec( {
            'foo': ['zoo', 'bar'],
            'goo,moo': ['moo'],


### PR DESCRIPTION
The proposed change is to fix the test `ycmd.completers.completer_utils_test.FiletypeTriggerDictFromSpec_Works_test` which previoulsy used an equality check which relied on `_sre.SRE_Pattern` objects in the dictionary being the same instances. However, this is not reliable as demonstrated in spurious test failures in https://github.com/Valloric/ycmd/pull/120.

In the instances where this test works it is relying on the call to `re.compile()` caching results and returning the same objects for the same patterns. The Python [docs](https://docs.python.org/2/library/re.html#re.compile) state that:
> The compiled versions of the most recent patterns passed to `re.match()`, `re.search()` or `re.compile()` are cached, so programs that use only a few regular expressions at a time needn’t worry about compiling regular expressions. 

Note that there is no guarantee of the cached versions being returned each time. The update to the test instead compares the `sre.SRE_Pattern.pattern` strings which can be used to reasonably say whether two of the objects represent the same pattern without being the same object necessarily.