### PR TITLE
[READY] Recognise ~/.tern-config in Tern completer

### DIFF
--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -70,17 +70,7 @@ def ShouldEnableTernCompleter():
   return True
 
 
-def FindTernProjectFile( starting_directory ):
-  # We use a dummy_file here because AncestorFolders requires a file name and we
-  # don't have one. Something like '.' doesn't work because, while
-  # os.path.dirname( /a/b/c/. ) returns /a/b/c, AncestorFolders calls
-  # os.path.abspath on it, so the /. is removed.
-  starting_file = os.path.join( starting_directory, 'dummy_file' )
-  for folder in utils.AncestorFolders( starting_file ):
-    tern_project = os.path.join( folder, '.tern-project' )
-    if os.path.exists( tern_project ):
-      return tern_project
-
+def PathToGlobalTernConfig():
   # As described here: http://ternjs.net/doc/manual.html#server a global
   # .tern-config file is also supported for the Tern server. This can provide
   # meaningful defaults (for libs, and possibly also for require paths), so
@@ -92,6 +82,20 @@ def FindTernProjectFile( starting_directory ):
     return tern_config
 
   return None
+
+
+def FindTernProjectFile( starting_directory ):
+  # We use a dummy_file here because AncestorFolders requires a file name and we
+  # don't have one. Something like '.' doesn't work because, while
+  # os.path.dirname( /a/b/c/. ) returns /a/b/c, AncestorFolders calls
+  # os.path.abspath on it, so the /. is removed.
+  starting_file = os.path.join( starting_directory, 'dummy_file' )
+  for folder in utils.AncestorFolders( starting_file ):
+    tern_project = os.path.join( folder, '.tern-project' )
+    if os.path.exists( tern_project ):
+      return tern_project
+
+  return PathToGlobalTernConfig()
 
 
 class TernCompleter( Completer ):

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -70,18 +70,11 @@ def ShouldEnableTernCompleter():
   return True
 
 
-def PathToGlobalTernConfig():
-  # As described here: http://ternjs.net/doc/manual.html#server a global
-  # .tern-config file is also supported for the Tern server. This can provide
-  # meaningful defaults (for libs, and possibly also for require paths), so
-  # don't warn if we find one. The point is that if the user has a .tern-config
-  # set up, then she has deliberately done so and a ycmd warning is unlikely
-  # to be anything other than annoying.
-  tern_config = os.path.expanduser( '~/.tern-config' )
-  if os.path.exists( tern_config ):
-    return tern_config
-
-  return None
+def GlobalConfigExists( tern_config ):
+  """Returns whether or not the global config file with the supplied path
+  exists. This method primarily exists to allow testability and simply returns
+  whether the supplied file exists."""
+  return os.path.exists( tern_config )
 
 
 def FindTernProjectFile( starting_directory ):
@@ -95,7 +88,17 @@ def FindTernProjectFile( starting_directory ):
     if os.path.exists( tern_project ):
       return tern_project
 
-  return PathToGlobalTernConfig()
+  # As described here: http://ternjs.net/doc/manual.html#server a global
+  # .tern-config file is also supported for the Tern server. This can provide
+  # meaningful defaults (for libs, and possibly also for require paths), so
+  # don't warn if we find one. The point is that if the user has a .tern-config
+  # set up, then she has deliberately done so and a ycmd warning is unlikely
+  # to be anything other than annoying.
+  tern_config = os.path.expanduser( '~/.tern-config' )
+  if GlobalConfigExists( tern_config ):
+    return tern_config
+
+  return None
 
 
 class TernCompleter( Completer ):

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -81,6 +81,16 @@ def FindTernProjectFile( starting_directory ):
     if os.path.exists( tern_project ):
       return tern_project
 
+  # As described here: http://ternjs.net/doc/manual.html#server a global
+  # .tern-config file is also supported for the Tern server. This can provide
+  # meaningful defaults (for libs, and possibly also for require paths), so
+  # don't warn if we find one. The point is that if the user has a .tern-config
+  # set up, then she has deliberately done so and a ycmd warning is unlikely
+  # to be anything other than annoying.
+  tern_config = os.path.expanduser( '~/.tern-config' )
+  if os.path.exists( tern_config ):
+    return tern_config
+
   return None
 
 
