### PR TITLE
Update flags.py for more complex compiler names

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -220,9 +220,10 @@ def _CompilerToLanguageFlag( flags ):
   if flags[ 0 ].startswith( '-' ):
     return flags
 
-  # If the compiler ends with '++', it's probably a C++ compiler
-  # (e.g., c++, g++, clang++, etc).
-  language = ( 'c++' if flags[ 0 ].endswith( '++' ) else
+  
+  # If the compiler contains '++' potentially followed by e.g. version numbers, it's probably a C++ compiler
+  # (e.g., c++, g++, clang++, c++-x.y, g++-x.y, clang++-x.y etc).
+  language = ( 'c++' if '++' in flags[ 0 ] else
                'c' )
 
   return [ '-x', language ] + flags[ 1: ]


### PR DESCRIPTION
If you're using a versioned compiler name (e.g. g++-4.9, clang++-3.5) as it might happen when you have more than one compiler installed, current automatic detection of file-type fails as the name doesn't end with just '++'.
My proposed change simply relaxes the criteria a bit so that any name that contains '++' anywhere triggers the language to be c++

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/262)
<!-- Reviewable:end -->
