### PR TITLE
Add GetDoc support to Python completer

### DIFF
--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -85,7 +85,8 @@ class JediCompleter( Completer ):
   def DefinedSubcommands( self ):
     return [ 'GoToDefinition',
              'GoToDeclaration',
-             'GoTo' ]
+             'GoTo',
+             'GetDoc' ]
 
 
   def OnUserCommand( self, arguments, request_data ):
@@ -99,6 +100,8 @@ class JediCompleter( Completer ):
       return self._GoToDeclaration( request_data )
     elif command == 'GoTo':
       return self._GoTo( request_data )
+    elif command == 'GetDoc':
+      return self._GetDoc( request_data )
     raise ValueError( self.UserCommandsHelpMessage() )
 
 
@@ -125,6 +128,14 @@ class JediCompleter( Completer ):
       return self._BuildGoToResponse( definitions )
     else:
       raise RuntimeError( 'Can\'t jump to definition or declaration.' )
+
+
+  def _GetDoc( self, request_data ):
+    definitions = self._GetDefinitionsList( request_data )
+    if definitions:
+      return self._BuildDetailedInfoResponse( definitions )
+    else:
+      raise RuntimeError( 'Can\'t find a definition.' )
 
 
   def _GetDefinitionsList( self, request_data, declaration = False ):
@@ -169,4 +180,8 @@ class JediCompleter( Completer ):
                                          definition.column + 1,
                                          definition.description ) )
       return defs
+
+  def _BuildDetailedInfoResponse( self, definition_list ):
+    docs = [ definition.docstring() for definition in definition_list ]
+    return responses.BuildDetailedInfoResponse( '\n---\n'.join( docs ) )
 

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -87,6 +87,7 @@ def RunCompleterCommand_GoTo_Clang_ZeroBasedLineAndColumn_test():
       },
       app.post_json( '/run_completer_command', goto_data ).json )
 
+
 def _RunCompleterCommand_GoTo_all_Clang(filename, command, test):
   contents = open( PathToTestFile( filename ) ).read()
   app = TestApp( handlers.app )
@@ -119,6 +120,7 @@ def _RunCompleterCommand_GoTo_all_Clang(filename, command, test):
 
   eq_( response,
        app.post_json( '/run_completer_command', goto_data ).json )
+
 
 @with_setup( Setup )
 def RunCompleterCommand_GoTo_all_Clang_test():
@@ -221,6 +223,7 @@ def RunCompleterCommand_GoTo_all_Clang_test():
           'GoTo_all_Clang_test.cc',            \
           ['GoToImprecise'],                   \
           test
+
 
 def _RunCompleterCommand_Message_Clang(filename, test, command):
   contents = open( PathToTestFile( filename ) ).read()
@@ -334,6 +337,7 @@ def RunCompleterCommand_GetType_Clang_test():
           test,                               \
           ['GetType']
 
+
 @with_setup( Setup )
 def RunCompleterCommand_GetParent_Clang_test():
   tests = [
@@ -415,6 +419,7 @@ def _RunFixItTest_Clang( line, column, lang, file_name, check ):
   pprint( results )
   check( results )
 
+
 def _FixIt_Check_cpp11_Ins( results ):
   # First fixit
   #   switch(A()) { // expected-error{{explicit conversion to}}
@@ -439,6 +444,7 @@ def _FixIt_Check_cpp11_Ins( results ):
       'location' : has_entries( { 'line_num': 16, 'column_num': 3 } )
     } ) )
   } ) )
+
 
 def _FixIt_Check_cpp11_InsMultiLine( results ):
   # Similar to _FixIt_Check_cpp11_1 but inserts split across lines
@@ -465,6 +471,7 @@ def _FixIt_Check_cpp11_InsMultiLine( results ):
     } ) )
   } ) )
 
+
 def _FixIt_Check_cpp11_Del( results ):
   # Removal of ::
   assert_that( results, has_entries( {
@@ -482,6 +489,7 @@ def _FixIt_Check_cpp11_Del( results ):
     } ) )
   } ) )
 
+
 def _FixIt_Check_cpp11_Repl( results ):
   assert_that( results, has_entries( {
     'fixits': contains( has_entries ( {
@@ -497,6 +505,7 @@ def _FixIt_Check_cpp11_Repl( results ):
       'location' : has_entries( { 'line_num': 40, 'column_num': 6 } )
     } ) )
   } ) )
+
 
 def _FixIt_Check_cpp11_DelAdd( results ):
   assert_that( results, has_entries( {
@@ -521,6 +530,7 @@ def _FixIt_Check_cpp11_DelAdd( results ):
     } ) )
   } ) )
 
