### PR TITLE
[Windows support] Fix Gmock tests

### DIFF
--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -142,9 +142,8 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
 
     std::string identifier( matches[ 1 ] );
     fs::path path( matches[ 2 ].str() );
-
-    if ( path.is_relative() )
-      path = path_to_tag_file.parent_path() / path;
+    path = fs::absolute( path, path_to_tag_file.parent_path() )
+      .make_preferred();
 
     filetype_identifier_map[ filetype ][ path.string() ].push_back( identifier );
   }

--- a/cpp/ycm/tests/IdentifierUtils_test.cpp
+++ b/cpp/ycm/tests/IdentifierUtils_test.cpp
@@ -32,6 +32,7 @@ using ::testing::WhenSorted;
 
 
 TEST( IdentifierUtilsTest, ExtractIdentifiersFromTagsFileWorks ) {
+  fs::path root = fs::current_path().root_path();
   fs::path testfile = PathToTestFile( "basic.tags" );
   fs::path testfile_parent = testfile.parent_path();
 
@@ -45,10 +46,10 @@ TEST( IdentifierUtilsTest, ExtractIdentifiersFromTagsFileWorks ) {
   expected[ "cpp" ][ ( testfile_parent / "bar" ).string() ]
   .push_back( "fooaaa" );
 
-  expected[ "c" ][ "/foo/zoo" ].push_back( "Floo::goo" );
-  expected[ "c" ][ "/foo/goo maa" ].push_back( "!goo" );
+  expected[ "c" ][ ( root / "foo" / "zoo" ).string() ].push_back( "Floo::goo" );
+  expected[ "c" ][ ( root / "foo" / "goo maa" ).string() ].push_back( "!goo" );
 
-  expected[ "cs" ][ "/m_oo" ].push_back( "#bleh" );
+  expected[ "cs" ][ ( root / "m_oo" ).string() ].push_back( "#bleh" );
 
   EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
                ContainerEq( expected ) );


### PR DESCRIPTION
The filesystem boost library will not consider a path like `/foo/zoo` as absolute on Windows. As a result, `path.is_relative()` will return true and the computed path will be wrong. To obtain the right path, we need to use the [fs::absolute](http://www.boost.org/doc/libs/1_46_0/libs/filesystem/v3/doc/reference.html#absolute) function.
The [make_preferred](http://www.boost.org/doc/libs/1_46_0/libs/filesystem/v3/doc/reference.html#path-make_preferred) method converts slashes to backslahes on Windows.

Fix IdentifierUtilsTest.ExtractIdentifiersFromTagsFileWorks test.