### PR TITLE
include `/usr/include` will make clang use incorrect macros

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -45,7 +45,6 @@ MAC_INCLUDE_PATHS = [
  '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1',
  '/usr/local/include',
  '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include',
- '/usr/include',
  '/System/Library/Frameworks',
  '/Library/Frameworks',
 ]


### PR DESCRIPTION
If this flag is set,
TARGET_MAC will be 1
TARGET_OS_IPHONE will be 0
TARGET_IPHONE_SIMULATOR will be 0
in iOS projects,
It causes clang to include OS-X specific headers (which cannot be found in iOS projects)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/247)
<!-- Reviewable:end -->
