### PR TITLE
Add FindUsages subcommand in jedi completer

### DIFF
--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -239,6 +239,8 @@ class JediCompleter( Completer ):
                            self._GoTo( request_data ) ),
       'GetDoc'         : ( lambda self, request_data, args:
                            self._GetDoc( request_data ) ),
+      'GoToReferences' : ( lambda self, request_data, args:
+                           self._GoToReferences( request_data ) ),
       'StopServer'     : ( lambda self, request_data, args:
                            self.Shutdown() ),
       'RestartServer'  : ( lambda self, request_data, args:
@@ -278,6 +280,13 @@ class JediCompleter( Completer ):
       return self._BuildDetailedInfoResponse( definitions )
     except Exception:
       raise RuntimeError( 'Can\'t find a definition.' )
+
+
+  def _GoToReferences( self, request_data ):
+    definitions = self._GetDefinitionsList( '/usages', request_data )
+    if not definitions:
+      raise RuntimeError( 'Can\'t find references.' )
+    return self._BuildGoToResponse( definitions )
 
 
   def _GetDefinitionsList( self, handler, request_data ):

--- a/ycmd/tests/python/subcommands_test.py
+++ b/ycmd/tests/python/subcommands_test.py
@@ -167,3 +167,43 @@ inception()
     eq_( response, {
       'detailed_info': 'Class Documentation',
     } )
+
+
+  def GoToReferences_test( self ):
+    filepath = self._PathToTestFile( 'goto_references.py' )
+    contents = open( filepath ).read()
+
+    event_data = self._BuildRequest( filepath = filepath,
+                                     filetype = 'python',
+                                     line_num = 4,
+                                     column_num = 5,
+                                     contents = contents,
+                                     command_arguments = [ 'GoToReferences' ],
+                                     completer_target = 'filetype_default' )
+
+    response = self._app.post_json( '/run_completer_command', event_data ).json
+
+    eq_( response, [ {
+      'filepath': self._PathToTestFile( 'goto_references.py' ),
+      'column_num': 5,
+      'description': 'def f',
+      'line_num': 1
+    },
+    {
+      'filepath': self._PathToTestFile( 'goto_references.py' ),
+      'column_num': 5,
+      'description': 'a = f()',
+      'line_num': 4
+    },
+    {
+      'filepath': self._PathToTestFile( 'goto_references.py' ),
+      'column_num': 5,
+      'description': 'b = f()',
+      'line_num': 5
+    },
+    {
+      'filepath': self._PathToTestFile( 'goto_references.py' ),
+      'column_num': 5,
+      'description': 'c = f()',
+      'line_num': 6
+    } ] )

--- a/ycmd/tests/python/testdata/goto_references.py
+++ b/ycmd/tests/python/testdata/goto_references.py
@@ -1,0 +1,6 @@
+def f():
+  pass
+
+a = f()
+b = f()
+c = f()


### PR DESCRIPTION
The feature to find usages/references of thing at point has been added recently to JediHTTP https://github.com/vheon/JediHTTP/commit/c7104b199f22082070fa669e52e2f5aac312ffb7.

This patch adds a subcommand in python completer to get usages.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/298)
<!-- Reviewable:end -->
