### PR TITLE
[READY] Properly shut down on Windows

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,14 @@
 [report]
 omit =
+    */third_party/requests/*
     */tests/*
     */__init__.py
+
+[run]
+parallel = True
+source =
+    ycmd
+
+[paths]
+source =
+    ycmd/

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+.coverage.*
 cover/
 .tox
 nosetests.xml

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -57,6 +57,11 @@ pip install -U pip wheel setuptools
 pip install -r test_requirements.txt
 npm install -g typescript
 
+# Enable coverage for Python subprocesses. See:
+# http://coverage.readthedocs.org/en/coverage-4.0.3/subprocess.html
+echo -e "import coverage\ncoverage.process_startup()" > \
+  ${PYENV_ROOT}/versions/${PYENV_VERSION}/lib/python${YCMD_PYTHON_VERSION}/site-packages/sitecustomize.py
+
 ############
 # rust setup
 ############

--- a/examples/example_client.py
+++ b/examples/example_client.py
@@ -113,10 +113,10 @@ class YcmdHandle( object ):
 
   def Shutdown( self ):
     if self.IsAlive():
-      self._popen_handle.terminate()
+      self.PostToHandlerAndLog( 'shutdown' )
 
 
-  def PostToHandlerAndLog( self, handler, data ):
+  def PostToHandlerAndLog( self, handler, data = None ):
     self._CallHttpie( 'post', handler, data )
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -192,7 +192,9 @@ def NoseTests( parsed_args, extra_nosetests_args ):
       nosetests_args.extend( COMPLETERS[ key ][ 'test' ] )
 
   if parsed_args.coverage:
-    nosetests_args += [ '--with-coverage', '--cover-package=ycmd',
+    nosetests_args += [ '--with-coverage',
+                        '--cover-erase',
+                        '--cover-package=ycmd',
                         '--cover-html' ]
 
   if extra_nosetests_args:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,6 +6,7 @@ WebTest>=2.0.20
 ordereddict>=1.1
 nose-exclude>=0.4.1
 unittest2>=1.1.0
+psutil>=3.3.0
 # This needs to be kept in sync with submodule checkout in third_party
 future==0.15.2
 codecov>=2.0.5

--- a/ycmd/__main__.py
+++ b/ycmd/__main__.py
@@ -104,6 +104,9 @@ def ParseArguments():
                               '[debug|info|warning|error|critical]' )
   parser.add_argument( '--idle_suicide_seconds', type = int, default = 0,
                        help = 'num idle seconds before server shuts down')
