### PR TITLE
[READY] Support for rename in tern completer

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -41,41 +41,6 @@ PATH_TO_OMNISHARP_BINARY = os.path.join(
   'OmniSharp', 'bin', 'Release', 'OmniSharp.exe' )
 
 
-# TODO: Handle this better than dummy classes
-class CsharpDiagnostic:
-  def __init__ ( self, ranges, location, location_extent, text, kind ):
-    self.ranges_ = ranges
-    self.location_ = location
-    self.location_extent_ = location_extent
-    self.text_ = text
-    self.kind_ = kind
-
-
-class CsharpFixIt:
-  def __init__ ( self, location, chunks ):
-    self.location = location
-    self.chunks = chunks
-
-
-class CsharpFixItChunk:
-  def __init__ ( self, replacement_text, range ):
-    self.replacement_text = replacement_text
-    self.range = range
-
-
-class CsharpDiagnosticRange:
-  def __init__ ( self, start, end ):
-    self.start_ = start
-    self.end_ = end
-
-
-class CsharpDiagnosticLocation:
-  def __init__ ( self, line, column, filename ):
-    self.line_number_ = line
-    self.column_number_ = column
-    self.filename_ = filename
-
-
 class CsharpCompleter( Completer ):
   """
   A Completer that uses the Omnisharp server as completion engine.
@@ -246,14 +211,15 @@ class CsharpCompleter( Completer ):
   def _QuickFixToDiagnostic( self, quick_fix ):
     filename = quick_fix[ "FileName" ]
 
-    location = CsharpDiagnosticLocation( quick_fix[ "Line" ],
-                                         quick_fix[ "Column" ], filename )
-    location_range = CsharpDiagnosticRange( location, location )
-    return CsharpDiagnostic( list(),
-                             location,
-                             location_range,
-                             quick_fix[ "Text" ],
-                             quick_fix[ "LogLevel" ].upper() )
+    location = responses.Location( quick_fix[ "Line" ],
+                                   quick_fix[ "Column" ],
+                                   filename )
+    location_range = responses.Range( location, location )
+    return responses.Diagnostic( list(),
+                                 location,
+                                 location_range,
+                                 quick_fix[ "Text" ],
+                                 quick_fix[ "LogLevel" ].upper() )
 
 
   def GetDetailedDiagnostic( self, request_data ):
@@ -513,11 +479,12 @@ class CsharpSolutionCompleter:
 
     result = self._GetResponse( '/fixcodeissue', request )
     replacement_text = result[ "Text" ]
-    location = CsharpDiagnosticLocation( request_data['line_num'],
-                                         request_data['column_num'],
-                                         request_data['filepath'] )
-    fixits = [ CsharpFixIt( location,
-                            _BuildChunks( request_data, replacement_text ) ) ]
+    location = responses.Location( request_data['line_num'],
+                                   request_data['column_num'],
+                                   request_data['filepath'] )
+    fixits = [ responses.FixIt( location,
+                                _BuildChunks( request_data,
+                                              replacement_text ) ) ]
 
     return responses.BuildFixItResponse( fixits )
 
@@ -654,10 +621,10 @@ def _BuildChunks( request_data, new_buffer ):
   ( start_line, start_column ) = _IndexToLineColumn( old_buffer, start_index )
   ( end_line, end_column ) = _IndexToLineColumn( old_buffer,
                                                  old_length - end_index )
-  start = CsharpDiagnosticLocation( start_line, start_column, filepath )
-  end = CsharpDiagnosticLocation( end_line, end_column, filepath )
-  return [ CsharpFixItChunk( replacement_text,
-                             CsharpDiagnosticRange( start, end ) ) ]
+  start = responses.Location( start_line, start_column, filepath )
+  end = responses.Location( end_line, end_column, filepath )
+  return [ responses.FixItChunk( replacement_text,
+                                 responses.Range( start, end ) ) ]
 
 
 def _FixLineEndings( old_buffer, new_buffer ):

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -188,6 +188,16 @@ class TernCompleter( Completer ):
   def OnFileReadyToParse( self, request_data ):
     self._WarnIfMissingTernProject()
 
+    # Keep tern server up to date with the file data. We do this by sending an
+    # empty request just containing the file data
+    try:
+      self._PostRequest( {}, request_data )
+    except:
+      # The server might not be ready yet or the server might not be running.
+      # in any case, just ignore this we'll hopefully get another parse request
+      # soon.
+      pass
+
 
   def GetSubcommandsMap( self ):
     return {
@@ -568,7 +578,6 @@ class TernCompleter( Completer ):
                             filename ) )
 
 
-
     def BuildFixItChunk( change ):
       return responses.FixItChunk(
         change[ 'text' ],
@@ -577,6 +586,9 @@ class TernCompleter( Completer ):
                     change[ 'end' ] ) )
 
 
+    # From an API perspective, Refactor and FixIt are the same thing - it just
+    # applies a set of changes to a set of files. So we re-use all of the
+    # existing FixIt infrastructure.
     return responses.BuildFixItResponse( [
       responses.FixIt(
         responses.Location( request_data[ 'line_num' ],

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -515,6 +515,10 @@ class TernCompleter( Completer ):
 
 
   def _Rename( self, request_data, args ):
+    if len( args ) != 1:
+      raise ValueError( 'Please specify a new name to rename it to.\n'
+                        'Usage: RefactorRename <new name>' )
+
     query = {
       'type': 'rename',
       'newName': args[ 0 ],

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -119,6 +119,7 @@ def BuildCompletionResponse( completion_datas,
     'errors': errors if errors else [],
   }
 
+
 def BuildLocationData( location ):
   return {
     'line_num': location.line_number_,
@@ -126,11 +127,61 @@ def BuildLocationData( location ):
     'filepath': location.filename_,
   }
 
+
 def BuildRangeData( source_range ):
   return {
     'start': BuildLocationData( source_range.start_ ),
     'end': BuildLocationData( source_range.end_ ),
   }
+
+
+class Diagnostic:
+  def __init__ ( self, ranges, location, location_extent, text, kind ):
+    self.ranges_ = ranges
+    self.location_ = location
+    self.location_extent_ = location_extent
+    self.text_ = text
+    self.kind_ = kind
+
+
+class FixIt:
+  """A set of replacements (of type FixItChunk) to be applied to fix a single
+  diagnostic"""
+
+  def __init__ ( self, location, chunks ):
+    """location of type Location, chunks of type list<FixItChunk>"""
+    self.location = location
+    self.chunks = chunks
+
+
+class FixItChunk:
+  """An individual replacement within a FixIt"""
+
+  def __init__ ( self, replacement_text, range ):
+    """replacement_text of type string, range of type Range"""
+    self.replacement_text = replacement_text
+    self.range = range
+
+
+class Range:
+  """Source code range relating to a diagnostic or FixIt."""
+
+  def __init__ ( self, start, end ):
+    "start of type Location, end of type Location"""
+    self.start_ = start
+    self.end_ = end
+
+
+class Location:
+  """Source code location for a diagnostic or FixIt."""
+
+  def __init__ ( self, line, column, filename ):
+    """Line is 1-based line, column is 1-based column, filename is absolute
+    path of the file"""
+    self.line_number_ = line
+    self.column_number_ = column
+    self.filename_ = filename
+
 
 def BuildDiagnosticData( diagnostic ):
 
