### PR TITLE
[Windows support] Do not use os.linesep

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -21,7 +21,6 @@ from collections import defaultdict
 import ycm_core
 import re
 import textwrap
-import os
 from ycmd import responses
 from ycmd import extra_conf_store
 from ycmd.utils import ToUtf8IfNeeded
@@ -450,11 +449,11 @@ STRIP_TRAILING_COMMENT = re.compile( '[ \t]*\*/[ \t]*$|[ \t]*$' )
 
 
 def _FormatRawComment( comment ):
-  """ Strips leading indentation and comment markers from the comment string """
+  """Strips leading indentation and comment markers from the comment string"""
   return textwrap.dedent(
-      os.linesep.join( [ re.sub( STRIP_TRAILING_COMMENT, '',
-                         re.sub( STRIP_LEADING_COMMENT, '', line ) )
-                                for line in comment.split( os.linesep ) ] ) )
+    '\n'.join( [ re.sub( STRIP_TRAILING_COMMENT, '',
+                 re.sub( STRIP_LEADING_COMMENT, '', line ) )
+                 for line in comment.splitlines() ] ) )
 
 
 def _BuildGetDocResponse( doc_data ):
@@ -479,10 +478,9 @@ def _BuildGetDocResponse( doc_data ):
   declaration = root.find( "Declaration" )
 
   return responses.BuildDetailedInfoResponse(
-        '{0}{5}{1}{5}Type: {2}{5}Name: {3}{5}---{5}{4}'.format(
-              declaration.text if declaration is not None else "",
-              doc_data.brief_comment,
-              doc_data.canonical_type,
-              doc_data.display_name,
-              _FormatRawComment( doc_data.raw_comment ),
-              os.linesep ) )
+    '{0}\n{1}\nType: {2}\nName: {3}\n---\n{4}'.format(
+      declaration.text if declaration is not None else "",
+      doc_data.brief_comment,
+      doc_data.canonical_type,
+      doc_data.display_name,
+      _FormatRawComment( doc_data.raw_comment ) ) )

--- a/ycmd/completers/cpp/tests/comment_strip_test.py
+++ b/ycmd/completers/cpp/tests/comment_strip_test.py
@@ -22,7 +22,6 @@ method/variable,etc. headers in order to remove non-data-ink from the raw
 comment"""
 
 from nose.tools import eq_
-import os
 from .. import clang_completer
 
 
@@ -31,17 +30,12 @@ def _Check_FormatRawComment( comment, expected ):
     result = clang_completer._FormatRawComment( comment )
     eq_( result, expected )
   except:
-    print ( "Failed while parsing:"
-            + os.linesep
-            + "'" + comment + "'"
-            + os.linesep
-            + "Expecting:"
-            + os.linesep
-            + "'" + expected + "'"
-            + os.linesep
-            + "But found: "
-            + os.linesep
-            + "'" + result + "'" )
+    print( "Failed while parsing:\n"
+           "'" + comment + "'\n"
+           "Expecting:\n"
+           "'" + expected + "'\n"
+           "But found:\n"
+           "'" + result + "'" )
     raise
 
 

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -1358,7 +1358,7 @@ def RunCompleterCommand_GetDoc_ClangCompleter_Variable_test():
   pprint( response )
 
   eq_( response, {
-        'detailed_info': """\
+    'detailed_info': """\
 char a_global_variable
 This really is a global variable.
 Type: char
@@ -1390,7 +1390,7 @@ def RunCompleterCommand_GetDoc_ClangCompleter_Method_test():
   pprint( response )
 
   eq_( response, {
-      'detailed_info': """\
+    'detailed_info': """\
 char with_brief()
 brevity is for suckers
 Type: char ()
@@ -1426,7 +1426,7 @@ def RunCompleterCommand_GetDoc_ClangCompleter_Namespace_test():
   pprint( response )
 
   eq_( response, {
-      'detailed_info': """\
+    'detailed_info': """\
 namespace Test {}
 This is a test namespace
 Type: 
@@ -1516,7 +1516,7 @@ def RunCompleterCommand_GetDocQuick_ClangCompleter_Variable_test():
   pprint( response )
 
   eq_( response, {
-        'detailed_info': """\
+    'detailed_info': """\
 char a_global_variable
 This really is a global variable.
 Type: char
@@ -1555,7 +1555,7 @@ def RunCompleterCommand_GetDocQuick_ClangCompleter_Method_test():
   pprint( response )
 
   eq_( response, {
-      'detailed_info': """\
+    'detailed_info': """\
 char with_brief()
 brevity is for suckers
 Type: char ()
@@ -1598,7 +1598,7 @@ def RunCompleterCommand_GetDocQuick_ClangCompleter_Namespace_test():
   pprint( response )
 
   eq_( response, {
-      'detailed_info': """\
+    'detailed_info': """\
 namespace Test {}
 This is a test namespace
 Type: 
@@ -1692,7 +1692,7 @@ def RunCompleterCommand_GetDocQuick_ClangCompleter_NoReadyToParse_test():
   response = app.post_json( '/run_completer_command', event_data ).json
 
   eq_( response, {
-      'detailed_info': """\
+    'detailed_info': """\
 int get_a_global_variable(bool test)
 This is a method which is only pretend global
 Type: int (bool)


### PR DESCRIPTION
Using `os.linesep` makes things complicated for no benefits:
 - Clang returns `\n` for newlines on Windows;
 - Python and editors should manage without issue `\n` on Windows;
 - there is a bug with `textwrap.dedent()` and `\r\n` newline;
 - tests are a pain to fix with platform-dependent newlines.

@puremourning Could you update your PRs (#232, #233, and #234) accordingly?