### PR TITLE
[READY] Remove timeout from Tern completer

### DIFF
--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -254,7 +254,7 @@ class TernCompleter( Completer ):
     the files are being updated.
 
     The request block should contain the optional query block only. The file
-    data and timeout are are added automatically."""
+    data are added automatically."""
 
     if not self._ServerIsRunning():
       raise ValueError( 'Not connected to server' )
@@ -271,7 +271,6 @@ class TernCompleter( Completer ):
     full_request = {
       'files': [ MakeIncompleteFile( x, file_data[ x ] )
                  for x in file_data.keys() ],
-      'timeout': 500,
     }
     full_request.update( request )
 
@@ -292,7 +291,7 @@ class TernCompleter( Completer ):
     just updating file data in which case _PostRequest should be used directly.
 
     The query block should contain the type and any parameters. The files,
-    position, timeout etc. are added automatically."""
+    position, etc. are added automatically."""
 
     def MakeTernLocation( request_data ):
       return {


### PR DESCRIPTION
Fixes #278 

As described on the issue, the Tern server exits when a timeout is hit. The Tern server's timeout is actually a guesstimate anyway, and ignores I/O time. We're better off just removing it and relying on ycmd client requests timing out. It doesn't appear that the other completers add any other time-out.

We can re-asses should https://github.com/ternjs/tern/issues/702 be fixed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/281)
<!-- Reviewable:end -->
