### PR TITLE
Add option to pass Python interpreter for CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ git submodule update --init --recursive
 Then run `./build.py --clang-completer --omnisharp-completer --gocode-completer`.
 This should get you going.
 
+The `--python-executable` option can be used to pass the specific Python interpreter
+path to CMake as needed, or if CMake cannot find the proper Python interpreter.
+
 For more detailed instructions on building ycmd, see [YCM's
 instructions][ycm-install] (ignore the Vim-specific parts).
 

--- a/build.py
+++ b/build.py
@@ -105,6 +105,9 @@ def ParseArguments():
   parser.add_argument( '--system-boost', action = 'store_true',
                        help = 'Use the system boost instead of bundled one. '
                        'NOT RECOMMENDED OR SUPPORTED!')
+  parser.add_argument( '--python-executable', dest='python_executable',
+                       help = 'Path to the specific Python interpreter '
+                       'for cmake')
   args = parser.parse_args()
 
   if args.system_libclang and not args.clang_completer:
@@ -123,6 +126,10 @@ def GetCmakeArgs( parsed_args ):
 
   if parsed_args.system_boost:
     cmake_args.append( '-DUSE_SYSTEM_BOOST=ON' )
+
+  if parsed_args.python_executable:
+    cmake_args.append( '-DPYTHON_EXECUTABLE=%s' %
+                       parsed_args.python_executable )
 
   extra_cmake_args = os.environ.get( 'EXTRA_CMAKE_ARGS', '' )
   cmake_args.extend( extra_cmake_args.split() )


### PR DESCRIPTION
I'm having issue building ycmd for YCM, with both `/usr/bin/python` (python2.4, system default) and `/usr/bin/python2.7` installed in the Linux(RHEL) system, CMake can not find the new one correctly.
```
$ python2.7 ./build.py
-- The C compiler identification is GNU 4.1.2
-- The CXX compiler identification is GNU 4.1.2
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
Your C++ compiler does NOT support C++11, compiling in C++03 mode.
-- Found PythonLibs: /usr/lib64/libpython2.7.so (found suitable version "2.7.8", minimum required is "2.6")
CMake Error at /usr/local/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:108 (message):
  Could NOT find PythonInterp: Found unsuitable version "2.4.3", but required
  is at least "2.6" (found /usr/bin/python2)
Call Stack (most recent call first):
  /usr/local/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:313 (_FPHSA_FAILURE_MESSAGE)
  /usr/local/share/cmake-2.8/Modules/FindPythonInterp.cmake:139 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  ycm/CMakeLists.txt:28 (find_package)


-- Configuring incomplete, errors occurred!
See also "/tmp/ycm_build.SPEq35/CMakeFiles/CMakeOutput.log".
Traceback (most recent call last):
  File "./build.py", line 203, in <module>
    Main()
  File "./build.py", line 196, in Main
    BuildYcmdLibs( GetCmakeArgs( args ) )
  File "./build.py", line 158, in BuildYcmdLibs
    subprocess.check_call( [ 'cmake' ] + full_cmake_args )
  File "/usr/lib64/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cmake', '-G', 'Unix Makefiles', '/home/[snip]/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp']' returned non-zero exit status 1
```
Have tried a lot, and the only way to get passed is to set `-DPYTHON_EXECUTABLE` arg for CMake with this patch.

BTW: Sorry to create a duplicate PR as the former one was mingled with some improper info.