### PR TITLE
[Windows support] Add Clang downloads for Windows

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -51,6 +51,17 @@ if ( USE_CLANG_COMPLETER AND
     set( CLANG_SHA256
          "057e56b445ac5dfbf0d5475badab374edebe8db5428001c8829340e40724b50d" )
     set( CLANG_FILENAME "${CLANG_DIRNAME}.tar.xz" )
+  elseif ( WIN32 )
+    if( 64_BIT_PLATFORM )
+      set( CLANG_DIRNAME "LLVM-${CLANG_VERSION}-win64" )
+      set( CLANG_SHA256
+           "04a393cf73bc7416c9903aa08f47f15c77cf475b22a607ac4b7493a658a11a3f" )
+    else()
+      set( CLANG_DIRNAME "LLVM-${CLANG_VERSION}-win32" )
+      set( CLANG_SHA256
+           "75933480c8f8e3ae3cf9281494bf0057e9e4cfae4315f59c468a4e850a86f544" )
+    endif()
+    set( CLANG_FILENAME "${CLANG_DIRNAME}.exe" )
   else()
     if ( 64_BIT_PLATFORM )
       # We MUST support the latest Ubuntu LTS release!
@@ -103,16 +114,31 @@ if ( USE_CLANG_COMPLETER AND
     execute_process( COMMAND tar -xjf ${CLANG_FILENAME} )
   elseif( CLANG_FILENAME MATCHES ".+xz" )
     execute_process( COMMAND tar -xJf ${CLANG_FILENAME} )
+  elseif( CLANG_FILENAME MATCHES ".+exe" )
+    # Find 7-zip executable in the PATH and using the registry
+    find_program( 7Z_EXECUTABLE 7z PATHS
+      [HKEY_LOCAL_MACHINE\\SOFTWARE\\7-Zip;Path] )
+    if ( NOT 7Z_EXECUTABLE )
+      message( FATAL_ERROR
+        "7-zip is needed to extract the files from the Clang installer. "
+        "Install it and try again." )
+    endif()
+    execute_process( COMMAND ${7Z_EXECUTABLE} x ${CLANG_FILENAME} OUTPUT_QUIET )
   else()
     execute_process( COMMAND tar -xzf ${CLANG_FILENAME} )
   endif()
 
   # We need to set PATH_TO_LLVM_ROOT. To do that, we first have to find the
   # folder name the archive produced. It isn't the archive base name.
-  execute_process( COMMAND
-    find ${CMAKE_CURRENT_BINARY_DIR}/.. -maxdepth 1 -type d -name clang*
-    OUTPUT_VARIABLE PATH_TO_LLVM_ROOT
-    OUTPUT_STRIP_TRAILING_WHITESPACE )
+  # On Windows, the find command is not available so we directly set the path.
+  if ( WIN32 )
+    set( PATH_TO_LLVM_ROOT ${CMAKE_CURRENT_BINARY_DIR}/../$_OUTDIR )
+  else()
+    execute_process( COMMAND
+      find ${CMAKE_CURRENT_BINARY_DIR}/.. -maxdepth 1 -type d -name clang*
+      OUTPUT_VARIABLE PATH_TO_LLVM_ROOT
+      OUTPUT_STRIP_TRAILING_WHITESPACE )
+  endif()
 endif()
 
 if ( PATH_TO_LLVM_ROOT OR USE_SYSTEM_LIBCLANG OR EXTERNAL_LIBCLANG_PATH )


### PR DESCRIPTION
`7-zip` is the best way I found to obtain the files from the Clang installer without installing it.