### PR TITLE
[READY] Fix python error on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,11 @@ install:
   - git submodule update --init --recursive
   - ps: $env:python = if ($env:arch -eq 32) { 'C:\Python27' } else { 'C:\Python27-x64' }
   - set PATH=%python%;%python%\Scripts;%PATH%
+  - python --version
+  # Manually setting PYTHONHOME for python 2.7.11 fix the following error when
+  # running core tests: "ImportError: No module named site"
+  # TODO: check if this is still needed when python 2.7.12 is released.
+  - set PYTHONHOME=%python%
   - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'C:\get-pip.py')
   - python C:\get-pip.py
   - pip install -r test_requirements.txt


### PR DESCRIPTION
AppVeyor just updated python to 2.7.11 and core tests are now failing with the error `ImportError: No module named site`. Setting `PYTHONHOME` environment variable fix this issue. It may be related to [this python issue](http://bugs.python.org/issue25824) even if I cannot reproduce it on my setup. I expect this issue to be fixed with the next python release but for the time being, use this workaround.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/283)
<!-- Reviewable:end -->
