### PR TITLE
[READY] Refactoring integration tests

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,4 +4,3 @@ nose>=1.3.0
 PyHamcrest>=1.8.0
 WebTest>=2.0.9
 ordereddict>=1.1
-contextlib2>=0.4.0

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -31,44 +31,33 @@ import os
 class Javascript_EventNotification_test( Javascript_Handlers_test ):
 
   def OnFileReadyToParse_ProjectFile_cwd_test( self ):
-    try:
-      self._WaitUntilTernServerReady()
+    contents = open( self._PathToTestFile( 'simple_test.js' ) ).read()
 
-      contents = open( self._PathToTestFile( 'simple_test.js' ) ).read()
+    response = self._app.post_json( '/event_notification',
+                                    self._BuildRequest(
+                                      event_name = 'FileReadyToParse',
+                                      contents = contents,
+                                      filetype = 'javascript' ),
+                                    expect_errors = True)
 
-      response = self._app.post_json( '/event_notification',
-                                      self._BuildRequest(
-                                        event_name = 'FileReadyToParse',
-                                        contents = contents,
-                                        filetype = 'javascript' ),
-                                      expect_errors = True)
-
-      eq_( response.status_code, httplib.OK )
-      assert_that( response.json, empty() )
-    finally:
-      self._StopTernServer()
-
+    eq_( response.status_code, httplib.OK )
+    assert_that( response.json, empty() )
 
 
   def OnFileReadyToParse_ProjectFile_parentdir_test( self ):
     os.chdir( self._PathToTestFile( 'lamelib' ) )
 
-    try:
-      self._WaitUntilTernServerReady()
+    contents = open( self._PathToTestFile( 'simple_test.js' ) ).read()
 
-      contents = open( self._PathToTestFile( 'simple_test.js' ) ).read()
+    response = self._app.post_json( '/event_notification',
+                                    self._BuildRequest(
+                                      event_name = 'FileReadyToParse',
+                                      contents = contents,
+                                      filetype = 'javascript' ),
+                                    expect_errors = True)
 
-      response = self._app.post_json( '/event_notification',
-                                      self._BuildRequest(
-                                        event_name = 'FileReadyToParse',
-                                        contents = contents,
-                                        filetype = 'javascript' ),
-                                      expect_errors = True)
-
-      eq_( response.status_code, httplib.OK )
-      assert_that( response.json, empty() )
-    finally:
-      self._StopTernServer()
+    eq_( response.status_code, httplib.OK )
+    assert_that( response.json, empty() )
 
 
   def OnFileReadyToParse_NoProjectFile_test( self ):
@@ -77,83 +66,78 @@ class Javascript_EventNotification_test( Javascript_Handlers_test ):
     # server startup.
     os.chdir( self._PathToTestFile( '..' ) )
 
-    try:
-      self._WaitUntilTernServerReady()
+    contents = open( self._PathToTestFile( 'simple_test.js' ) ).read()
 
-      contents = open( self._PathToTestFile( 'simple_test.js' ) ).read()
+    response = self._app.post_json( '/event_notification',
+                                    self._BuildRequest(
+                                      event_name = 'FileReadyToParse',
+                                      contents = contents,
+                                      filetype = 'javascript' ),
+                                    expect_errors = True )
 
-      response = self._app.post_json( '/event_notification',
-                                      self._BuildRequest(
-                                        event_name = 'FileReadyToParse',
-                                        contents = contents,
-                                        filetype = 'javascript' ),
-                                      expect_errors = True )
+    print( 'event response: {0}'.format( pformat( response.json ) ) )
 
-      print( 'event response: {0}'.format( pformat( response.json ) ) )
+    eq_( response.status_code, httplib.INTERNAL_SERVER_ERROR )
 
-      eq_( response.status_code, httplib.INTERNAL_SERVER_ERROR )
+    assert_that(
+      response.json,
+      self._ErrorMatcher( RuntimeError,
+                          'Warning: Unable to detect a .tern-project file '
+                          'in the hierarchy before ' + os.getcwd() + '. '
+                          'This is required for accurate JavaScript '
+                          'completion. Please see the User Guide for '
+                          'details.' )
+    )
 
-      assert_that(
-        response.json,
-        self._ErrorMatcher( RuntimeError,
-                            'Warning: Unable to detect a .tern-project file '
-                            'in the hierarchy before ' + os.getcwd() + '. '
-                            'This is required for accurate JavaScript '
-                            'completion. Please see the User Guide for '
-                            'details.' )
-      )
+    # Check that a subsequent call does *not* raise the error
 
