### PR TITLE
Error message when rust_src_path unset

### DIFF
--- a/ycmd/tests/rust/get_completions_test.py
+++ b/ycmd/tests/rust/get_completions_test.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-from hamcrest import assert_that, has_items
+from hamcrest import assert_that, has_entry, has_items, contains_string
 from rust_handlers_test import Rust_Handlers_test
 
 
@@ -43,3 +43,24 @@ class Rust_GetCompletions_test( Rust_Handlers_test ):
     assert_that( results,
                  has_items( self._CompletionEntryMatcher( 'build_rocket' ),
                             self._CompletionEntryMatcher( 'build_shuttle' ) ) )
+
+
+  def WhenStandardLibraryCompletionFails_MentionRustSrcPath_test( self ):
+    filepath = self._PathToTestFile( 'std_completions.rs' )
+    contents = open( filepath ).read()
+
+    self._WaitUntilServerReady()
+
+    completion_data = self._BuildRequest( filepath = filepath,
+                                          filetype = 'rust',
+                                          contents = contents,
+                                          force_semantic = True,
+                                          line_num = 5,
+                                          column_num = 11 )
+
+    response = self._app.post_json( '/completions',
+                                    completion_data,
+                                    expect_errors = True ).json
+    assert_that( response,
+                 has_entry( 'message',
+                            contains_string( 'rust_src_path' ) ) )

--- a/ycmd/tests/rust/testdata/std_completions.rs
+++ b/ycmd/tests/rust/testdata/std_completions.rs
@@ -1,0 +1,7 @@
+use std::path::Path;
+
+pub fn main() {
+  let program = Path::new( "/foo" );
+  program.
+}
+


### PR DESCRIPTION
If a completion request to racerd fails AND the user has not set the
rust_src_path config option, then we return a nice error message
mentioning to the user that they likely reason of the failure is the
empty value for that option. This should provide the user with something
to search for in the YCM docs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/299)
<!-- Reviewable:end -->
