### PR TITLE
Ignore commands before the compiler path when replacing it with language flag

### DIFF
--- a/ycmd/completers/cpp/tests/flags_test.py
+++ b/ycmd/completers/cpp/tests/flags_test.py
@@ -182,27 +182,30 @@ def CompilerToLanguageFlag_Passthrough_test():
        flags._CompilerToLanguageFlag( [ '-foo', '-bar' ] ) )
 
 
-def CompilerToLanguageFlag_ReplaceCCompiler_test():
-  def tester( path ):
-    eq_( [ '-x', 'c' ] + expected,
-        flags._CompilerToLanguageFlag( [ path ] + expected ) )
-
-  compiler_paths = [ 'cc', 'gcc', 'clang', '/usr/bin/cc',
-                     '/some/other/path', 'some_command' ]
+def _ReplaceCompilerTester( compiler, language ):
+  to_removes = [
+    [],
+    [ '/usr/bin/ccache' ],
+    [ 'some_command', 'another_command' ]
+  ]
   expected = [ '-foo', '-bar' ]
 
-  for compiler in compiler_paths:
-    yield tester, compiler
+  for to_remove in to_removes:
+    eq_( [ '-x', language ] + expected,
+         flags._CompilerToLanguageFlag( to_remove + [ compiler ] + expected ) )
+
+
+def CompilerToLanguageFlag_ReplaceCCompiler_test():
+  compilers = [ 'cc', 'gcc', 'clang', '/usr/bin/cc',
+                '/some/other/path', 'some_command' ]
+
+  for compiler in compilers:
+    yield _ReplaceCompilerTester, compiler, 'c'
 
 
 def CompilerToLanguageFlag_ReplaceCppCompiler_test():
-  def tester( path ):
-    eq_( [ '-x', 'c++' ] + expected,
-        flags._CompilerToLanguageFlag( [ path ] + expected ) )
+  compilers = [ 'c++', 'g++', 'clang++', '/usr/bin/c++',
+                '/some/other/path++', 'some_command++' ]
 
-  compiler_paths = [ 'c++', 'g++', 'clang++', '/usr/bin/c++',
-                     '/some/other/path++', 'some_command++' ]
-  expected = [ '-foo', '-bar' ]
-
-  for compiler in compiler_paths:
-    yield tester, compiler
+  for compiler in compilers:
+    yield _ReplaceCompilerTester, compiler, 'c++'


### PR DESCRIPTION
PR #248 introduced an unexpected behavior when dealing with compilation database. When commands (like `ccache`) are used before the actual compiler, YCM considers the first of those commands as the compiler path, which leads YCM to use the wrong language flag (`-x c`) for C++ files. This was found in issue Valloric/YouCompleteMe#1737.

New behavior is to assume that the flag just before the first one starting with a dash is the compiler path. All flags preceding the compiler path are ignored.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/253)
<!-- Reviewable:end -->
