### PR TITLE
Set default MSVC version to 14

### DIFF
--- a/build.py
+++ b/build.py
@@ -128,7 +128,7 @@ def ParseArguments():
                        help = 'Use the system boost instead of bundled one. '
                        'NOT RECOMMENDED OR SUPPORTED!')
   parser.add_argument( '--msvc', type = int, choices = [ 11, 12, 14 ],
-                       default = 12, help = 'Choose the Microsoft Visual '
+                       default = 14, help = 'Choose the Microsoft Visual '
                        'Studio version (default: %(default)s).' )
   parser.add_argument( '--arch', type = int, choices = [ 32, 64 ],
                        help = 'Force architecture to 32 or 64 bits on '

--- a/run_tests.py
+++ b/run_tests.py
@@ -40,7 +40,7 @@ def ParseArguments():
                        help = 'Do not build ycmd before testing.' )
   parser.add_argument( '--msvc', type = int, choices = [ 11, 12, 14 ],
                        help = 'Choose the Microsoft Visual '
-                       'Studio version. (default: 12).' )
+                       'Studio version. (default: 14).' )
   parser.add_argument( '--arch', type = int, choices = [ 32, 64 ],
                        help = 'Force architecture to 32 or 64 bits on '
                        'Windows (default: python interpreter architecture).' )


### PR DESCRIPTION
Since this is the version that users will download and install if they don't already have it, it makes sense to set the default to MSVC 14. It will also simplify the Windows documentation (no need to tell the user to set the option `--msvc` to 14).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/239)
<!-- Reviewable:end -->
