### PR TITLE
Remove Vim-specific code

### DIFF
--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -21,15 +21,12 @@ import tempfile
 import os
 import sys
 import signal
-import functools
 import socket
 import stat
 import json
 import subprocess
 import collections
 
-WIN_PYTHON27_PATH = 'C:\python27\python.exe'
-WIN_PYTHON26_PATH = 'C:\python26\python.exe'
 # Creation flag to disable creating a console window on Windows. See
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863.aspx
 CREATE_NO_WINDOW = 0x08000000
@@ -124,47 +121,6 @@ def RemoveIfExists( filename ):
     os.remove( filename )
   except OSError:
     pass
-
-
-def Memoize( obj ):
-  cache = obj.cache = {}
-
-  @functools.wraps( obj )
-  def memoizer( *args, **kwargs ):
-    key = str( args ) + str( kwargs )
-    if key not in cache:
-      cache[ key ] = obj( *args, **kwargs )
-    return cache[ key ]
-  return memoizer
-
-
-@Memoize
-def PathToPythonInterpreter():
-  if not RunningInsideVim():
-    return sys.executable
-
-  import vim  # NOQA
-  user_path_to_python = vim.eval( 'g:ycm_path_to_python_interpreter' )
-  if user_path_to_python:
-    return user_path_to_python
-
-  # We check for 'python2' before 'python' because some OS's (I'm looking at you
-  # Arch Linux) have made the... interesting decision to point /usr/bin/python
-  # to python3.
-  python_names = [ 'python2', 'python' ]
-
-  path_to_python = PathToFirstExistingExecutable( python_names )
-  if path_to_python:
-    return path_to_python
-
-  # On Windows, Python may not be on the PATH at all, so we check some common
-  # install locations.
-  if OnWindows():
-    if os.path.exists( WIN_PYTHON27_PATH ):
-      return WIN_PYTHON27_PATH
-    elif os.path.exists( WIN_PYTHON26_PATH ):
-      return WIN_PYTHON26_PATH
-  raise RuntimeError( 'Python 2.7/2.6 not installed!' )
 
 
 def PathToFirstExistingExecutable( executable_name_list ):


### PR DESCRIPTION
This code is specific to Vim and should be moved to YouCompleteMe. See Valloric/YouCompleteMe#1719.

For @Valloric, is the Vim-related code really needed in `ycmd/completers/completer.py`?
```python
if RunningInsideVim():
  from ycm_client_support import FilterAndSortCandidates
else:
  from ycm_core import FilterAndSortCandidates
```
I tried it without the `RunningInsideVim` part and it was working so I am wondering if we can safely remove it. Ideally, ycmd should not contain any Vim specifics.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/249)
<!-- Reviewable:end -->
