### PR TITLE
Remove unused method

### DIFF
--- a/ycmd/server_state.py
+++ b/ycmd/server_state.py
@@ -94,10 +94,6 @@ class ServerState( object ):
              self.FiletypeCompletionAvailable( filetypes ) )
 
 
-  def ShouldUseGeneralCompleter( self, request_data ):
-    return self._gencomp.ShouldUseNow( request_data )
-
-
   def ShouldUseFiletypeCompleter( self, request_data ):
     """
     Determines whether or not the semantic completer should be called, and


### PR DESCRIPTION
I was looking at the coverage and I noticed that this method is not tested, a quick grep on the codebase showed why: we apparently don't use it.