### PR TITLE
[Windows support] Force C++03 in diagnostics FixIt test

### DIFF
--- a/ycmd/tests/diagnostics_test.py
+++ b/ycmd/tests/diagnostics_test.py
@@ -361,7 +361,8 @@ def Diagnostics_ClangCompleter_FixIt_Available_test():
   event_data = BuildRequest( contents = contents,
                              event_name = 'FileReadyToParse',
                              filetype = 'cpp',
-                             compilation_flags = [ '-x' , 'c++',
+                             compilation_flags = [ '-x', 'c++',
+                                                   '-std=c++03',
                                                    '-Wall',
                                                    '-Wextra',
                                                    '-pedantic' ] )

--- a/ycmd/tests/testdata/FixIt_Clang_cpp11.cpp
+++ b/ycmd/tests/testdata/FixIt_Clang_cpp11.cpp
@@ -2,7 +2,7 @@
 // A selection of the tests from llvm/tools/clang/test/FixIt/fixit-cxx0x.cpp
 //
 // Modified to test fixits across multiple lines and ensure that the number of
-// diagnistics doesn't hit the compile threshold.
+// diagnostics doesn't hit the compile threshold.
 //
 
 /* This is a test of the various code modification hints that only


### PR DESCRIPTION
The `Diagnostics_ClangCompleter_FixIt_Available` test depends on the absence of a C++11 feature (explicit conversion functions) to succeed. By default, this is the case on Linux (and certainly OS X), not on Windows. This is solved by specifying an older version of C++ (C++03) in the test. 