### PR TITLE
Test on on OS X using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,42 @@
-language: python
-python:
-  - "2.6"
-  - "2.7"
+language: csharp
+os:
+  - linux
+  - osx
+sudo: false
+mono:
+  - beta
 before_install:
   - git submodule update --init --recursive
 install:
-  - pip install -r test_requirements.txt
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo add-apt-repository -y ppa:ermshiperete/monodevelop
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install monodevelop-current
-  - sudo apt-get -qq install g++-4.8
-  - npm install -g typescript
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-  - MONO_PREFIX=/opt/monodevelop
-  - export DYLD_LIBRARY_FALLBACK_PATH=$MONO_PREFIX/lib:$DYLD_LIBRARY_FALLBACK_PATH
-  - export LD_LIBRARY_PATH=$MONO_PREFIX/lib:$LD_LIBRARY_PATH
-  - export C_INCLUDE_PATH=$MONO_PREFIX/include:$C_INCLUDE_PATH
-  - export PKG_CONFIG_PATH=$MONO_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH
-  - export PATH=$MONO_PREFIX/bin:$PATH
-  # Travis can run out of RAM when compiling if don't prevent parallelization.
-  - export YCM_CORES=1
+  # source because it sets up env vars on some platforms
+  - source travis/travis_install.sh
 compiler:
   - gcc
-  - clang
 script: ./run_tests.py
 env:
-  - USE_CLANG_COMPLETER="true"
-  - USE_CLANG_COMPLETER="false"
+  global:
+    - MONO_THREADS_PER_CPU=2000
+    - MONO_MANAGED_WATCHER=disabled
+    # Travis can run out of RAM when compiling if we don't prevent parallelization.
+    - YCM_CORES=1
+  matrix:
+    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7
+    - USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.7
+    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6
+    - USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6
+addons:
+  apt:
+    sources:
+     - ubuntu-toolchain-r-test
+     - deadsnakes
+    packages:
+     - g++-4.8
+     - python2.6
+     - python2.6-dev
+     - python2.7
+     - python2.7-dev
+     - python-virtualenv
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.dnx/packages

--- a/build.py
+++ b/build.py
@@ -61,34 +61,68 @@ def CheckDeps():
     sys.exit( 'Please install CMake and retry.')
 
 
+# Shamelessly stolen from https://gist.github.com/edufelipe/1027906
+def _CheckOutput( *popen_args, **kwargs ):
+  """Run command with arguments and return its output as a byte string.
+  Backported from Python 2.7."""
+
+  process = subprocess.Popen( stdout=subprocess.PIPE, *popen_args, **kwargs )
+  output, unused_err = process.communicate()
+  retcode = process.poll()
+  if retcode:
+    command = kwargs.get( 'args' )
+    if command is None:
+      command = popen_args[ 0 ]
+    error = subprocess.CalledProcessError( retcode, command )
+    error.output = output
+    raise error
+  return output
+
+
 def CustomPythonCmakeArgs():
   # The CMake 'FindPythonLibs' Module does not work properly.
   # So we are forced to do its job for it.
 
