### PR TITLE
Use 127.0.0.1 instead of localhost in C♯ completer

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -584,7 +584,7 @@ class CsharpSolutionCompleter:
 
 
   def _ServerLocation( self ):
-    return 'http://localhost:' + str( self._omnisharp_port )
+    return 'http://127.0.0.1:' + str( self._omnisharp_port )
 
 
   def _GetResponse( self, handler, parameters = {}, timeout = None ):


### PR DESCRIPTION
Use `127.0.0.1` because `localhost` may not be defined by the OS.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/288)
<!-- Reviewable:end -->
