### PR TITLE
Fixed names for CMake generators, used on Windows.

### DIFF
--- a/build.py
+++ b/build.py
@@ -158,11 +158,11 @@ def CustomPythonCmakeArgs():
 def GetGenerator( args ):
   if OnWindows():
     if args.msvc == 14:
-      generator = 'Visual Studio 14 2015'
+      generator = 'Visual Studio 14'
     elif args.msvc == 12:
-      generator = 'Visual Studio 12 2013'
+      generator = 'Visual Studio 12'
     else:
-      generator = 'Visual Studio 11 2012'
+      generator = 'Visual Studio 11'
 
     if ( not args.arch and platform.architecture()[ 0 ] == '64bit'
          or args.arch == 64 ):


### PR DESCRIPTION
Basicaly, everything is in the name.

When I tried to build ycmd on Windows I found out that build script uses wrong names for all generators, that are used to build project on Windows.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/285)
<!-- Reviewable:end -->
