### PR TITLE
Add configuration to exclude tests and empty files from Coveralls.io report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+omit =
+    */tests/*
+    */__init__.py


### PR DESCRIPTION
There is no point to get the coverage of the tests and `__init__.py` files are empties so we exclude them from the coverage report.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/274)
<!-- Reviewable:end -->