@@ -107,6 +117,11 @@ class TernCompleter( Completer ):
 
 
   def _WarnIfMissingTernProject( self ):
+    # The Tern server will operate without a .tern-project file. However, it
+    # does not operate optimally, and will likely lead to issues reported that
+    # JavaScript completion is not working properly. So we raise a warning if we
+    # aren't able to detect some semblance of manual Tern configuration.
+
     # We do this check after the server has started because the server does
     # have nonzero use without a project file, however limited. We only do this
     # check once, though because the server can only handle one project at a
@@ -120,7 +135,8 @@ class TernCompleter( Completer ):
       if not tern_project:
         _logger.warning( 'No .tern-project file detected: ' + os.getcwd() )
         raise RuntimeError( 'Warning: Unable to detect a .tern-project file '
-                            'in the hierarchy before ' + os.getcwd() + '. '
+                            'in the hierarchy before ' + os.getcwd() +
+                            ' and no global .tern-config file was found. '
                             'This is required for accurate JavaScript '
                             'completion. Please see the User Guide for '
                             'details.' )

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -60,8 +60,8 @@ class Javascript_EventNotification_test( Javascript_Handlers_test ):
     assert_that( response.json, empty() )
 
 
-  @patch( 'ycmd.completers.javascript.tern_completer.PathToGlobalTernConfig',
-          return_value = None )
+  @patch( 'ycmd.completers.javascript.tern_completer.GlobalConfigExists',
+          return_value = False )
   def OnFileReadyToParse_NoProjectFile_test( self, *args ):
     # We raise an error if we can't detect a .tern-project file.
     # We only do this on the first OnFileReadyToParse event after a
@@ -147,8 +147,8 @@ class Javascript_EventNotification_test( Javascript_Handlers_test ):
     )
 
 
-  @patch( 'ycmd.completers.javascript.tern_completer.PathToGlobalTernConfig',
-          return_value = '/dummy/path/.tern-config' )
+  @patch( 'ycmd.completers.javascript.tern_completer.GlobalConfigExists',
+          return_value = True )
   def OnFileReadyToParse_UseGlobalConfig_test( self, *args ):
     os.chdir( self._PathToTestFile( '..' ) )
 

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -66,6 +66,10 @@ class Javascript_EventNotification_test( Javascript_Handlers_test ):
     # server startup.
     os.chdir( self._PathToTestFile( '..' ) )
 
+    if os.path.exists( os.path.expanduser( '~/.tern-config' ) ):
+      raise ValueError( 'You must remove/rename your ~/.tern-config for this '
+                        'test to pass' )
+
     contents = open( self._PathToTestFile( 'simple_test.js' ) ).read()
 
     response = self._app.post_json( '/event_notification',
@@ -83,7 +87,8 @@ class Javascript_EventNotification_test( Javascript_Handlers_test ):
       response.json,
       self._ErrorMatcher( RuntimeError,
                           'Warning: Unable to detect a .tern-project file '
-                          'in the hierarchy before ' + os.getcwd() + '. '
+                          'in the hierarchy before ' + os.getcwd() +
+                          ' and no global .tern-config file was found. '
                           'This is required for accurate JavaScript '
                           'completion. Please see the User Guide for '
                           'details.' )
@@ -136,7 +141,8 @@ class Javascript_EventNotification_test( Javascript_Handlers_test ):
       response.json,
       self._ErrorMatcher( RuntimeError,
                           'Warning: Unable to detect a .tern-project file '
-                          'in the hierarchy before ' + os.getcwd() + '. '
+                          'in the hierarchy before ' + os.getcwd() +
+                          ' and no global .tern-config file was found. '
                           'This is required for accurate JavaScript '
                           'completion. Please see the User Guide for '
                           'details.' )


### PR DESCRIPTION
Fixes #277 

We simply suppress the warning if we detect a `.tern-project` or a user's `~/.tern-config`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/280)
<!-- Reviewable:end -->