+
 def _FixIt_Check_objc( results ):
   assert_that( results, has_entries( {
     'fixits': contains( has_entries ( {
@@ -537,9 +547,11 @@ def _FixIt_Check_objc( results ):
     } ) )
   } ) )
 
+
 def _FixIt_Check_objc_NoFixIt( results ):
   # and finally, a warning with no fixits
   assert_that( results, equal_to( { 'fixits' : [] } ) )
+
 
 def _FixIt_Check_cpp11_MultiFirst( results ):
   assert_that( results, has_entries( {
@@ -580,6 +592,7 @@ def _FixIt_Check_cpp11_MultiFirst( results ):
     )
   } ) )
 
+
 def _FixIt_Check_cpp11_MultiSecond( results ):
   assert_that( results, has_entries( {
     'fixits': contains(
@@ -619,6 +632,7 @@ def _FixIt_Check_cpp11_MultiSecond( results ):
     )
   } ) )
 
+
 @with_setup( Setup )
 def RunCompleterCommand_FixIt_all_Clang_test():
   cfile = 'FixIt_Clang_cpp11.cpp'
@@ -652,6 +666,7 @@ def RunCompleterCommand_FixIt_all_Clang_test():
 
   for test in tests:
     yield _RunFixItTest_Clang, test[0], test[1], test[2], test[3], test[4]
+
 
 @with_setup( Setup )
 def RunCompleterCommand_GoTo_CsCompleter_Works_test():
@@ -1269,7 +1284,8 @@ def DefinedSubcommands_Works_test():
 
   eq_( [ 'GoToDefinition',
          'GoToDeclaration',
-         'GoTo' ],
+         'GoTo',
+         'GetDoc' ],
        app.post_json( '/defined_subcommands', subcommands_data ).json )
 
 
@@ -1280,7 +1296,8 @@ def DefinedSubcommands_WorksWhenNoExplicitCompleterTargetSpecified_test():
 
   eq_( [ 'GoToDefinition',
          'GoToDeclaration',
-         'GoTo' ],
+         'GoTo',
+         'GetDoc' ],
        app.post_json( '/defined_subcommands', subcommands_data ).json )
 
 
@@ -1700,3 +1717,52 @@ Name: get_a_global_variable
 ---
 This is a method which is only pretend global
 @param test Set this to true. Do it.""" } )
+
+
+@with_setup( Setup )
+def RunCompleterCommand_GetDoc_Jedi_Works_Method_test():
+  # Testcase1
+  app = TestApp( handlers.app )
+
+  filepath = PathToTestFile( 'GetDoc_Jedi.py' )
+  contents = open( filepath ).read()
+
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'python',
+                             line_num = 17,
+                             column_num = 9,
+                             contents = contents,
+                             command_arguments = [ 'GetDoc' ],
+                             completer_target = 'filetype_default' )
+
+  response = app.post_json( '/run_completer_command', event_data ).json
+
+  eq_( response, {
+       'detailed_info': '_ModuleMethod()\n\n'
+                        'Module method docs\n'
+                        'Are dedented, like you might expect',
+  } )
+
+
+@with_setup( Setup )
+def RunCompleterCommand_GetDoc_Jedi_Works_Class_test():
+  # Testcase1
+  app = TestApp( handlers.app )
+
+  filepath = PathToTestFile( 'GetDoc_Jedi.py' )
+  contents = open( filepath ).read()
+
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'python',
+                             line_num = 19,
+                             column_num = 2,
+                             contents = contents,
+                             command_arguments = [ 'GetDoc' ],
+                             completer_target = 'filetype_default' )
+
+  response = app.post_json( '/run_completer_command', event_data ).json
+
+  eq_( response, {
+       'detailed_info': 'Class Documentation',
+  } )
+

--- a/ycmd/tests/testdata/GetDoc_Jedi.py
+++ b/ycmd/tests/testdata/GetDoc_Jedi.py
@@ -1,0 +1,20 @@
+
+class TestClass:
+  """ Class Documentation"""
+
+
+  def TestMethod(self):
+    """ Method Documentation """
+    return self.member_variable
+
+
+def _ModuleMethod():
+  """ Module method docs
+      Are dedented, like you might expect"""
+  pass
+
+
+_ModuleMethod()
+
+tc = TestClass()
+tc.TestMethod()


### PR DESCRIPTION
    This builds on the Clang completer support and returns the docstring from any
    associated declarations for the context.

References: : 
* https://github.com/Valloric/YouCompleteMe/issues/1653
* https://github.com/Valloric/YouCompleteMe/pull/1694
* https://github.com/Valloric/ycmd/pull/229