### PR TITLE
Move subcommands logic to Completer class

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -149,8 +149,79 @@ class CsharpCompleter( Completer ):
     return result
 
 
-  def DefinedSubcommands( self ):
-    return CsharpSolutionCompleter.subcommands.keys()
+  def GetSubcommandsMap( self ):
+    return {
+      'StartServer'                      : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_StartServer',
+                                   no_request_data = True ) ),
+      'StopServer'                       : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_StopServer',
+                                   no_request_data = True ) ),
+      'RestartServer'                    : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_RestartServer',
+                                   no_request_data = True ) ),
+      'ReloadSolution'                   : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_ReloadSolution',
+                                   no_request_data = True ) ),
+      'SolutionFile'                     : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_SolutionFile',
+                                   no_request_data = True ) ),
+      'GoToDefinition'                   : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_GoToDefinition' ) ),
+      'GoToDeclaration'                  : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_GoToDefinition' ) ),
+      'GoTo'                             : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_GoToImplementation',
+                                   fallback_to_declaration = True ) ),
+      'GoToDefinitionElseDeclaration'    : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_GoToDefinition' ) ),
+      'GoToImplementation'               : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_GoToImplementation',
+                                   fallback_to_declaration = False ) ),
+      'GoToImplementationElseDeclaration': ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_GoToImplementation',
+                                   fallback_to_declaration = True ) ),
+      'GetType'                          : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_GetType' ) ),
+      'FixIt'                            : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_FixIt' ) ),
+      'GetDoc'                           : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = '_GetDoc' ) ),
+      'ServerRunning'                    : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = 'ServerIsRunning',
+                                   no_request_data = True ) ),
+      'ServerReady'                      : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = 'ServerIsReady',
+                                   no_request_data = True ) ),
+      'ServerTerminated'                 : ( lambda self, request_data:
+         self._SolutionSubcommand( request_data,
+                                   method = 'ServerTerminated',
+                                   no_request_data = True ) )
+    }
+
+
+  def _SolutionSubcommand( self, request_data, method,
+                           no_request_data = False, **kwargs ):
+    solutioncompleter = self._GetSolutionCompleter( request_data )
+    if not no_request_data:
+      kwargs[ 'request_data' ] = request_data
+    return getattr( solutioncompleter, method )( **kwargs )
 
 
   def OnFileReadyToParse( self, request_data ):
@@ -210,18 +281,6 @@ class CsharpCompleter( Completer ):
       closest_diagnostic.text_ )
 
 
-  def OnUserCommand( self, arguments, request_data ):
-    if not arguments:
-      raise ValueError( self.UserCommandsHelpMessage() )
-
-    command = arguments[ 0 ]
-    if command in CsharpSolutionCompleter.subcommands:
-      solutioncompleter = self._GetSolutionCompleter( request_data )
-      return solutioncompleter.Subcommand( command, arguments, request_data )
-    else:
-      raise ValueError( self.UserCommandsHelpMessage() )
-
-
   def DebugInfo( self, request_data ):
     solutioncompleter = self._GetSolutionCompleter( request_data )
     if solutioncompleter.ServerIsRunning():
@@ -275,34 +334,6 @@ class CsharpCompleter( Completer ):
 
 
 class CsharpSolutionCompleter:
