### PR TITLE
Removes dead code.

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -70,20 +70,6 @@ def _FiletypeDictUnion( dict_one, dict_two ):
   return final_dict
 
 
-def _StringTriggerMatches( trigger, line_value, start_column ):
-  index = -1
-  trigger_length = len( trigger )
-  while True:
-    line_index = start_column + index
-    if line_index < 0 or line_value[ line_index ] != trigger[ index ]:
-      break
-
-    if abs( index ) == trigger_length:
-      return True
-    index -= 1
-  return False
-
-
 def _RegexTriggerMatches( trigger, line_value, start_column ):
   for match in trigger.finditer( line_value ):
     if match.end() == start_column:
@@ -100,12 +86,8 @@ def _MatchesSemanticTrigger( line_value, start_column, trigger_list ):
   # ignore characters after user's caret column
   line_value = line_value[ :start_column ]
 
-  match = False
   for trigger in trigger_list:
-    match = ( _StringTriggerMatches( trigger, line_value, start_column )
-        if isinstance( trigger, basestring ) else
-        _RegexTriggerMatches( trigger, line_value, start_column ) )
-    if match:
+    if _RegexTriggerMatches( trigger, line_value, start_column ):
       return True
   return False
 

--- a/ycmd/completers/completer_utils_test.py
+++ b/ycmd/completers/completer_utils_test.py
@@ -67,47 +67,49 @@ def FiletypeDictUnion_Works_test():
 
 
 def MatchesSemanticTrigger_Basic_test():
-  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 7, ['.'] ) )
-  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 6, ['.'] ) )
-  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 5, ['.'] ) )
+  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 7, [cu._PrepareTrigger( '.' )] ) )
+  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 6, [cu._PrepareTrigger( '.' )] ) )
+  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 5, [cu._PrepareTrigger( '.' )] ) )
 
-  ok_( cu._MatchesSemanticTrigger( 'foo.bar', 4, ['.'] ) )
+  ok_( cu._MatchesSemanticTrigger( 'foo.bar', 4, [cu._PrepareTrigger( '.' )] ) )
 
-  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 3, ['.'] ) )
-  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 2, ['.'] ) )
-  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 1, ['.'] ) )
-  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 0, ['.'] ) )
+  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 3, [cu._PrepareTrigger( '.' )] ) )
+  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 2, [cu._PrepareTrigger( '.' )] ) )
+  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 1, [cu._PrepareTrigger( '.' )] ) )
+  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 0, [cu._PrepareTrigger( '.' )] ) )
 
 
 def MatchesSemanticTrigger_JustTrigger_test():
-  ok_( cu._MatchesSemanticTrigger( '.', 1, ['.'] ) )
-  ok_( not cu._MatchesSemanticTrigger( '.', 0, ['.'] ) )
+  ok_( cu._MatchesSemanticTrigger( '.', 1, [cu._PrepareTrigger( '.' )] ) )
+  ok_( not cu._MatchesSemanticTrigger( '.', 0, [cu._PrepareTrigger( '.' )] ) )
 
 
 def MatchesSemanticTrigger_TriggerBetweenWords_test():
-  ok_( cu._MatchesSemanticTrigger( 'foo . bar', 5, ['.'] ) )
+  ok_( cu._MatchesSemanticTrigger( 'foo . bar', 5, [cu._PrepareTrigger( '.' )] ) )
 
 
 def MatchesSemanticTrigger_BadInput_test():
-  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 10, ['.'] ) )
-  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', -1, ['.'] ) )
-  ok_( not cu._MatchesSemanticTrigger( '', -1, ['.'] ) )
-  ok_( not cu._MatchesSemanticTrigger( '', 0, ['.'] ) )
-  ok_( not cu._MatchesSemanticTrigger( '', 1, ['.'] ) )
+  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 10, [cu._PrepareTrigger( '.' )] ) )
+  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', -1, [cu._PrepareTrigger( '.' )] ) )
+  ok_( not cu._MatchesSemanticTrigger( '', -1, [cu._PrepareTrigger( '.' )] ) )
+  ok_( not cu._MatchesSemanticTrigger( '', 0, [cu._PrepareTrigger( '.' )] ) )
+  ok_( not cu._MatchesSemanticTrigger( '', 1, [cu._PrepareTrigger( '.' )] ) )
   ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 4, [] ) )
 
 
 def MatchesSemanticTrigger_TriggerIsWrong_test():
-  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 4, [':'] ) )
+  ok_( not cu._MatchesSemanticTrigger( 'foo.bar', 4, [cu._PrepareTrigger( ':' )] ) )
 
 
 def MatchesSemanticTrigger_LongerTrigger_test():
-  ok_( cu._MatchesSemanticTrigger( 'foo::bar', 5, ['::'] ) )
-  ok_( not cu._MatchesSemanticTrigger( 'foo::bar', 4, ['::'] ) )
+  ok_( cu._MatchesSemanticTrigger( 'foo::bar', 5, [cu._PrepareTrigger( '::' )] ) )
+  ok_( not cu._MatchesSemanticTrigger( 'foo::bar', 4, [cu._PrepareTrigger( '::' )] ) )
 
 
 def MatchesSemanticTrigger_OneTriggerMatches_test():
-  ok_( cu._MatchesSemanticTrigger( 'foo::bar', 5, ['.', ';', '::'] ) )
+  ok_( cu._MatchesSemanticTrigger( 'foo::bar', 5, [cu._PrepareTrigger( '.' ),
+                                                   cu._PrepareTrigger( ';' ),
+                                                   cu._PrepareTrigger( '::' )] ) )
 
 
 def MatchesSemanticTrigger_RegexTrigger_test():


### PR DESCRIPTION
Since regex triggers have been enabled, _StringTriggerMatches was
actually not in use anymore since _PrepareTrigger always return
regexes, making triggers never a instance of basestring.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/300)
<!-- Reviewable:end -->
