### PR TITLE
Remove coverage options on Travis because we can

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - source travis/travis_install.sh
 compiler:
   - gcc
-script: ./run_tests.py --with-coverage --cover-package=ycmd
+script: ./run_tests.py
 after_success:
   - if [ x"${COVERAGE}" = x"true" ]; then coveralls; fi
 env:


### PR DESCRIPTION
`run_tests.py` automatically uses coverage options if the `COVERAGE` environment variable is defined.

Maybe it would be better to change the name of this environment variable to `YCMD_COVERAGE`, `COVERAGE` is too generic.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/279)
<!-- Reviewable:end -->
