### PR TITLE
Support GetDoc subcommand for Clang completer

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -220,13 +220,38 @@ ClangCompleter::GetFixItsForLocationInFile(
   shared_ptr< TranslationUnit > unit =
     translation_unit_store_.GetOrCreate( filename, unsaved_files, flags );
 
-  if ( !unit )
+  if ( !unit ) {
     return std::vector< FixIt >();
+  }
 
   return unit->GetFixItsForLocationInFile( line,
                                            column,
                                            unsaved_files,
                                            reparse );
+
+}
+
+DocumentationData ClangCompleter::GetDocsForLocationInFile(
+  const std::string &filename,
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  const std::vector< std::string > &flags,
+  bool reparse) {
+
+  ReleaseGil unlock;
+
+  shared_ptr< TranslationUnit > unit =
+    translation_unit_store_.GetOrCreate( filename, unsaved_files, flags );
+
+  if ( !unit ) {
+    return DocumentationData();
+  }
+
+  return unit->GetDocsForLocationInFile( line,
+                                         column,
+                                         unsaved_files,
+                                         reparse );
 
 }
 

--- a/cpp/ycm/ClangCompleter/ClangCompleter.h
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.h
@@ -21,6 +21,7 @@
 #include "UnsavedFile.h"
 #include "Diagnostic.h"
 #include "TranslationUnitStore.h"
+#include "Documentation.h"
 
 #include <boost/utility.hpp>
 
@@ -90,6 +91,14 @@ public:
     bool reparse = true );
 
   std::vector< FixIt > GetFixItsForLocationInFile(
+    const std::string &filename,
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    const std::vector< std::string > &flags,
+    bool reparse = true);
+
+  DocumentationData GetDocsForLocationInFile(
     const std::string &filename,
     int line,
     int column,

--- a/cpp/ycm/ClangCompleter/Documentation.cpp
+++ b/cpp/ycm/ClangCompleter/Documentation.cpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 YouCompleteMe Contributors
+//
+// This file is part of YouCompleteMe.
+//
+// YouCompleteMe is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// YouCompleteMe is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Documentation.h"
+#include "ClangHelpers.h"
+
+#include <clang-c/Documentation.h>
+
+namespace YouCompleteMe {
+
+namespace {
+
+bool CXCommentValid( const CXComment & comment ) {
+  return clang_Comment_getKind( comment ) != CXComment_Null;
+}
+
+}
+
+DocumentationData::DocumentationData( const CXCursor& cursor )
+  : raw_comment( CXStringToString( clang_Cursor_getRawCommentText( cursor ) ) )
+  , brief_comment( CXStringToString(
+                                 clang_Cursor_getBriefCommentText( cursor ) ) )
+  , canonical_type( CXStringToString(
+                    clang_getTypeSpelling( clang_getCursorType( cursor ) ) ) )
+  , display_name( CXStringToString( clang_getCursorSpelling( cursor ) ) ) {
+
+
+  CXComment parsed_comment = clang_Cursor_getParsedComment( cursor );
+  if ( CXCommentValid( parsed_comment ) ) {
+    comment_xml = CXStringToString(
+                                clang_FullComment_getAsXML( parsed_comment ) );
+  }
+}
+
+} // namespace YouCompleteMe

--- a/cpp/ycm/ClangCompleter/Documentation.h
+++ b/cpp/ycm/ClangCompleter/Documentation.h
@@ -1,0 +1,54 @@
+// Copyright (C) 2015 YouCompleteMe Contributors
+//
+// This file is part of YouCompleteMe.
+//
+// YouCompleteMe is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// YouCompleteMe is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef DOCUMENTATION_H_POYSHVX8
+#define DOCUMENTATION_H_POYSHVX8
+
+#include <clang-c/Index.h>
+#include <string>
+
+
+namespace YouCompleteMe {
+
+/// This class holds information useful for generating a documentation response
+/// for a given cursor
+struct DocumentationData {
+  /// Construct an empty object
+  DocumentationData() {}
+
+  /// Construct and extract information from the supplied cursor. The cursor
+  /// should be pointing to a canonical declaration, such as returned by
+  /// clang_getCanonicalCursor( clang_getCursorReferenced( cursor ) )
+  DocumentationData( const CXCursor &cursor );
+
+  /// XML data as parsed by libclang. This provides full semantic parsing of
+  /// doxygen-syntax comments.
+  std::string comment_xml;
+
+  /// The raw text of the comment preceding the declaration
+  std::string raw_comment;
+  /// The brief comment (either first paragraph or \brief) as parsed by libclang
+  std::string brief_comment;
+  /// The canonical type of the referenced cursor
+  std::string canonical_type;
+  /// The display name of the referenced cursor
+  std::string display_name;
+};
+
+} // namespace YouCompleteMe
+
+#endif /* end of include guard: DOCUMENTATION_H_POYSHVX8 */

--- a/cpp/ycm/ClangCompleter/TranslationUnit.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.h
@@ -21,6 +21,7 @@
 #include "UnsavedFile.h"
 #include "Diagnostic.h"
 #include "Location.h"
+#include "Documentation.h"
 
 #include <clang-c/Index.h>
 #include <boost/utility.hpp>
@@ -91,6 +92,12 @@ public:
     bool reparse = true );
 
   std::vector< FixIt > GetFixItsForLocationInFile(
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    bool reparse = true );
+
+  DocumentationData GetDocsForLocationInFile(
     int line,
     int column,
     const std::vector< UnsavedFile > &unsaved_files,

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -28,6 +28,7 @@
 #  include "Range.h"
 #  include "UnsavedFile.h"
 #  include "CompilationDatabase.h"
+#  include "Documentation.h"
 #endif // USE_CLANG_COMPLETER
 
 #include <boost/python.hpp>
@@ -102,7 +103,9 @@ BOOST_PYTHON_MODULE(ycm_core)
     .def( "GetEnclosingFunctionAtLocation",
           &ClangCompleter::GetEnclosingFunctionAtLocation )
     .def( "GetFixItsForLocationInFile",
-          &ClangCompleter::GetFixItsForLocationInFile );
+          &ClangCompleter::GetFixItsForLocationInFile )
+    .def( "GetDocsForLocationInFile",
+          &ClangCompleter::GetDocsForLocationInFile );
 
   enum_< CompletionKind >( "CompletionKind" )
     .value( "STRUCT", STRUCT )
