### PR TITLE
Support typescript.tsx filetype for typescript completer

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -172,7 +172,7 @@ class TypeScriptCompleter( Completer ):
 
 
   def SupportedFiletypes( self ):
-    return [ 'typescript' ]
+    return [ 'typescript', 'typescript.tsx' ]
 
 
   def ComputeCandidatesInner( self, request_data ):


### PR DESCRIPTION
`typescript.tsx` is a filetype to differentiate regular `.ts` files from `.tsx`. This is necessary to disambiguate typecasting (i.e. `<String>something`) from TSX syntax (i.e. `<SomeComponent />`)

This patch just adds support for ycmd to detect the `typescript.tsx` filetype.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/269)
<!-- Reviewable:end -->