@@ -147,6 +198,7 @@ def BuildDiagnosticData( diagnostic ):
     'kind': kind,
     'fixit_available': len( fixits ) > 0,
   }
+
 
 def BuildFixItResponse( fixits ):
   def BuildFixitChunkData( chunk ):

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -146,7 +146,8 @@ class Diagnostic:
 
 class FixIt:
   """A set of replacements (of type FixItChunk) to be applied to fix a single
-  diagnostic"""
+  diagnostic. This can be used for any type of refactoring command, not just
+  quick fixes. The individual chunks may span multiple files."""
 
   def __init__ ( self, location, chunks ):
     """location of type Location, chunks of type list<FixItChunk>"""
@@ -155,7 +156,7 @@ class FixIt:
 
 
 class FixItChunk:
-  """An individual replacement within a FixIt"""
+  """An individual replacement within a FixIt (aka Refactor)"""
 
   def __init__ ( self, replacement_text, range ):
     """replacement_text of type string, range of type Range"""
@@ -164,7 +165,7 @@ class FixItChunk:
 
 
 class Range:
-  """Source code range relating to a diagnostic or FixIt."""
+  """Source code range relating to a diagnostic or FixIt (aka Refactor)."""
 
   def __init__ ( self, start, end ):
     "start of type Location, end of type Location"""