+  parser.add_argument( '--check_interval_seconds', type = int, default = 600,
+                       help = 'interval in seconds to check server '
+                              'inactivity' )
   parser.add_argument( '--options_file', type = str, required = True,
                        help = 'file with user options, in JSON format' )
   parser.add_argument( '--stdout', type = str, default = None,
@@ -170,7 +173,8 @@ def Main():
   handlers.UpdateUserOptions( options )
   handlers.SetHmacSecret( hmac_secret )
   SetUpSignalHandler( args.stdout, args.stderr, args.keep_logfiles )
-  handlers.app.install( WatchdogPlugin( args.idle_suicide_seconds ) )
+  handlers.app.install( WatchdogPlugin( args.idle_suicide_seconds,
+                                        args.check_interval_seconds ) )
   handlers.app.install( HmacPlugin( hmac_secret ) )
   CloseStdin()
   waitress.serve( handlers.app,

--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -43,7 +43,7 @@ from ycmd.tests.test_utils import BuildRequest
 from ycmd.user_options_store import DefaultOptions
 from ycmd.utils import ( GetUnusedLocalhostPort, OpenForStdHandle,
                          PathToCreatedTempDir, ReadFile, RemoveIfExists,
-                         SafePopen, ToBytes, ToUnicode )
+                         SafePopen, SetEnviron, ToBytes, ToUnicode )
 
 HEADERS = { 'content-type': 'application/json' }
 HMAC_HEADER = 'x-ycm-hmac'
@@ -90,6 +90,11 @@ class Client_test( object ):
       self._port = GetUnusedLocalhostPort()
       self._location = 'http://127.0.0.1:' + str( self._port )
 
+      # Define environment variable to enable subprocesses coverage. See:
+      # http://coverage.readthedocs.org/en/coverage-4.0.3/subprocess.html
+      env = os.environ.copy()
+      SetEnviron( env, 'COVERAGE_PROCESS_START', '.coveragerc' )
+
       ycmd_args = [
         sys.executable,
         PATH_TO_YCMD,
@@ -105,7 +110,8 @@ class Client_test( object ):
         _popen_handle = SafePopen( ycmd_args,
                                    stdin_windows = subprocess.PIPE,
                                    stdout = stdout,
-                                   stderr = subprocess.STDOUT )
+                                   stderr = subprocess.STDOUT,
+                                   env = env )
         self.server = psutil.Process( _popen_handle.pid )
 
 

--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -1,0 +1,231 @@
+# Copyright (C) 2016 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+from future.utils import native
+
+from base64 import b64decode, b64encode
+from hamcrest import assert_that, equal_to, has_length, is_in
+from tempfile import NamedTemporaryFile
+import functools
+import json
+import os
+import psutil
+import re
+import requests
+import subprocess
+import sys
+import time
+import urllib.parse
+
+from ycmd.hmac_utils import CreateHmac, CreateRequestHmac, SecureBytesEqual
+from ycmd.tests.test_utils import BuildRequest
+from ycmd.user_options_store import DefaultOptions
+from ycmd.utils import ( GetUnusedLocalhostPort, OpenForStdHandle,
+                         PathToCreatedTempDir, ReadFile, RemoveIfExists,
+                         SafePopen, ToBytes, ToUnicode )
+
+HEADERS = { 'content-type': 'application/json' }
+HMAC_HEADER = 'x-ycm-hmac'
+HMAC_SECRET_LENGTH = 16
+DIR_OF_THIS_SCRIPT = os.path.dirname( os.path.abspath( __file__ ) )
+PATH_TO_YCMD = os.path.join( DIR_OF_THIS_SCRIPT, '..' )
+
+
+class Client_test( object ):
+
+  def __init__( self ):
+    self._location = None
+    self._port = None
+    self._hmac_secret = None
+    self._stdout = None
+    self.server = None
+    self.subservers = []
+    self._options_dict = DefaultOptions()
+
+
+  def setUp( self ):
+    self._hmac_secret = os.urandom( HMAC_SECRET_LENGTH )
+    self._options_dict[ 'hmac_secret' ] = ToUnicode(
+      b64encode( self._hmac_secret ) )
+
+
+  def tearDown( self ):
+    if self.server.is_running():
+      self.server.terminate()
+    if self._stdout:
+      RemoveIfExists( self._stdout )
+    if self.subservers:
+      for subserver in self.subservers:
+        if subserver.is_running():
+          subserver.terminate()
+
+
+  def Start( self, idle_suicide_seconds = 60,
+             check_interval_seconds = 60 * 10 ):
+    # The temp options file is deleted by ycmd during startup
+    with NamedTemporaryFile( mode = 'w+', delete = False ) as options_file:
+      json.dump( self._options_dict, options_file )
+      options_file.flush()
+      self._port = GetUnusedLocalhostPort()
+      self._location = 'http://127.0.0.1:' + str( self._port )
+
+      ycmd_args = [
+        sys.executable,
+        PATH_TO_YCMD,
+        '--port={0}'.format( self._port ),
+        '--options_file={0}'.format( options_file.name ),
+        '--log=debug',
+        '--idle_suicide_seconds={0}'.format( idle_suicide_seconds ),
+        '--check_interval_seconds={0}'.format( check_interval_seconds ),
+      ]
+
+      self._stdout = os.path.join( PathToCreatedTempDir(), 'test.log' )
+      with OpenForStdHandle( self._stdout ) as stdout:
+        _popen_handle = SafePopen( ycmd_args,
+                                   stdin_windows = subprocess.PIPE,
+                                   stdout = stdout,
+                                   stderr = subprocess.STDOUT )
+        self.server = psutil.Process( _popen_handle.pid )
+
+
+  def _IsReady( self, filetype = None ):
+    params = { 'subserver': filetype } if filetype else None
+    response = self.GetRequest( 'ready', params )
+    response.raise_for_status()
+    return response.json()
+
+
+  def WaitUntilReady( self, filetype = None, timeout = 5 ):
+    total_slept = 0
+    while True:
+      try:
+        if total_slept > timeout:
+          raise RuntimeError( 'Waited for the server to be ready '
+                              'for {0} seconds, aborting.'.format(
+                                timeout ) )
+
+        if self._IsReady( filetype ):
+          return
+      except requests.exceptions.ConnectionError:
+        pass
+      finally:
+        time.sleep( 0.1 )
+        total_slept += 0.1
+
+
+  def StartSubserverForFiletype( self, filetype ):
+    # This automatically starts the subserver if not already started.
+    self.WaitUntilReady( filetype )
+
+    response = self.PostRequest(
+      'debug_info',
+      BuildRequest( filetype = filetype )
+    )
+    pid_match = re.search( 'process ID: (\d+)', response.json() )
+    if not pid_match:
+      raise RuntimeError( 'Cannot find PID in debug informations for {0} '
+                          'filetype.'.format( filetype ) )
+    subserver_pid = int( pid_match.group( 1 ) )
+    self.subservers.append( psutil.Process( subserver_pid ) )
+
+
+  def AssertServerAndSubserversAreRunning( self ):
+    for server in [ self.server ] + self.subservers:
+      assert_that( server.is_running(), equal_to( True ) )
+
+
+  def AssertServerAndSubserversShutDown( self, timeout = 5 ):
+    _, alive = psutil.wait_procs( [ self.server ] + self.subservers,
+                                  timeout = timeout )
+    assert_that( alive, has_length( equal_to( 0 ) ) )
+
+
+  def GetRequest( self, handler, params = None ):
+    return self._Request( 'GET', handler, params = params )
+
+
+  def PostRequest( self, handler, data = None ):
+    return self._Request( 'POST', handler, data = data )
+
+
+  def _ToUtf8Json( self, data ):
+    return ToBytes( json.dumps( data ) if data else None )
+
+
+  def _Request( self, method, handler, data = None, params = None ):
+    request_uri = self._BuildUri( handler )
+    data = self._ToUtf8Json( data )
+    headers = self._ExtraHeaders( method,
+                                  request_uri,
+                                  data )
+    response = requests.request( method,
+                                 request_uri,
+                                 headers = headers,
+                                 data = data,
+                                 params = params )
+    return response
+
+
+  def _BuildUri( self, handler ):
+    return native( ToBytes( urllib.parse.urljoin( self._location, handler ) ) )
+
+
+  def _ExtraHeaders( self, method, request_uri, request_body = None ):
+    if not request_body:
+      request_body = bytes( b'' )
+    headers = dict( HEADERS )
+    headers[ HMAC_HEADER ] = b64encode(
+        CreateRequestHmac( ToBytes( method ),
+                           ToBytes( urllib.parse.urlparse( request_uri ).path ),
+                           request_body,
+                           self._hmac_secret ) )
+    return headers
+
+
+  def AssertResponse( self, response ):
+    assert_that( response.status_code, equal_to( requests.codes.ok ) )
+    assert_that( HMAC_HEADER, is_in( response.headers ) )
+    assert_that(
+      self._ContentHmacValid( response ),
+      equal_to( True )
+    )
+
+
+  def _ContentHmacValid( self, response ):
+    our_hmac = CreateHmac( response.content, self._hmac_secret )
+    their_hmac = ToBytes( b64decode( response.headers[ HMAC_HEADER ] ) )
+    return SecureBytesEqual( our_hmac, their_hmac )
+
+
+  @staticmethod
+  def CaptureOutputFromServer( test ):
+    @functools.wraps( test )
+    def Wrapper( self, *args ):
+      try:
+        test( self, *args )
+      finally:
+        if self._stdout:
+          sys.stdout.write( ReadFile( self._stdout ) )
+
+    return Wrapper

--- a/ycmd/tests/shutdown_test.py
+++ b/ycmd/tests/shutdown_test.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2016 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from hamcrest import assert_that, equal_to
+
+from ycmd.tests.client_test import Client_test
+
+
+class Shutdown_test( Client_test ):
+
+  @Client_test.CaptureOutputFromServer
+  def FromHandlerWithoutSubserver_test( self ):
+    self.Start()
+    self.WaitUntilReady()
+    self.AssertServerAndSubserversAreRunning()
+
+    response = self.PostRequest( 'shutdown' )
+    self.AssertResponse( response )
+    assert_that( response.json(), equal_to( True ) )
+    self.AssertServerAndSubserversShutDown( timeout = 5 )
+
+
+  @Client_test.CaptureOutputFromServer
+  def FromHandlerWithSubservers_test( self ):
+    self.Start()
+    self.WaitUntilReady()
+
+    # C# subserver cannot be started without a solution file so we don't test
+    # it.
+    filetypes = [ 'go',
+                  'javascript',
+                  'python',
+                  'typescript',
+                  'rust' ]
+    for filetype in filetypes:
+      self.StartSubserverForFiletype( filetype )
+    self.AssertServerAndSubserversAreRunning()
+
+    response = self.PostRequest( 'shutdown' )
+    self.AssertResponse( response )
+    assert_that( response.json(), equal_to( True ) )
+    self.AssertServerAndSubserversShutDown( timeout = 5 )
+
+
+  @Client_test.CaptureOutputFromServer
+  def FromWatchdogWithoutSubserver_test( self ):
+    self.Start( idle_suicide_seconds = 2, check_interval_seconds = 1 )
+    self.WaitUntilReady()
+    self.AssertServerAndSubserversAreRunning()
+
+    self.AssertServerAndSubserversShutDown( timeout = 5 )
+
+
+  @Client_test.CaptureOutputFromServer
+  def FromWatchdogWithSubservers_test( self ):
+    self.Start( idle_suicide_seconds = 2, check_interval_seconds = 1 )
+    self.WaitUntilReady()
+
+    # C# subserver cannot be started without a solution file so we don't test
+    # it.
+    filetypes = [ 'go',
+                  'javascript',
+                  'python',
+                  'typescript',
+                  'rust' ]
+    for filetype in filetypes:
+      self.StartSubserverForFiletype( filetype )
+    self.AssertServerAndSubserversAreRunning()
+
+    self.AssertServerAndSubserversShutDown( timeout = 5 )

--- a/ycmd/watchdog_plugin.py
+++ b/ycmd/watchdog_plugin.py
@@ -47,7 +47,7 @@ class WatchdogPlugin( object ):
 
   def __init__( self,
                 idle_suicide_seconds,
-                check_interval_seconds = 60 * 10 ):
+                check_interval_seconds ):
     self._check_interval_seconds = check_interval_seconds
     self._idle_suicide_seconds = idle_suicide_seconds
 

