### PR TITLE
Fix missing comma in Clang completer subcommands

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -113,7 +113,7 @@ class ClangCompleter( Completer ):
              'ClearCompilationFlagCache',
              'GetType',
              'GetParent',
-             'FixIt'
+             'FixIt',
              'GetDoc',
              'GetDocQuick' ]
 


### PR DESCRIPTION
Fix subcommands completion and listing. `GetDoc` subcommand was not directly affected by this.