### PR TITLE
clang_reparseTranslationUnit takes CXReparse_Flags, not CXTranslation…

### DIFF
--- a/cpp/ycm/ClangCompleter/TranslationUnit.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.h
@@ -61,8 +61,6 @@ public:
   std::vector< Diagnostic > Reparse(
     const std::vector< UnsavedFile > &unsaved_files );
 
-  void ReparseForIndexing( const std::vector< UnsavedFile > &unsaved_files );
-
   std::vector< CompletionData > CandidatesForLocation(
     int line,
     int column,


### PR DESCRIPTION
Currently there's no flags even existing so one could argue whether it makes sense to incur the extra mutex lock but I didn't want to change anymore than necessary.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/255)
<!-- Reviewable:end -->