--- a/ycmd/watchdog_plugin.py
+++ b/ycmd/watchdog_plugin.py
@@ -24,10 +24,12 @@ standard_library.install_aliases()
 from builtins import *  # noqa
 
 import time
-import os
 import copy
-from ycmd import utils
+import logging
 from threading import Thread, Lock
+from ycmd.handlers import ServerShutdown
+
+_logger = logging.getLogger( __name__ )
 
 
 # This class implements the Bottle plugin API:
@@ -95,7 +97,8 @@ class WatchdogPlugin( object ):
       # wait interval to contact us before we die.
       if (self._TimeSinceLastRequest() > self._idle_suicide_seconds and
           self._TimeSinceLastWakeup() < 2 * self._check_interval_seconds):
-        utils.TerminateProcess( os.getpid() )
+        _logger.info( 'Shutting down server due to inactivity' )
+        ServerShutdown()
 
       self._UpdateLastWakeupTime()
 

--- a/ycmd/wsgi_server.py
+++ b/ycmd/wsgi_server.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2016 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from future.utils import listvalues
+from waitress.server import TcpWSGIServer
+import select
+
+
+class StoppableWSGIServer( TcpWSGIServer ):
+  """StoppableWSGIServer is a subclass of the TcpWSGIServer Waitress server
+  with a shutdown method. It is based on StopableWSGIServer class from webtest:
+  https://github.com/Pylons/webtest/blob/master/webtest/http.py"""
+
+  shutdown_requested = False
+
+  def Run( self ):
+    """Wrapper of TcpWSGIServer run method. It prevents a traceback from
+    asyncore."""
+    try:
+      self.run()
+    except select.error:
+      if not self.shutdown_requested:
+        raise
+
+
+  def Shutdown( self ):
+    """Properly shutdown the server."""
+    self.shutdown_requested = True
+    # Shutdown waitress threads.
+    self.task_dispatcher.shutdown()
+    # Close asyncore channels.
+    # We don't use itervalues here because _map is modified while looping
+    # through it.
+    # NOTE: _map is an attribute from the asyncore.dispatcher class, which is a
+    # base class of TcpWSGIServer. This may change in future versions of
+    # waitress so extra care should be taken when updating waitress.
+    for channel in listvalues( self._map ):
+      channel.close()