@@ -173,7 +174,7 @@ class Range:
 
 
 class Location:
-  """Source code location for a diagnostic or FixIt."""
+  """Source code location for a diagnostic or FixIt (aka Refactor)."""
 
   def __init__ ( self, line, column, filename ):
     """Line is 1-based line, column is 1-based column, filename is absolute
@@ -201,6 +202,10 @@ def BuildDiagnosticData( diagnostic ):
 
 
 def BuildFixItResponse( fixits ):
+  """Build a response from a list of FixIt (aka Refactor) objects. This response
+  can be used to apply arbitrary changes to arbitrary files and is suitable for
+  both quick fix and refactor operations"""
+
   def BuildFixitChunkData( chunk ):
     return {
       'replacement_text': chunk.replacement_text,

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -17,10 +17,10 @@
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
 from nose.tools import eq_
-from hamcrest import (assert_that,
-                      contains,
-                      contains_inanyorder,
-                      has_entries)
+from hamcrest import ( assert_that,
+                       contains,
+                       contains_inanyorder,
+                       has_entries )
 from javascript_handlers_test import Javascript_Handlers_test
 from pprint import pformat
 import httplib
@@ -373,5 +373,26 @@ class Javascript_Subcommands_test( Javascript_Handlers_test ):
             'location': LocationMatcher( file1, 3, 14 )
           } ) )
         }
+      }
+    } )
+
+
+  def RefactorRename_Missing_New_Name_test( self ):
+    self._RunTest( {
+      'description': 'FixItRename raises an error without new name',
+      'request': {
+        'command': 'FixItRename',
+        'line_num': 17,
+        'column_num': 29,
+        'filepath': self._PathToTestFile( 'coollib', 'cool_object.js' ),
+      },
+      'expect': {
+        'response': httplib.INTERNAL_SERVER_ERROR,
+        'data': {
+          'exception': self._ErrorMatcher(
+                                  ValueError,
+                                  'Please specify a new name to rename it to.\n'
+                                  'Usage: RefactorRename <new name>' ),
+        },
       }
     } )

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -17,10 +17,31 @@
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
 from nose.tools import eq_
-from hamcrest import assert_that, contains_inanyorder, has_entries
+from hamcrest import (assert_that,
+                      contains,
+                      contains_inanyorder,
+                      has_entries)
 from javascript_handlers_test import Javascript_Handlers_test
 from pprint import pformat
 import httplib
+
+
+def LocationMatcher( filepath, column_num, line_num ):
+  return has_entries( {
+    'line_num': line_num,
+    'column_num': column_num,
+    'filepath': filepath
+  } )
+
+
+def ChunkMatcher( replacement_text, start, end ):
+  return has_entries( {
+    'replacement_text': replacement_text,
+    'range': has_entries( {
+      'start': start,
+      'end': end
+    } )
+  } )
 
 
 class Javascript_Subcommands_test( Javascript_Handlers_test ):
@@ -76,7 +97,8 @@ class Javascript_Subcommands_test( Javascript_Handlers_test ):
                    'GetType',
                    'StartServer',
                    'StopServer',
-                   'GoToReferences' ] ),
+                   'GoToReferences',
+                   'RefactorRename' ] ),
          self._app.post_json( '/defined_subcommands',
                               subcommands_data ).json )
 
@@ -202,5 +224,154 @@ class Javascript_Subcommands_test( Javascript_Handlers_test ):
         'response': httplib.INTERNAL_SERVER_ERROR,
         'data': self._ErrorMatcher( RuntimeError, 'TernError: No type found '
                                                   'at the given position.' ),
+      }
+    } )
+
+
+  def RefactorRename_Simple_test( self ):
+    filepath = self._PathToTestFile( 'simple_test.js' )
+    self._RunTest( {
+      'description': 'RefactorRename works within a single scope/file',
+      'request': {
+        'command': 'RefactorRename',
+        'arguments': [ 'test' ],
+        'filepath': filepath,
+        'line_num': 15,
+        'column_num': 32,
+      },
+      'expect': {
+        'response': httplib.OK,
+        'data': {
+          'fixits': contains( has_entries( {
+            'chunks': contains(
+                ChunkMatcher( 'test',
+                              LocationMatcher( filepath, 1, 5 ),
+                              LocationMatcher( filepath, 1, 22 ) ),
+                ChunkMatcher( 'test',
+                              LocationMatcher( filepath, 13, 25 ),
+                              LocationMatcher( filepath, 13, 42 ) ),
+                ChunkMatcher( 'test',
+                              LocationMatcher( filepath, 14, 24 ),
+                              LocationMatcher( filepath, 14, 41 ) ),
+                ChunkMatcher( 'test',
+                              LocationMatcher( filepath, 15, 24 ),
+                              LocationMatcher( filepath, 15, 41 ) ),
+                ChunkMatcher( 'test',
+                              LocationMatcher( filepath, 21, 7 ),
+                              LocationMatcher( filepath, 21, 24 ) ),
+                # On the same line, ensuring offsets are as expected (as
+                # unmodified source, similar to clang)
+                ChunkMatcher( 'test',
+                              LocationMatcher( filepath, 21, 28 ),
+                              LocationMatcher( filepath, 21, 45 ) ),
+            ) ,
+            'location': LocationMatcher( filepath, 15, 32 )
+          } ) )
+        }
+      }
+    } )
+
+
+  def RefactorRename_MultipleFiles_test( self ):
+    file1 = self._PathToTestFile( 'file1.js' )
+    file2 = self._PathToTestFile( 'file2.js' )
+    file3 = self._PathToTestFile( 'file3.js' )
+
+    self._RunTest( {
+      'description': 'RefactorRename works across files',
+      'request': {
+        'command': 'RefactorRename',
+        'arguments': [ 'a-quite-long-string' ],
+        'filepath': file1,
+        'line_num': 3,
+        'column_num': 14,
+      },
+      'expect': {
+        'response': httplib.OK,
+        'data': {
+          'fixits': contains( has_entries( {
+            'chunks': contains(
+              ChunkMatcher(
+                'a-quite-long-string',
+                LocationMatcher( file1, 1, 5 ),
+                LocationMatcher( file1, 1, 11 ) ),
+              ChunkMatcher(
+                'a-quite-long-string',
+                LocationMatcher( file1, 3, 14 ),
+                LocationMatcher( file1, 3, 19 ) ),
+              ChunkMatcher(
+                'a-quite-long-string',
+                LocationMatcher( file2, 2, 14 ),
+                LocationMatcher( file2, 2, 19 ) ),
+              ChunkMatcher(
+                'a-quite-long-string',
+                LocationMatcher( file3, 3, 12 ),
+                LocationMatcher( file3, 3, 17 ) )
+            ) ,
+            'location': LocationMatcher( file1, 3, 14 )
+          } ) )
+        }
+      }
+    } )
+
+
+  def RefactorRename_MultipleFiles_OnFileReadyToParse_test( self ):
+    file1 = self._PathToTestFile( 'file1.js' )
+    file2 = self._PathToTestFile( 'file2.js' )
+    file3 = self._PathToTestFile( 'file3.js' )
+
+    # This test is roughly the same as the previous one, except here file4.js is
+    # pushed into the Tern engine via 'opening it in the editor' (i.e.
+    # FileReadyToParse event). The first 3 are loaded into the tern server
+    # because they are listed in the .tern-project file's loadEagerly option.
+    file4 = self._PathToTestFile( 'file4.js' )
+
+    self._app.post_json( '/event_notification',
+                         self._BuildRequest( **{
+                           'filetype': 'javascript',
+                           'event_name': 'FileReadyToParse',
+                           'contents': open( file4 ).read(),
+                           'filepath': file4,
+                         } ),
+                         expect_errors = False )
+
+    self._RunTest( {
+      'description': 'FileReadyToParse loads files into tern server',
+      'request': {
+        'command': 'RefactorRename',
+        'arguments': [ 'a-quite-long-string' ],
+        'filepath': file1,
+        'line_num': 3,
+        'column_num': 14,
+      },
+      'expect': {
+        'response': httplib.OK,
+        'data': {
+          'fixits': contains( has_entries( {
+            'chunks': contains(
+              ChunkMatcher(
+                'a-quite-long-string',
+                LocationMatcher( file1, 1, 5 ),
+                LocationMatcher( file1, 1, 11 ) ),
+              ChunkMatcher(
+                'a-quite-long-string',
+                LocationMatcher( file1, 3, 14 ),
+                LocationMatcher( file1, 3, 19 ) ),
+              ChunkMatcher(
+                'a-quite-long-string',
+                LocationMatcher( file2, 2, 14 ),
+                LocationMatcher( file2, 2, 19 ) ),
+              ChunkMatcher(
+                'a-quite-long-string',
+                LocationMatcher( file3, 3, 12 ),
+                LocationMatcher( file3, 3, 17 ) ),
+              ChunkMatcher(
+                'a-quite-long-string',
+                LocationMatcher( file4, 4, 22 ),
+                LocationMatcher( file4, 4, 28 ) )
+            ) ,
+            'location': LocationMatcher( file1, 3, 14 )
+          } ) )
+        }
       }
     } )

--- a/ycmd/tests/javascript/testdata/.tern-project
+++ b/ycmd/tests/javascript/testdata/.tern-project
@@ -3,6 +3,11 @@
     "browser",
     "jquery"
   ],
+  "loadEagerly": [
+      "file1.js",
+      "file2.js",
+      "file3.js"
+  ],
   "plugins": {
     "requirejs": {
       "baseURL": "./",

--- a/ycmd/tests/javascript/testdata/file1.js
+++ b/ycmd/tests/javascript/testdata/file1.js
@@ -1,0 +1,4 @@
+var global = 'this is a test'
+
+console.log( global );
+

--- a/ycmd/tests/javascript/testdata/file2.js
+++ b/ycmd/tests/javascript/testdata/file2.js
@@ -1,0 +1,3 @@
+
+console.log( global );
+

--- a/ycmd/tests/javascript/testdata/file3.js
+++ b/ycmd/tests/javascript/testdata/file3.js
@@ -1,0 +1,4 @@
+
+function method( xyz ) {
+    return global
+}

--- a/ycmd/tests/javascript/testdata/file4.js
+++ b/ycmd/tests/javascript/testdata/file4.js
@@ -1,0 +1,6 @@
+// This file contains a usage of the global value 'global', but it does *not*
+// appear in .tern-project's 'loadEagerly'. This means that it does not get
+// renamed when we run the rename command.
+window.eval( 'xyz' + global );
+
+// Though it does if we tell tern about it.

--- a/ycmd/tests/javascript/testdata/simple_test.js
+++ b/ycmd/tests/javascript/testdata/simple_test.js
@@ -13,3 +13,9 @@ var simple_test_obect = {
 var simple_assignment = simple_test_obect.
 var query_assignment = simple_test_obect.typ
 var query_assignment = simple_test_obect.asf
+
+function blah( simple_test_obect ) {
+    simple_test_obect.a_simple_function;
+}
+
+blah( simple_test_obect ); simple_test_obect = null;


### PR DESCRIPTION
## Tern rename

Tern server supports renames of variables only. It can do this across multiple files, only when it knows about those files. This feature is supported by tern_for_vim, so with the addition of this feature we should have feature-parity on that front.

## Refactoring infrastructure

This re-uses the existing FixIt infrastructure, with no changes to the JSON API. The only change is that this is the first time the command will return changes in multiple files.

The largest change is moving the Cs* classes that are equivalent of the C++ classes representing diagnostics/FixIts to `responses.py`, so they can be shared by other completers.

A Vim client change is required to recognise FixIt responses by the contents of the response, rather than the command name, and to apply the chunks across files.

## FileReadyToParse

Previously, the server would only learn about files if we sent a request (such as a completion request), or by appearing in the loadEagerly list.  Now we pass the file data to the server in the parse request.  This ensures that the server knows about files as soon as possible, so that they are available for completion suggestions and for rename/etc. commands.

## Tests

Simple tests for the single- and multi-file rename cases, both eagerly loaded and picked up from parse request.

## JSON API Changes

None.

## Client changes required

* FixIt commands are now identified by the presence of `'fixit'` entry in the  response
* FixIt commands can now apply across multiple files. The client is responsible for applying the chunks in an appropriate fashion.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/311)
<!-- Reviewable:end -->
