### PR TITLE
Build ycm_core_tests target when running tests

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -54,6 +54,7 @@ def BuildYcmdLibs( args ):
       extra_cmake_args.append( '-DUSE_CLANG_COMPLETER=ON' )
 
     os.environ[ 'EXTRA_CMAKE_ARGS' ] = ' '.join(extra_cmake_args)
+    os.environ[ 'YCM_TESTRUN' ] = '1'
 
     build_cmd = [
       sys.executable,


### PR DESCRIPTION
Forgot this when converting the run_tests script to Python in commit ce6343f6525f0731d308efebf93cbb34de590cc1.