### PR TITLE
[Windows support] Do not delay parsing of templates on Windows

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -21,7 +21,7 @@ import ycm_core
 import os
 import inspect
 from ycmd import extra_conf_store
-from ycmd.utils import ToUtf8IfNeeded, OnMac
+from ycmd.utils import ToUtf8IfNeeded, OnMac, OnWindows
 from ycmd.responses import NoExtraConfDetected
 
 INCLUDE_FLAGS = [ '-isystem', '-I', '-iquote', '--sysroot=', '-isysroot',
@@ -248,6 +248,16 @@ def _ExtraClangFlags():
   if OnMac():
     for path in MAC_INCLUDE_PATHS:
       flags.extend( [ '-isystem', path ] )
+  # On Windows, parsing of templates is delayed until instantation time.
+  # This makes GetType and GetParent commands not returning the expected
+  # result when the cursor is in templates.
+  # Using the -fno-delayed-template-parsing flag disables this behavior.
+  # See http://clang.llvm.org/extra/PassByValueTransform.html#note-about-delayed-template-parsing
+  # for an explanation of the flag and
+  # https://code.google.com/p/include-what-you-use/source/detail?r=566
+  # for a similar issue.
+  if OnWindows():
+    flags.append( '-fno-delayed-template-parsing' )
   return flags
 
 

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -223,13 +223,18 @@ def _RunCompleterCommand_Message_Clang(filename, test, command):
   contents = open( PathToTestFile( filename ) ).read()
   app = TestApp( handlers.app )
 
+  # We use the -fno-delayed-template-parsing flag to not delay
+  # parsing of templates on Windows.  This is the default on
+  # other platforms.  See the _ExtraClangFlags function in
+  # ycmd/completers/cpp/flags.py file for more information.
   common_args = {
     'completer_target'  : 'filetype_default',
     'command_arguments' : command,
     'compilation_flags' : ['-x',
                            'c++',
                            # C++11 flag is needed for lambda functions
-                           '-std=c++11'],
+                           '-std=c++11',
+                           '-fno-delayed-template-parsing'],
     'line_num'          : 10,
     'column_num'        : 3,
     'contents'          : contents,


### PR DESCRIPTION
This PR is a delicate one.

On Windows, templates are not parsed until instantation time which makes commands like GetType and GetParent not returning the expected value when the cursor is inside a template. To fix this, we add the flag `-fno-delayed-template-parsing` on Windows (this is the default on other platforms). We also add it to the `RunCompleterCommand_GetParent_Clang` tests to fix two tests on Windows.

However, there are some concerns about adding automatically this flag. From this comment (see this [issue](https://code.google.com/p/include-what-you-use/issues/detail?id=129))
> When IWYU runs on Windows it defaults to MSVC compatibility, to be able to parse Microsoft's STL  and Platform SDK headers. Turning off delayed template parsing will likely make it fail to parse these system headers, in turn making IWYU useless.

using this flag could cause some problems, though I was not able to find an example where ycmd is not working because of this flag.

A more conservative approach would be to only use this flag for the tests and add a note about it in the documentation.