### PR TITLE
Add soversion Clang library to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 
 # Compiled Dynamic libraries
 *.dll
-*.so
+*.so*
 *.dylib
 
 # Compiled Static libraries


### PR DESCRIPTION
Ignore the `libclang.so.3.7` file. I forgot to do this when updating Clang to 3.7.0.