-      # Check that a subsequent call does *not* raise the error
+    response = self._app.post_json( '/event_notification',
+                                    self._BuildRequest(
+                                      event_name = 'FileReadyToParse',
+                                      contents = contents,
+                                      filetype = 'javascript' ),
+                                    expect_errors = True )
 
-      response = self._app.post_json( '/event_notification',
-                                      self._BuildRequest(
-                                        event_name = 'FileReadyToParse',
-                                        contents = contents,
-                                        filetype = 'javascript' ),
-                                      expect_errors = True )
+    print( 'event response: {0}'.format( pformat( response.json ) ) )
 
-      print( 'event response: {0}'.format( pformat( response.json ) ) )
+    eq_( response.status_code, httplib.OK )
+    assert_that( response.json, empty() )
 
-      eq_( response.status_code, httplib.OK )
-      assert_that( response.json, empty() )
+    # Restart the server and check that it raises it again
 
-      # Restart the server and check that it raises it again
+    self._app.post_json(
+      '/run_completer_command',
+      self._BuildRequest( command_arguments = [ 'StopServer' ],
+                          filetype = 'javascript',
+                          contents = contents,
+                          completer_target = 'filetype_default' )
+    )
+    self._app.post_json(
+      '/run_completer_command',
+      self._BuildRequest( command_arguments = [ 'StartServer' ],
+                          filetype = 'javascript',
+                          contents = contents,
+                          completer_target = 'filetype_default' ) )
 
-      self._app.post_json(
-        '/run_completer_command',
-        self._BuildRequest( command_arguments = [ 'StopServer' ],
-                            filetype = 'javascript',
-                            contents = contents,
-                            completer_target = 'filetype_default' )
-      )
-      self._app.post_json(
-        '/run_completer_command',
-        self._BuildRequest( command_arguments = [ 'StartServer' ],
-                            filetype = 'javascript',
-                            contents = contents,
-                            completer_target = 'filetype_default' ) )
+    self._WaitUntilTernServerReady()
 
-      self._WaitUntilTernServerReady()
+    response = self._app.post_json( '/event_notification',
+                                    self._BuildRequest(
+                                      event_name = 'FileReadyToParse',
+                                      contents = contents,
+                                      filetype = 'javascript' ),
+                                    expect_errors = True)
 
-      response = self._app.post_json( '/event_notification',
-                                      self._BuildRequest(
-                                        event_name = 'FileReadyToParse',
-                                        contents = contents,
-                                        filetype = 'javascript' ),
-                                      expect_errors = True)
+    print( 'event response: {0}'.format( pformat( response.json ) ) )
 
-      print( 'event response: {0}'.format( pformat( response.json ) ) )
+    eq_( response.status_code, httplib.INTERNAL_SERVER_ERROR )
 
-      eq_( response.status_code, httplib.INTERNAL_SERVER_ERROR )
-
-      assert_that(
-        response.json,
-        self._ErrorMatcher( RuntimeError,
-                            'Warning: Unable to detect a .tern-project file '
-                            'in the hierarchy before ' + os.getcwd() + '. '
-                            'This is required for accurate JavaScript '
-                            'completion. Please see the User Guide for '
-                            'details.' )
-      )
-    finally:
-      self._StopTernServer()
+    assert_that(
+      response.json,
+      self._ErrorMatcher( RuntimeError,
+                          'Warning: Unable to detect a .tern-project file '
+                          'in the hierarchy before ' + os.getcwd() + '. '
+                          'This is required for accurate JavaScript '
+                          'completion. Please see the User Guide for '
+                          'details.' )
+    )

--- a/ycmd/tests/javascript/get_completions_test.py
+++ b/ycmd/tests/javascript/get_completions_test.py
@@ -51,7 +51,6 @@ class Javascript_GetCompletions_test( Javascript_Handlers_test ):
     try:
       self._WaitUntilTernServerReady()
       contents = open( test[ 'request' ][ 'filepath' ] ).read()
-      print( pformat( test ) )
 
       def CombineRequest( request, data ):
         kw = request

