### PR TITLE
[READY] Fix RestartServer command in Python completer

### DIFF
--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -104,7 +104,7 @@ class JediCompleter( Completer ):
         return False
 
 
-  def RestartServer( self, request_data ):
+  def RestartServer( self ):
     """ Restart the JediHTTP Server. """
     with self._server_lock:
       self._StopServer()


### PR DESCRIPTION
`RestartServer` subcommand is not working because the `request_data` parameter is not given to the `RestartServer` method. Since this parameter is not used, remove it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/303)
<!-- Reviewable:end -->
