### PR TITLE
Improves semantic trigger match.

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -97,6 +97,9 @@ def _MatchesSemanticTrigger( line_value, start_column, trigger_list ):
   if not line_length or start_column > line_length:
     return False
 
+  # ignore characters after user's caret column
+  line_value = line_value[ :start_column ]
+
   match = False
   for trigger in trigger_list:
     match = ( _StringTriggerMatches( trigger, line_value, start_column )


### PR DESCRIPTION
Improves semantic trigger match.

Match triggers until user's caret column solely. Trying to match
triggers with characters after user's caret column doesn't seem
to have any utility.

---

This is the first in a series of pull-requests that will transparently enable
#1300 for any completer that cares for. After this minimal foundation is
stablished, an initial Swift completer will be available, supporting diagnostics,
fix-it's, semantic completion and argument hints. Changes will also be
proposed to enable hints for C and C++.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/292)
<!-- Reviewable:end -->