### PR DESCRIPTION
### Problem

When killing a process on Windows, it is terminated like it received a `SIGKILL` signal on Linux. This means that @atexit functions will not be called. In our case, `ServerCleanup` is not executed:
completers `Shutdown` methods are not called, neither the `Shutdown` function in the global extra conf. In particular, subservers like `OmniSharpServer` and `Tern.js` are left running.
This issue happens in two situations:
 - [a client like YCM terminates the ycmd server](https://github.com/Valloric/YouCompleteMe/blob/master/python/ycm/youcompleteme.py#L175);
 - [watchdog plugin pulls the trigger](https://github.com/Valloric/ycmd/blob/master/ycmd/watchdog_plugin.py#L92).

How to solve it?

### Solution

First situation should be solved by adding a new handler `/shutdown` to properly shut down the ycmd server from a client. Unfortunately, `waitress` and `bottle` don't provide an easy way to shut it down. Using `sys.exit()` in the `/shutdown` handler will not work because it is run in a thread. The solution is to use the same mechanism as in the watchdog plugin. After cleaning up, we start a thread to immediately kill the server.
Second situation is fixed by using the function associated to the `/shutdown` handler in the watchdog plugin.

### Tests

To test that the shutdown handler and the watchdog plugin are properly working, we need to start the ycmd server for real. We cannot use [webtest](https://webtest.readthedocs.org/en/latest/) here. I added 4 tests, which are a combination of shutting down ycmd without and with a subserver, from a request and from the watchdog plugin.
[psutil](http://pythonhosted.org/psutil/) module was added to the test requirements to work with processes in a portable way.
In order to test the watchdog plugin, I added a command-line argument to set the `check_interval_seconds` variable.
Since we are starting subprocesses in those tests, some changes were needed to enable coverage in Python subprocesses. Another change to improve coverage was to update Waitress to version 0.8.10. See the commit message for some explanation.
A benefit of those tests is a significant increase in coverage (~6%).

###  Caveats

- Tests may introduce flakyness. Robustness should be improved;
- Coverage seems to cause issue with the Gocode daemon. Not sure if it is related to this PR. Need to investigate.

### Next

- Update YCM to use the `shutdown` handler (fix issue Valloric/YouCompleteMe#876);
- Fix logfiles clean up on Windows.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/282)
<!-- Reviewable:end -->