--- a/ycmd/tests/javascript/get_completions_test.py
+++ b/ycmd/tests/javascript/get_completions_test.py
@@ -48,37 +48,33 @@ class Javascript_GetCompletions_test( Javascript_Handlers_test ):
       }
     """
 
-    try:
-      self._WaitUntilTernServerReady()
-      contents = open( test[ 'request' ][ 'filepath' ] ).read()
+    contents = open( test[ 'request' ][ 'filepath' ] ).read()
 
-      def CombineRequest( request, data ):
-        kw = request
-        request.update( data )
-        return self._BuildRequest( **kw )
+    def CombineRequest( request, data ):
+      kw = request
+      request.update( data )
+      return self._BuildRequest( **kw )
 
-      self._app.post_json( '/event_notification',
-                           CombineRequest( test[ 'request' ], {
-                                           'event_name': 'FileReadyToParse',
-                                           'contents': contents,
-                                           } ),
-                           expect_errors = True )
+    self._app.post_json( '/event_notification',
+                         CombineRequest( test[ 'request' ], {
+                                         'event_name': 'FileReadyToParse',
+                                         'contents': contents,
+                                         } ),
+                         expect_errors = True )
 
-      # We ignore errors here and we check the response code ourself.
-      # This is to allow testing of requests returning errors.
-      response = self._app.post_json( '/completions',
-                                      CombineRequest( test[ 'request' ], {
-                                        'contents': contents
-                                      } ),
-                                      expect_errors = True )
+    # We ignore errors here and we check the response code ourself.
+    # This is to allow testing of requests returning errors.
+    response = self._app.post_json( '/completions',
+                                    CombineRequest( test[ 'request' ], {
+                                      'contents': contents
+                                    } ),
+                                    expect_errors = True )
 
-      print( 'completer response: {0}'.format( pformat( response.json ) ) )
+    print( 'completer response: {0}'.format( pformat( response.json ) ) )
 
-      eq_( response.status_code, test[ 'expect' ][ 'response' ] )
+    eq_( response.status_code, test[ 'expect' ][ 'response' ] )
 
-      assert_that( response.json, test[ 'expect' ][ 'data' ] )
-    finally:
-      self._StopTernServer()
+    assert_that( response.json, test[ 'expect' ][ 'data' ] )
 
 
   def NoQuery_test( self ):

--- a/ycmd/tests/javascript/javascript_handlers_test.py
+++ b/ycmd/tests/javascript/javascript_handlers_test.py
@@ -30,11 +30,16 @@ class Javascript_Handlers_test( Handlers_test ):
 
   def setUp( self ):
     super( Javascript_Handlers_test, self ).setUp()
+
     self._prev_current_dir = os.getcwd()
     os.chdir( self._PathToTestFile() )
 
+    self._WaitUntilTernServerReady()
+
 
   def tearDown( self ):
+    self._StopTernServer()
+
     os.chdir( self._prev_current_dir )
 
 

--- a/ycmd/tests/javascript/javascript_handlers_test.py
+++ b/ycmd/tests/javascript/javascript_handlers_test.py
@@ -30,12 +30,12 @@ class Javascript_Handlers_test( Handlers_test ):
 
   def setUp( self ):
     super( Javascript_Handlers_test, self ).setUp()
-    self.prev_wd = os.getcwd()
+    self._prev_current_dir = os.getcwd()
     os.chdir( self._PathToTestFile() )
 
 
   def tearDown( self ):
-    os.chdir( self.prev_wd )
+    os.chdir( self._prev_current_dir )
 
 
   def _StopTernServer( self ):

--- a/ycmd/tests/javascript/javascript_handlers_test.py
+++ b/ycmd/tests/javascript/javascript_handlers_test.py
@@ -49,6 +49,7 @@ class Javascript_Handlers_test( Handlers_test ):
     except:
       pass
 
+
   def _WaitUntilTernServerReady( self ):
     self._app.post_json( '/run_completer_command', self._BuildRequest(
       command_arguments = [ 'StartServer' ],


### PR DESCRIPTION
### Changes
- Move related completer tests to their own subdirectories:
```
ycmd
  └── tests        
      ├── clang
      │   ├── testdata
      │   ├── __init__.py
      │   ├── get_completions_test.py
      │   ├── diagnostics_test.py
      │   ├── subcommands_test.py
      │   └── utils.py 
      ├── cs ── ... 
      ├── python ── ...
      ├── go ── ...
      ...
```
- Regroup tests in classes and subclasses: take advantage of fixtures (`setUp` and `tearDown` methods) and inheritance.
- Rename tests: names are now shorter;
- Fix coding style;
- Update copyright notices;
- No tests were harmed during the making of this PR: 458 tests before, 458 tests after.

### Issues?
- Code to set the Bottle debug mode:
```python
import bottle

bottle.debug( True )
```
was removed from all tests inheriting from `Handlers_test` where it is set in the `setUp` method. Is it enough to enable debug mode in all tests? I don't know how to check this.
- `Basic_test` and `ZeroBasedLineAndColumn_test` tests in `Cs_Diagnostics_test` are near to be identical. Should we remove one of them?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/270)
<!-- Reviewable:end -->
