### PR TITLE
Add --sysroot and -gcc-toolchain as INCLUDE_FLAGS

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -25,9 +25,8 @@ from ycmd import extra_conf_store
 from ycmd.utils import ToUtf8IfNeeded, OnMac, OnWindows
 from ycmd.responses import NoExtraConfDetected
 
-INCLUDE_FLAGS = [ '-isystem', '-I', '-iquote', '--sysroot=', '-isysroot',
-                  '--sysroot', '-gcc-toolchain', '-include', '-iframework',
-                  '-F', '-imacros' ]
+INCLUDE_FLAGS = [ '-isystem', '-I', '-iquote', '-isysroot', '--sysroot',
+                  '-gcc-toolchain', '-include', '-iframework', '-F', '-imacros' ]
 
 # We need to remove --fcolor-diagnostics because it will cause shell escape
 # sequences to show up in editors, which is bad. See Valloric/YouCompleteMe#1421

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -26,7 +26,8 @@ from ycmd.utils import ToUtf8IfNeeded, OnMac, OnWindows
 from ycmd.responses import NoExtraConfDetected
 
 INCLUDE_FLAGS = [ '-isystem', '-I', '-iquote', '--sysroot=', '-isysroot',
-                  '-include', '-iframework', '-F', '-imacros' ]
+                  '--sysroot', '-gcc-toolchain', '-include', '-iframework',
+                  '-F', '-imacros' ]
 
 # We need to remove --fcolor-diagnostics because it will cause shell escape
 # sequences to show up in editors, which is bad. See Valloric/YouCompleteMe#1421

--- a/ycmd/completers/cpp/tests/flags_test.py
+++ b/ycmd/completers/cpp/tests/flags_test.py
@@ -156,8 +156,8 @@ def RemoveUnusedFlags_RemoveFilenameWithoutPrecedingInclude_test():
           flags._RemoveUnusedFlags( expected + to_remove + expected[ 1: ],
                                    filename ) )
 
-  include_flags = [ '-isystem', '-I', '-iquote', '--sysroot=', '-isysroot',
-                    '-include', '-iframework', '-F', '-imacros' ]
+  include_flags = [ '-isystem', '-I', '-iquote', '-isysroot', '--sysroot',
+                    '-gcc-toolchain', '-include', '-iframework', '-F', '-imacros' ]
   to_remove = [ '/moo/boo' ]
   filename = 'file'
 


### PR DESCRIPTION
Hello,

I use YCM in a cross compiled project.
To compile the project we use '--sysroot' and '-gcc-toolchain' these directories were removed from the compiling commandline and resulted in build fails.
Therefore I added those to the INCLUDE_FLAGS.

Greetings,
Nagua

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/312)
<!-- Reviewable:end -->
