### PR TITLE
Fix IndexError in Typescript completer when querying a subcommand without argument

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -220,6 +220,9 @@ class TypeScriptCompleter( Completer ):
 
 
   def OnUserCommand( self, arguments, request_data ):
+    if not arguments:
+      raise ValueError( self.UserCommandsHelpMessage() )
+
     command = arguments[ 0 ]
     if command == 'GoToDefinition':
       return self._GoToDefinition( request_data )


### PR DESCRIPTION
When typing the command `:YcmCompleter` without argument in Vim, YCM will return the following error `IndexError: list index out of range`. This is because the Typescript completer, unlike other completers, does not check if `arguments` in `OnUserCommand` is defined.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/263)
<!-- Reviewable:end -->
