### PR TITLE
[request_wrap.py] _Query does not take UTF8 into account

### DIFF
--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -77,7 +77,7 @@ class RequestWrap( object ):
 
 
   def _Query( self ):
-    return self[ 'line_value' ][
+    return ToUtf8IfNeeded(self[ 'line_value' ])[
              self[ 'start_column' ] - 1 : self[ 'column_num' ] - 1 ]
 
 

--- a/ycmd/tests/request_wrap_test.py
+++ b/ycmd/tests/request_wrap_test.py
@@ -154,3 +154,31 @@ def Query_InWhiteSpace_test():
   eq_( '',
        RequestWrap( PrepareJson( column_num = 8,
                                  contents = 'foo       ') )[ 'query' ] )
+
+def Query_AtWordEnd_WithUtf8_test():
+    eq_( 'foo',
+        RequestWrap( PrepareJson( column_num = 13,
+                                  contents = 'Hélène foo') )[ 'query' ] )
+
+def Query_InWordMiddle_WithUtf8_test():
+    eq_( 'foo',
+        RequestWrap( PrepareJson( column_num = 13,
+                                  contents = 'Hélène foobar') )[ 'query' ] )
+
+
+def Query_StartOfLine_WithUtf8_test():
+  eq_( '',
+       RequestWrap( PrepareJson( column_num = 1,
+                                 contents = 'Hélène foobar') )[ 'query' ] )
+
+
+def Query_StopsAtParen_WithUtf8_test():
+  eq_( 'bar',
+       RequestWrap( PrepareJson( column_num = 17,
+                                 contents = 'Hélène foo(bar') )[ 'query' ] )
+
+
+def Query_InWhiteSpace_WithUtf8_test():
+  eq_( '',
+       RequestWrap( PrepareJson( column_num = 17,
+                                 contents = 'Hélène foo       ') )[ 'query' ] )


### PR DESCRIPTION
Hi,

When designing a custom semantic completer for LaTeX (to complete labels and citations), I realised that the request_data['query'] is wrong when there are utf8 chars in the input line and works perfectly otherwise.

Changing l.80 in request_wrap.py by
```python 
return ToUtf8IfNeeded(self[ 'line_value' ])[
```
fixes the problem without making any tests failed. I also added some tests to ensure non regression with my modifications.

Hope this helps.

Best regards,

-- 
CR