-  subcommands = {
-    'StartServer': ( lambda self, request_data: self._StartServer() ),
-    'StopServer': ( lambda self, request_data: self._StopServer() ),
-    'RestartServer': ( lambda self, request_data: self._RestartServer() ),
-    'ReloadSolution': ( lambda self, request_data: self._ReloadSolution() ),
-    'SolutionFile': ( lambda self, request_data: self._SolutionFile() ),
-    'GoToDefinition': ( lambda self, request_data: self._GoToDefinition(
-        request_data ) ),
-    'GoToDeclaration': ( lambda self, request_data: self._GoToDefinition(
-        request_data ) ),
-    'GoTo': ( lambda self, request_data: self._GoToImplementation(
-        request_data, True ) ),
-    'GoToDefinitionElseDeclaration': ( lambda self, request_data:
-        self._GoToDefinition( request_data ) ),
-    'GoToImplementation': ( lambda self, request_data:
-        self._GoToImplementation( request_data, False ) ),
-    'GoToImplementationElseDeclaration': ( lambda self, request_data:
-        self._GoToImplementation( request_data, True ) ),
-    'GetType': ( lambda self, request_data: self._GetType(
-        request_data ) ),
-    'FixIt': ( lambda self, request_data: self._FixIt( request_data ) ),
-    'GetDoc': ( lambda self, request_data: self._GetDoc( request_data ) ),
-    'ServerRunning': ( lambda self, request_data: self.ServerIsRunning() ),
-    'ServerReady': ( lambda self, request_data: self.ServerIsReady() ),
-    'ServerTerminated': ( lambda self, request_data: self.ServerTerminated() ),
-  }
-
-
   def __init__( self, solution_path, keep_logfiles, desired_omnisharp_port ):
     self._logger = logging.getLogger( __name__ )
     self._solution_path = solution_path
@@ -312,15 +343,6 @@ class CsharpSolutionCompleter:
     self._omnisharp_port = None
     self._omnisharp_phandle = None
     self._desired_omnisharp_port = desired_omnisharp_port;
-
-
-  def Subcommand( self, command, arguments, request_data ):
-    command_lamba = CsharpSolutionCompleter.subcommands[ command ]
-    return command_lamba( self, request_data )
-
-
-  def DefinedSubcommands( self ):
-    return CsharpSolutionCompleter.subcommands.keys()
 
 
   def CodeCheck( self, request_data ):

--- a/ycmd/completers/go/gocode_completer.py
+++ b/ycmd/completers/go/gocode_completer.py
@@ -45,11 +45,6 @@ _logger = logging.getLogger( __name__ )
 
 class GoCodeCompleter( Completer ):
 
-  subcommands = {
-    'StartServer': ( lambda self, request_data: self._StartServer() ),
-    'StopServer': ( lambda self, request_data: self._StopServer() ),
-  }
-
   def __init__( self, user_options ):
     super( GoCodeCompleter, self ).__init__( user_options )
     self._popener = utils.SafePopen # Overridden in test.
@@ -96,6 +91,13 @@ class GoCodeCompleter( Completer ):
     return [ _ConvertCompletionData( x ) for x in resultdata[1] ]
 
 
