### PR TITLE
Changed build.py to use python2 if available

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python
+#!/bin/sh
+''''which python2 >/dev/null 2>&1 && exec python2 "$0" "$@" # '''
+''''which python  >/dev/null 2>&1 && exec python  "$0" "$@" # '''
+''''exec echo "Error: I can't find python anywhere"         # '''
 
 import os
 import subprocess
@@ -74,7 +77,7 @@ def CustomPythonCmakeArgs():
     python_include = p.join( python_prefix, '/Headers' )
   else:
     which_python = subprocess.check_output( [
-      'python',
+      sys.executable,
       '-c',
       'import sys;i=sys.version_info;print "python%d.%d" % (i[0], i[1])'
     ] ).strip()


### PR DESCRIPTION
Following https://github.com/Valloric/YouCompleteMe/pull/1702
This is also needed for smooth installation of YCM if `python` calls Python 3 and `python2` is needed for the Python 2 interpreter.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/241)
<!-- Reviewable:end -->
