### PR TITLE
Add GetDoc subcommand to typescript completer

### DIFF
--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -1299,7 +1299,7 @@ def RunCompleterCommand_GetType_TypescriptCompleter_test():
   app.post_json( '/event_notification', event_data )
 
   gettype_data = BuildRequest( completer_target = 'filetype_default',
-                               command_arguments = ['GetType'],
+                               command_arguments = [ 'GetType' ],
                                line_num = 12,
                                column_num = 1,
                                contents = contents,
@@ -1326,7 +1326,7 @@ def RunCompleterCommand_GetType_HasNoType_TypescriptCompleter_test():
   app.post_json( '/event_notification', event_data )
 
   gettype_data = BuildRequest( completer_target = 'filetype_default',
-                               command_arguments = ['GetType'],
+                               command_arguments = [ 'GetType' ],
                                line_num = 2,
                                column_num = 1,
                                contents = contents,
@@ -1335,6 +1335,65 @@ def RunCompleterCommand_GetType_HasNoType_TypescriptCompleter_test():
 
   assert_that( calling( app.post_json ).with_args( '/run_completer_command', gettype_data ),
                raises( AppError, 'RuntimeError.*No content available' ) )
+
+
+@with_setup( Setup )
+def RunCompleterCommand_GetDoc_TypescriptCompleter_Works_Method_test():
+  app = TestApp( handlers.app )
+
+  filepath = PathToTestFile( 'test.ts' )
+  contents = open( filepath ).read()
+
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'typescript',
+                             contents = contents,
+                             event_name = 'BufferVisit' )
+
+  app.post_json( '/event_notification', event_data )
+
+  gettype_data = BuildRequest( completer_target = 'filetype_default',
+                               command_arguments = [ 'GetDoc' ],
+                               line_num = 29,
+                               column_num = 9,
+                               contents = contents,
+                               filetype = 'typescript',
+                               filepath = filepath )
+
+  eq_( {
+         'detailed_info': '(method) Bar.testMethod(): void\n\n'
+                          'Method documentation',
+       },
+       app.post_json( '/run_completer_command', gettype_data ).json )
+
+
+@with_setup( Setup )
+def RunCompleterCommand_GetDoc_TypescriptCompleter_Works_Class_test():
+  app = TestApp( handlers.app )
+
+  filepath = PathToTestFile( 'test.ts' )
+  contents = open( filepath ).read()
+
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'typescript',
+                             contents = contents,
+                             event_name = 'BufferVisit' )
+
+  app.post_json( '/event_notification', event_data )
+
+  gettype_data = BuildRequest( completer_target = 'filetype_default',
+                               command_arguments = [ 'GetDoc' ],
+                               line_num = 31,
+                               column_num = 2,
+                               contents = contents,
+                               filetype = 'typescript',
+                               filepath = filepath )
+
+  eq_( {
+         'detailed_info': 'class Bar\n\n'
+                          'Class documentation\n\n'
+                          'Multi-line',
+       },
+       app.post_json( '/run_completer_command', gettype_data ).json )
 
 
 @with_setup( Setup )

--- a/ycmd/tests/testdata/test.ts
+++ b/ycmd/tests/testdata/test.ts
@@ -12,4 +12,20 @@ var foo = new Foo();
 foo.m
 
 
+/**
+ * Class documentation
+ *
+ * Multi-line
+ */
+class Bar {
 
+  /**
+   * Method documentation
+   */
+  testMethod() {}
+}
+
+var bar = new Bar();
+bar.testMethod();
+
+Bar.apply()


### PR DESCRIPTION
    This builds on the Clang completer support for GetDoc subcommand, and just
    returns the docuemntation supplied by tsserver in the quickinfo response.

References: 
* https://github.com/Valloric/YouCompleteMe/issues/1653
* https://github.com/Valloric/YouCompleteMe/pull/1694
* https://github.com/Valloric/ycmd/pull/229