@@ -175,6 +178,13 @@ BOOST_PYTHON_MODULE(ycm_core)
 
   class_< std::vector< Diagnostic > >( "DiagnosticVector" )
     .def( vector_indexing_suite< std::vector< Diagnostic > >() );
+
+  class_< DocumentationData >( "DocumentationData" )
+    .def_readonly( "comment_xml", &DocumentationData::comment_xml )
+    .def_readonly( "raw_comment", &DocumentationData::raw_comment )
+    .def_readonly( "brief_comment", &DocumentationData::brief_comment )
+    .def_readonly( "canonical_type", &DocumentationData::canonical_type )
+    .def_readonly( "display_name", &DocumentationData::display_name );
 
   class_< CompilationDatabase, boost::noncopyable >(
       "CompilationDatabase", init< std::string >() )

--- a/ycmd/completers/cpp/tests/comment_strip.py
+++ b/ycmd/completers/cpp/tests/comment_strip.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2015  YouCompleteMe contributors
+#
+# This file is part of YouCompleteMe.
+#
+# YouCompleteMe is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# YouCompleteMe is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This tests the comment "sanitisation" which is done on C/C++/ObjC
+method/variable,etc. headers in order to remove non-data-ink from the raw
+comment"""
+
+from nose.tools import eq_
+import os
+from .. import clang_completer
+
+
+def _Check_FormatRawComment( comment, expected ):
+  try:
+    result = clang_completer._FormatRawComment( comment )
+    eq_( result, expected )
+  except:
+    print ( "Failed while parsing:"
+            + os.linesep
+            + "'" + comment + "'"
+            + os.linesep
+            + "Expecting:"
+            + os.linesep
+            + "'" + expected + "'"
+            + os.linesep
+            + "But found: "
+            + os.linesep
+            + "'" + result + "'" )
+    raise
+
+
+def ClangCompleter_FormatRawComment_SingleLine_Doxygen_test():
+  # - <whitespace>///
+
+  # Indent + /// +
+  _Check_FormatRawComment( '    /// Single line comment',
+                           'Single line comment' )
+
+  # No indent, Internal indent removed, trailing whitespace removed
+  _Check_FormatRawComment( '///      Single line comment    ',
+                           'Single line comment' )
+
+  # Extra / prevents initial indent being removed
+  _Check_FormatRawComment( '////      Single line comment    ',
+                           '/      Single line comment' )
+  _Check_FormatRawComment( '////* Test	', '/* Test' )
+
+
+def ClangCompleter_FormatRawComment_SingleLine_InlineDoxygen_test():
+  # Inline-style comments with and without leading/trailing tokens
+  # - <whitespace>///<
+  _Check_FormatRawComment( '///<Test', 'Test' )
+  _Check_FormatRawComment( '  ///<Test */', 'Test' )
+  _Check_FormatRawComment( '///<Test  ', 'Test' )
+  _Check_FormatRawComment( '///< Test  ', 'Test' )
+  _Check_FormatRawComment( ' ///<< Test  ', '< Test' )
+  _Check_FormatRawComment( ' ///<! Test  ', '! Test' )
+
+
+def ClangCompleter_FormatRawComment_SingleLine_InlineShort_test():
+  # - <whitespace>//<
+  _Check_FormatRawComment( '//<Test', 'Test' )
+  _Check_FormatRawComment( '	//<Test', 'Test' )
+  _Check_FormatRawComment( '//<Test', 'Test' )
+  _Check_FormatRawComment( '//< Test', 'Test' )
+  _Check_FormatRawComment( '//<< Test  ', '< Test' )
+
+
+def ClangCompleter_FormatRawComment_SingleLine_InlineShortBang_test():
+  # - <whitespace>//!
+  _Check_FormatRawComment( '//!Test', 'Test' )
+  _Check_FormatRawComment( '	//<Test */	', 'Test' )
+  _Check_FormatRawComment( '//!Test  ', 'Test' )
+  _Check_FormatRawComment( '//! Test	', 'Test' )
+  _Check_FormatRawComment( '//!! Test  ', '! Test' )
+
+
+def ClangCompleter_FormatRawComment_SingleLine_JavaDoc_test():
+  # - <whitespace>/*
+  # - <whitespace>/**
+  # - <whitespace>*/
+  _Check_FormatRawComment( '/*Test', 'Test' )
+  _Check_FormatRawComment( '	/** Test */    ', 'Test' )
+  _Check_FormatRawComment( '/*** Test', '* Test' )
+
+
+def ClangCompleter_FormatRawComment_MultiOneLine_JavaDoc_test():
+  # sic: This one isn't ideal, but it is (probably) uncommon
+  _Check_FormatRawComment( '/** Test */ /** Test2 */',
+                           'Test */ /** Test2' )
+
+
+def ClangCompleter_FormatRawComment_MultiLine_Doxygen_Inbalance_test():
+  # The dedenting only applies to consistent indent
+  # Note trailing whitespace is intentional
+  _Check_FormatRawComment( 
+  """
+      /// This is
+      ///    a
+      ///Multi-line
+    /// Comment	
+/// 	 With many different */ 	
+      ///< Doxygen-like    
+      ///!   comment   ****/ Entries
+      
+  """,
+  """
+ This is
+    a
+Multi-line
+ Comment
+ 	 With many different
+ Doxygen-like
+   comment   ****/ Entries
+
+""" )
+
+def ClangCompleter_FormatRawComment_MultiLine_JavaDoc_Inconsistent_test():
+  # The dedenting only applies to consistent indent, and leaves any subsequent
+  # indent intact
+  # Note trailing whitespace is intentional
+  _Check_FormatRawComment( 
+  """
+      /**  All of the 
+    *  Lines in this	
+  	Comment consistently
+           *  * Have a 2-space indent */  
+  """,
+  """
+All of the
+Lines in this
+	Comment consistently
+* Have a 2-space indent
+""" )
+
+
+def ClangCompleter_FormatRawComment_ZeroLine_test():
+  _Check_FormatRawComment( '', '' )
+
+
+def ClangCompleter_FormatRawComment_MultiLine_empty_test():
+  # Note trailing whitespace is intentional
+  _Check_FormatRawComment( 
+  """
+	
+
+  *
+///   
+  */
+  """,
+  """
+
+
+
+
+
+""" )

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -73,11 +73,17 @@ def BuildDescriptionOnlyGoToResponse( text ):
   }
 
 
-# TODO: Look at all the callers and ensure they are not using this instead of an
-# exception.
 def BuildDisplayMessageResponse( text ):
   return {
     'message': text
+  }
+
+
+def BuildDetailedInfoResponse( text ):
+  """ Retuns the response object for displaying detailed information about types
+  and usage, suach as within a preview window"""
+  return {
+    'detailed_info': text
   }
 
 

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -23,7 +23,8 @@ SetUpPythonPath()
 import httplib
 from .test_utils import ( Setup, BuildRequest, PathToTestFile,
                           ChangeSpecificOptions, StopOmniSharpServer,
-                          WaitUntilOmniSharpServerReady, StopGoCodeServer )
+                          WaitUntilOmniSharpServerReady, StopGoCodeServer,
+                          ErrorMatcher )
 from webtest import TestApp, AppError
 from nose.tools import eq_, with_setup
 from hamcrest import ( assert_that, has_item, has_items, has_entry, has_entries,
@@ -49,14 +50,8 @@ def CompletionLocationMatcher( location_type, value ):
                     has_entry( 'location',
                                has_entry( location_type, value ) ) )
 
-
-def ErrorMatcher( cls, msg ):
-  return has_entries( {
-    'exception' : has_entry( 'TYPE', cls.__name__ ),
-    'message': msg,
-  } )
-
 NO_COMPLETIONS_ERROR = ErrorMatcher( RuntimeError, NO_COMPLETIONS_MESSAGE )
+
 
 @with_setup( Setup )
 def GetCompletions_RunTest( test ):

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -22,6 +22,7 @@ import time
 from .. import handlers
 from ycmd import user_options_store
 from ycmd.utils import OnTravis
+from hamcrest import has_entries, has_entry
 
 
 def BuildRequest( **kwargs ):
@@ -106,3 +107,11 @@ def StopGoCodeServer( app ):
                  BuildRequest( completer_target = 'filetype_default',
                                command_arguments = ['StopServer'],
                                filetype = 'go' ) )
+
+
+def ErrorMatcher( cls, msg ):
+  """ Returns a hamcrest matcher for a server exception response """
+  return has_entries( {
+    'exception' : has_entry( 'TYPE', cls.__name__ ),
+    'message': msg,
+  } )

--- a/ycmd/tests/testdata/.ycm_extra_conf.py
+++ b/ycmd/tests/testdata/.ycm_extra_conf.py
@@ -1,5 +1,5 @@
 def FlagsForFile( filename ):
   return {
-    'flags': ['-x', 'c++'],
+    'flags': ['-x', 'c++', '-I', '.'],
     'do_cache': True
   }

--- a/ycmd/tests/testdata/GetDoc_Clang.cc
+++ b/ycmd/tests/testdata/GetDoc_Clang.cc
@@ -1,0 +1,87 @@
+#include "GetDoc_Clang.h"
+
+/// This is a test namespace
+namespace Test {
+
+    /// This is a global variable, that isn't really all that global.
+    int a_global_variable;
+
+    /// This is a method which is only pretend global
+    /// @param test Set this to true. Do it.
+    int get_a_global_variable( bool test );
+
+    char postfix_comment(); ///< Method postfix
+
+    /**
+     * This is not the brief.
+     *
+     * \brief brevity is for suckers
+     *
+     * This is more information
+     */
+    char with_brief();
+
+    /** The
+* indentation
+                    * of this comment
+            * is
+    * all messed up. */
+    int messed_up();
+}
+
+/// This really is a global variable.
+///
+/// The first line of comment is the brief.
+char a_global_variable;
+
+/** JavaDoc-style */
+bool javadoc_style;
+
+//! Qt-style
+bool qt_style;
+
+/// This method has lots of lines of text in its comment.
+///
+/// That's important because the preview window
+///
+/// Has
+///
+/// Limited Space.
+char get_a_global_variable( );
+
+bool postfix_comment; ///< The brief follows the declaration.
+
+typedef TestClass AnotherClass;
+
+// Double slash is not considered attached to declaration
+bool double_slash;
+
+/* slash asterisk is also not considered attached to declaration */
+bool slash_asterisk;
+
+/** Main */
+int main() {
+    char c = get_a_global_variable( );
+    int i = Test::get_a_global_variable( true );
+
+    typedef int(*FUNCTION_POINTER)( bool );
+    FUNCTION_POINTER fp = &Test::get_a_global_variable;
+
+    bool b = c == a_global_variable &&
+             i == Test::a_global_variable &&
+             javadoc_style &&
+             qt_style &&
+             postfix_comment &&
+             double_slash &&
+             slash_asterisk;
+
+    TestClass tc;
+    const AnotherClass& ac = tc;
+    tc.a_public_method( tc.a_public_var );
+    tc.an_undocumented_method();
+
+    Test::postfix_comment();
+    Test::messed_up();
+
+    return b ? 0 : 1;
+}

--- a/ycmd/tests/testdata/GetDoc_Clang.h
+++ b/ycmd/tests/testdata/GetDoc_Clang.h
@@ -1,0 +1,29 @@
+///
+/// A TestClass is a sort of class for testing.
+///
+/// TODO: BenJ 2010-09-21 Perhaps we should consider renaming this, as it is the
+/// core of our application?
+///
+class TestClass
+{
+public:
+    int a_public_var; /** don't touch this directly, use a_public_method */
+
+    /**
+     * Constructs a test class. Note gap to TestClass()
+     */
+
+    TestClass();
+
+    /**
+     * Call a_public_method when you want to do something exciting.
+     *
+     * @param excitement_level The level between 100 and 8 of required
+     * excitement. The unit is puppy bounce height.
+     *
+     * @return whether or not the required excitement level was entered.
+     */
+    bool a_public_method( int excitement_level );
+
+    void an_undocumented_method();
+};


### PR DESCRIPTION
References 
====

Feature request: https://github.com/Valloric/YouCompleteMe/issues/1653
YCM change: https://github.com/Valloric/YouCompleteMe/pull/1694

Overview
====

The GetDoc subcommand returns detailed information (sometimes known as
QuickInfo) for the identifier at a particular location.

For C-family languages, we display:

```
  <declaration of the identifier>
  <brief>
  Type: <canonical type>
  Name: <display name>
  ---
  <Detailed information from the doxygen comment>
```

Technical Information 
===

Clang actually has very rich support for parsing of doxygen comments. However,
this API is not strictly part of the "libclang" API - it is technically a
separate module. The core libclang module does include methods to get the raw
comment string (as typed in the buffer) and the "brief" as parsed by the full
documentation parser.

Annoyingly, we have to get a fully parsed XML document out of the non-core API
just to extract the declaration. There does not appear to be any other way to
get this out of libclang.

Regarding the detailed information, we actually use the raw comment text, rather
than the parsed infomation from the XML. This is because we don't want to write
a lot of complex code, and we also don't want to lose any actual data from the
comment. However, we do want to remove distracting indentation and comment
markets. We jsut use some basic regular expressions and python's textwrap to
remove the general syntax markers used on comments.

API Changes
====

Completer subcommands can now return 'detailed info' using `ycmd.responses.BuildDetailedInfoResponse`, as follows:

```
{
   detailed_info: <multi-line string, with OS-specific line endings>
}
```