### PR TITLE
Remove CMake legacy mode for cygwin

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -29,13 +29,6 @@ else()
   endif()
 endif()
 
-
-# Disable CMake legacy mode for Cygwin, since the build doesn't depend on
-# WIN32 being set for Cygwin, and this property being unset causes a
-# warning in Cygwin.
-# Remove when CMake >= 2.8.4 is required, since that implicitly sets this
-set( CMAKE_LEGACY_CYGWIN_WIN32 0 )
-
 project( YouCompleteMe )
 
 # Get the core version


### PR DESCRIPTION
Remove CMAKE_LEGACY_CYGWIN_WIN32, since we are now requiring CMake >=
2.8.4, where it was forced to our current setting and only produces a
warning when set.

Reverts https://github.com/Valloric/YouCompleteMe/commit/aa719665da7c726cefdc417a93c90830c45ec0b0

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/308)
<!-- Reviewable:end -->