-  python_prefix = subprocess.check_output( [
+  print( 'Searching for python libraries...' )
+
+  python_prefix = _CheckOutput( [
       'python-config',
       '--prefix'
   ] ).strip()
+
   if p.isfile( p.join( python_prefix, '/Python' ) ):
     python_library = p.join( python_prefix, '/Python' )
     python_include = p.join( python_prefix, '/Headers' )
+    print( 'Using OSX-style libs from {0}'.format( python_prefix ) )
   else:
-    which_python = subprocess.check_output( [
+    which_python = _CheckOutput( [
       'python',
       '-c',
-      'import sys;i=sys.version_info;print "python%d.%d" % (i[0], i[1])'
+      'import sys;i=sys.version_info;print( "python%d.%d" % (i[0], i[1]) )'
     ] ).strip()
     lib_python = '{0}/lib/lib{1}'.format( python_prefix, which_python ).strip()
+
+    print( 'Searching for python with prefix: {0} and lib {1}:'.format(
+      python_prefix, which_python ) )
 
     if p.isfile( '{0}.a'.format( lib_python ) ):
       python_library = '{0}.a'.format( lib_python )
     # This check is for CYGWIN
     elif p.isfile( '{0}.dll.a'.format( lib_python ) ):
       python_library = '{0}.dll.a'.format( lib_python )
-    else:
+    elif p.isfile( '{0}.dylib'.format( lib_python ) ):
       python_library = '{0}.dylib'.format( lib_python )
+    elif p.isfile( '/usr/lib/lib{0}.dylib'.format( which_python ) ):
+      # For no clear reason, python2.6 only exists in /usr/lib on OS X and
+      # not in the python prefix location
+      python_library = '/usr/lib/lib{0}.dylib'.format( which_python )
+    else:
+      sys.exit( 'ERROR: Unable to find an appropriate python library' )
+
     python_include = '{0}/include/{1}'.format( python_prefix, which_python )
 
+  print( 'Using PYTHON_LIBRARY={0} PYTHON_INCLUDE_DIR={1}'.format(
+      python_library, python_include ) )
   return [
     '-DPYTHON_LIBRARY={0}'.format( python_library ),
     '-DPYTHON_INCLUDE_DIR={0}'.format( python_include )
@@ -208,7 +242,7 @@ def BuildOmniSharp():
     sys.exit( 'msbuild or xbuild is required to build Omnisharp' )
 
   os.chdir( p.join( DIR_OF_THIS_SCRIPT, 'third_party', 'OmniSharpServer' ) )
-  subprocess.check_call( [ build_command, "/property:Configuration=Release" ] )
+  subprocess.check_call( [ build_command, '/property:Configuration=Release' ] )
 
 
 def BuildGoCode():
@@ -228,5 +262,5 @@ def Main():
   if args.gocode_completer:
     BuildGoCode()
 
-if __name__ == "__main__":
+if __name__ == '__main__':
   Main()

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,4 +3,4 @@ mock>=1.0.1
 nose>=1.3.0
 PyHamcrest>=1.8.0
 WebTest>=2.0.9
-
+ordereddict>=1.1

--- a/travis/README.md
+++ b/travis/README.md
@@ -1,0 +1,5 @@
+Travis Scripts
+====
+
+This directory contains scripts used for testing `ycmd` using Travis CI. They
+should not normally be run by users.

--- a/travis/travis_install.linux.sh
+++ b/travis/travis_install.linux.sh
@@ -1,0 +1,14 @@
+# Linux-specific installation
+
+# We can't use sudo, so we have to approximate the behaviour of the following:
+# $ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+
+mkdir ${HOME}/bin
+
+ln -s /usr/bin/g++-4.8 ${HOME}/bin/g++
+ln -s /usr/bin/gcc-4.8 ${HOME}/bin/gcc
+ln -s ${HOME}/bin/g++ ${HOME}/bin/c++
+
+export PATH=${HOME}/bin:${PATH}
+
+virtualenv -p python${YCMD_PYTHON_VERSION} ${YCMD_VENV_DIR}

--- a/travis/travis_install.osx.sh
+++ b/travis/travis_install.osx.sh
@@ -1,0 +1,25 @@
+# OS X-specific installation
+
+# There's a homebrew bug which causes brew update to fail the first time. Run
+# it twice to workaround. https://github.com/Homebrew/homebrew/issues/42553
+brew update || brew update
+brew install node.js || brew outdated node.js || brew upgrade node.js
+brew install go || brew outdated go || brew upgrade go
+
+# OS X comes with 2 versions of python by default, and a neat system
+# (versioner) to switch between them:
+#   /usr/bin/python2.7 - python 2.7
+#   /usr/bin/python2.6 - python 2.6
+#
+# We just set the system default to match it
+# http://stackoverflow.com/q/6998545
+defaults write com.apple.versioner.python Version ${YCMD_PYTHON_VERSION}
+
+# virtualenv is not installed by default on OS X under python2.6, and we don't
+# have sudo, so we install it manually. There is no "latest" link, so we have
+# to install a specific version.
+VENV_VERSION=13.1.2
+
+curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${VENV_VERSION}.tar.gz
+tar xvfz virtualenv-${VENV_VERSION}.tar.gz
+python virtualenv-${VENV_VERSION}/virtualenv.py -p python${YCMD_PYTHON_VERSION} ${YCMD_VENV_DIR}

--- a/travis/travis_install.sh
+++ b/travis/travis_install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -ev
+
+YCMD_VENV_DIR=${HOME}/venvs/ycmd_test
+
+# Requirements of OS-specific install:
+#  - install any software which is not installed by Travis configuration
+#  - create (but don't activate) a virtualenv for the python version
+#    ${YCMD_PYTHON_VERSION} in the directory ${YCMD_VENV_DIR}, e.g.
+#    virtualenv -p python${YCMD_PYTHON_VERSION} ${YCMD_VENV_DIR}
+source travis/travis_install.${TRAVIS_OS_NAME}.sh
+
+# virtualenv doesn't copy python-config https://github.com/pypa/virtualenv/issues/169
+# but our build system uses it
+cp /usr/bin/python${YCMD_PYTHON_VERSION}-config ${YCMD_VENV_DIR}/bin/python-config
+
+# virtualenv script is noisy, so don't print every command
+set +v
+source ${YCMD_VENV_DIR}/bin/activate
+set -v
+
+# It is quite easy to get the above series of steps wrong. Verify that the
+# version of python actually in the path and used is the version that was
+# requested, and fail the build if we broke the travis setup
+python_version=$(python -c 'import sys; print "{0}.{1}".format( sys.version_info[0], sys.version_info[1] )')
+echo "Checking python version (actual ${python_version} vs expected ${YCMD_PYTHON_VERSION})"
+test ${python_version} == ${YCMD_PYTHON_VERSION}
+
+pip install -U pip wheel setuptools
+pip install -r test_requirements.txt
+npm install -g typescript
+
+# The build infrastructure prints a lot of spam after this script runs, so make
+# sure to disable printing, and failing on non-zero exit code after this script
+# finishes
+set +ev


### PR DESCRIPTION
Fixes https://github.com/Valloric/ycmd/issues/191

Dependency
====

Merging this will require @Valloric to request OS X support for ycmd repo. This requires sending a mail to support@travis-ci.com and requesting to feature-flag the repo for multiple OS support.

Overview
====

This involved 2 changes:
 - switching to the new Travis infrastructure, and
 - getting build scripts set up to bootstrap on OS X

Unfortunately, the "python" Travis config is not yet supported on OS X, so we actually transition to the "csharp" one (because that just handles installing mono for us), and we implement the required multi-python-environment stuff manually.

This involves using a third-party repo for Linux and some cool built-in multi-lib stuff on OS X. 

Multiple Python Versions
========

We use an environment variable YCMD_PYTHON_VERSION in the travis config to set
the major.minor python version to test with.

On linux: We use the ppa fkrull/deadsnakes
(https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes) to install specific
major.minor python version.
On OSX: Apple ships both python 2.6 and 2.7 as part of the base Yosemite OS
release, as such we don't need to install anything. All we need to do is tell
the OS which "default" python version to use:
http://stackoverflow.com/questions/6998545/how-can-i-make-python-2-6-my-default-in-mac-os-x-lion

Annoyingly, however, Apple doesn't ship libpython2.6.dylib in the same
directory pattern as libpython2.7.dylib (it is only in /usr/lib rather than
also in /python_prefix/lib. A small change is required to build.py to support
this.

Timing
====

While the new infrastructure is faster for Linux builds, sadly the OS X builds take quite a long time, as there is significantly less resource available in Travis' cloud. This makes the whole run take about 1 hour, rather than the previous 20 minutes or so.

Other changes
====

* Fixed a bug where we were using `check_output` on python 2.6. Simply use a backport of it.
* `ordereddict` is not installed by default on python 2.6, so we add it to `test_requirements.txt`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/240)
<!-- Reviewable:end -->
