### PR TITLE
Fix LLVM path for new 7-zip release

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -150,7 +150,14 @@ if ( USE_CLANG_COMPLETER AND
   # folder name the archive produced. It isn't the archive base name.
   # On Windows, the find command is not available so we directly set the path.
   if ( WIN32 )
-    set( PATH_TO_LLVM_ROOT ${CMAKE_CURRENT_BINARY_DIR}/../$_OUTDIR )
+    # Since 7-zip release version 15.12, files are not anymore extracted in
+    # $_OUTDIR folder but directly to the root. So, we check the existence of
+    # $_OUTDIR to appropriately set PATH_TO_LLVM_ROOT.
+    if ( EXISTS ${CMAKE_CURRENT_BINARY_DIR}/../$_OUTDIR )
+      set( PATH_TO_LLVM_ROOT ${CMAKE_CURRENT_BINARY_DIR}/../$_OUTDIR )
+    else()
+      set( PATH_TO_LLVM_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.. )
+    endif()
   else()
     execute_process( COMMAND
       find ${CMAKE_CURRENT_BINARY_DIR}/.. -maxdepth 1 -type d -name clang*


### PR DESCRIPTION
With this PR, `PATH_TO_LLVM_ROOT` is correctly set on Windows with the new 7-zip release (15.12).

Issue was found on the [ycm-users](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/ycm-users/Rro51uaFooU/sR3Px2PDBwAJ) list.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/261)
<!-- Reviewable:end -->