+  def GetSubcommandsMap( self ):
+    return {
+      'StartServer': ( lambda self, request_data: self._StartServer() ),
+      'StopServer': ( lambda self, request_data: self._StopServer() )
+    }
+
+
   def FindGoCodeBinary( self, user_options ):
     """ Find the path to the gocode binary.
 
@@ -120,24 +122,8 @@ class GoCodeCompleter( Completer ):
     return utils.PathToFirstExistingExecutable( [ 'gocode' ] )
 
 
-  def DefinedSubcommands( self ):
-    return GoCodeCompleter.subcommands.keys()
-
-
   def OnFileReadyToParse( self, request_data ):
     self._StartServer()
-
-
-  def OnUserCommand( self, arguments, request_data ):
-    if not arguments:
-      raise ValueError( self.UserCommandsHelpMessage() )
-
-    command = arguments[ 0 ]
-    if command in GoCodeCompleter.subcommands:
-      command_lamba = GoCodeCompleter.subcommands[ command ]
-      return command_lamba( self, request_data )
-    else:
-      raise ValueError( self.UserCommandsHelpMessage() )
 
 
   def Shutdown( self ):

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -82,27 +82,18 @@ class JediCompleter( Completer ):
                 extra_data = self._GetExtraData( completion ) )
              for completion in script.completions() ]
 
-  def DefinedSubcommands( self ):
-    return [ 'GoToDefinition',
-             'GoToDeclaration',
-             'GoTo',
-             'GetDoc' ]
 
-
-  def OnUserCommand( self, arguments, request_data ):
-    if not arguments:
-      raise ValueError( self.UserCommandsHelpMessage() )
-
-    command = arguments[ 0 ]
-    if command == 'GoToDefinition':
-      return self._GoToDefinition( request_data )
-    elif command == 'GoToDeclaration':
-      return self._GoToDeclaration( request_data )
-    elif command == 'GoTo':
-      return self._GoTo( request_data )
-    elif command == 'GetDoc':
-      return self._GetDoc( request_data )
-    raise ValueError( self.UserCommandsHelpMessage() )
+  def GetSubcommandsMap( self ):
+    return {
+      'GoToDefinition' : ( lambda self, request_data:
+                           self._GoToDefinition( request_data ) ),
+      'GoToDeclaration': ( lambda self, request_data:
+                           self._GoToDeclaration( request_data ) ),
+      'GoTo'           : ( lambda self, request_data:
+                           self._GoTo( request_data ) ),
+      'GetDoc'         : ( lambda self, request_data:
+                           self._GetDoc( request_data ) )
+    }
 
 
   def _GoToDefinition( self, request_data ):

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -196,6 +196,17 @@ class TypeScriptCompleter( Completer ):
                for e in detailed_entries ]
 
 
+  def GetSubcommandsMap( self ):
+    return {
+      'GoToDefinition': ( lambda self, request_data:
+                          self._GoToDefinition( request_data ) ),
+      'GetType'       : ( lambda self, request_data:
+                          self._GetType( request_data ) ),
+      'GetDoc'        : ( lambda self, request_data:
+                          self._GetDoc( request_data ) )
+    }
+
+
   def OnBufferVisit( self, request_data ):
     filename = request_data[ 'filepath' ]
     with self._lock:
@@ -211,24 +222,6 @@ class TypeScriptCompleter( Completer ):
   def OnFileReadyToParse( self, request_data ):
     with self._lock:
       self._Reload( request_data )
-
-
-  def DefinedSubcommands( self ):
-    return [ 'GoToDefinition',
-             'GetType',
-             'GetDoc' ]
-
-
-  def OnUserCommand( self, arguments, request_data ):
-    command = arguments[ 0 ]
-    if command == 'GoToDefinition':
-      return self._GoToDefinition( request_data )
-    if command == 'GetType':
-      return self._GetType( request_data )
-    if command == 'GetDoc':
-      return self._GetDoc( request_data )
-
-    raise ValueError( self.UserCommandsHelpMessage() )
 
 
   def _GoToDefinition( self, request_data ):

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -1446,10 +1446,10 @@ def DefinedSubcommands_Works_test():
   app = TestApp( handlers.app )
   subcommands_data = BuildRequest( completer_target = 'python' )
 
-  eq_( [ 'GoToDefinition',
-         'GoToDeclaration',
+  eq_( [ 'GetDoc',
          'GoTo',
-         'GetDoc' ],
+         'GoToDeclaration',
+         'GoToDefinition' ],
        app.post_json( '/defined_subcommands', subcommands_data ).json )
 
 
@@ -1458,10 +1458,10 @@ def DefinedSubcommands_WorksWhenNoExplicitCompleterTargetSpecified_test():
   app = TestApp( handlers.app )
   subcommands_data = BuildRequest( filetype = 'python' )
 
-  eq_( [ 'GoToDefinition',
-         'GoToDeclaration',
+  eq_( [ 'GetDoc',
          'GoTo',
-         'GetDoc' ],
+         'GoToDeclaration',
+         'GoToDefinition' ],
        app.post_json( '/defined_subcommands', subcommands_data ).json )
 
 


### PR DESCRIPTION
Currently, each semantic completer reimplements the `OnUserCommand` and `DefinedSubcommands` in about the same way. To avoid duplication of code, this PR moves the logic of these methods to the `Completer` class. Completers only need to implement a new function `GetSubcommandsMap` that return a map between the subcommands name and the methods to call. The map structure is explained in the method documentation. 

Minor improvements:
 - `DefinedSubcommands` now returns an alphabetically sorted list (tests updated to reflect this);
 - Fix issue in PR #263.

Important: if this PR is merged, the `OmniCompleter` class will need to be updated in YCM by inheriting from `GeneralCompleter` instead of `Completer` or implementing the `GetSubcommandsMap` method.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/264)
<!-- Reviewable:end -->
