### PR TITLE
[READY] Prevent simultaneous starts of OmniSharp server

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -227,11 +227,15 @@ class CsharpCompleter( Completer ):
   def OnFileReadyToParse( self, request_data ):
     solutioncompleter = self._GetSolutionCompleter( request_data )
 
+    # Only start the server associated to this solution if the option to
+    # automatically start one is set and no server process is already running.
     if ( self.user_options[ 'auto_start_csharp_server' ]
          and not solutioncompleter.ServerIsActive() ):
       solutioncompleter._StartServer()
       return
 
+    # Bail out if the server is unresponsive. We don't start or restart the
+    # server in this case because current one may still be warming up.
     if not solutioncompleter.ServerIsRunning():
       return
 

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -227,8 +227,8 @@ class CsharpCompleter( Completer ):
   def OnFileReadyToParse( self, request_data ):
     solutioncompleter = self._GetSolutionCompleter( request_data )
 
-    if ( not solutioncompleter.ServerIsActive() and
-         self.user_options[ 'auto_start_csharp_server' ] ):
+    if ( self.user_options[ 'auto_start_csharp_server' ]
+         and not solutioncompleter.ServerIsActive() ):
       solutioncompleter._StartServer()
       return
 

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -555,8 +555,7 @@ class CsharpSolutionCompleter:
 
   def ServerIsActive( self ):
     """ Check if our OmniSharp server is active (started, not yet stopped)."""
-    return ( self._omnisharp_phandle is not None and
-             self._omnisharp_phandle.poll() is None )
+    return utils.ProcessIsRunning( self._omnisharp_phandle )
 
 
   def ServerIsRunning( self ):
@@ -583,8 +582,7 @@ class CsharpSolutionCompleter:
 
   def ServerTerminated( self ):
     """ Check if the server process has already terminated. """
-    return ( self._omnisharp_phandle is not None and
-             self._omnisharp_phandle.poll() is not None )
+    return not utils.ProcessIsRunning( self._omnisharp_phandle )
 
 
   def _SolutionFile( self ):

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -440,8 +440,7 @@ class TernCompleter( Completer ):
 
 
   def _ServerIsRunning( self ):
-    return ( self._server_handle is not None and
-             self._server_handle.poll() is None )
+    return utils.ProcessIsRunning( self._server_handle )
 
 
   def _GetType( self, request_data ):

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -131,7 +131,7 @@ def GetHealthy():
   _logger.info( 'Received health request' )
   if request.query.include_subservers:
     cs_completer = _server_state.GetFiletypeCompleter( ['cs'] )
-    return _JsonResponse( cs_completer.ServerIsRunning() )
+    return _JsonResponse( cs_completer.ServerIsHealthy() )
   return _JsonResponse( True )
 
 

--- a/ycmd/tests/cs/cs_handlers_test.py
+++ b/ycmd/tests/cs/cs_handlers_test.py
@@ -57,11 +57,11 @@ class Cs_Handlers_test( Handlers_test ):
         success = True
         break
       request = self._BuildRequest( completer_target = 'filetype_default',
-                                    command_arguments = [ 'ServerTerminated' ],
+                                    command_arguments = [ 'ServerIsActive' ],
                                     filepath = filename,
                                     filetype = 'cs' )
       result = self._app.post_json( '/run_completer_command', request ).json
-      if result:
+      if not result:
         raise RuntimeError( "OmniSharp failed during startup." )
       time.sleep( 0.2 )
       retries = retries - 1

--- a/ycmd/tests/cs/cs_handlers_test.py
+++ b/ycmd/tests/cs/cs_handlers_test.py
@@ -57,7 +57,7 @@ class Cs_Handlers_test( Handlers_test ):
         success = True
         break
       request = self._BuildRequest( completer_target = 'filetype_default',
-                                    command_arguments = [ 'ServerIsActive' ],
+                                    command_arguments = [ 'ServerIsRunning' ],
                                     filepath = filename,
                                     filetype = 'cs' )
       result = self._app.post_json( '/run_completer_command', request ).json

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -171,6 +171,10 @@ def OnTravis():
   return 'TRAVIS' in os.environ
 
 
+def ProcessIsRunning( handle ):
+  return handle is not None and handle.poll() is None
+
+
 # From here: http://stackoverflow.com/a/8536476/1672783
 def TerminateProcess( pid ):
   if OnWindows():


### PR DESCRIPTION
Currently, C# completer starts a new server on the `FileReadyToParse` event if no port is defined or the running server does not respond. This can lead to situations where multiple servers with same port and solution are started until one of them become ready. See PR #284 and Valloric/YouCompleteMe#1913. 

This is fixed by using `ServerIsActive` instead of `ServerIsRunning` to start the server in `OnFileReadyToParse`. We then check `ServerIsRunning` for an early return.

`ServerIsActive` is updated to check the handle (instead of the port) and to poll the process. We cannot only rely on the port because it can be defined while the process is down: server crashed during start up or its process was directly terminated by the user.

`ServerIsRunning` and `ServerIsReady` are also changed. We return early in both methods by checking `ServerIsAlive` first and we restrict exceptions catching.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/310)
<!-- Reviewable:end -->
