### PR TITLE
[READY] Add test for typescript MAX_DETAILED_COMPLETION

### DIFF
--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -17,13 +17,14 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-from hamcrest import assert_that, has_items
+from hamcrest import assert_that, contains_inanyorder, has_entries
 from typescript_handlers_test import Typescript_Handlers_test
+from mock import patch
 
 
 class TypeScript_GetCompletions_test( Typescript_Handlers_test ):
 
-  def Basic_test( self ):
+  def _RunTest( self, test ):
     filepath = self._PathToTestFile( 'test.ts' )
     contents = open( filepath ).read()
 
@@ -41,9 +42,37 @@ class TypeScript_GetCompletions_test( Typescript_Handlers_test ):
                                           line_num = 12,
                                           column_num = 6 )
 
-    results = self._app.post_json( '/completions',
-                                   completion_data ).json[ 'completions' ]
-    assert_that( results,
-                 has_items( self._CompletionEntryMatcher( 'methodA' ),
-                            self._CompletionEntryMatcher( 'methodB' ),
-                            self._CompletionEntryMatcher( 'methodC' ) ) )
+    response = self._app.post_json( '/completions', completion_data )
+    assert_that( response.json, test[ 'expect' ][ 'data' ] )
+
+
+  def Basic_test( self ):
+    self._RunTest( {
+      'expect': {
+        'data': has_entries( {
+          'completions': contains_inanyorder(
+            self.CompletionEntryMatcher( 'methodA',
+                                         'methodA (method) Foo.methodA(): void' ),
+            self.CompletionEntryMatcher( 'methodB',
+                                         'methodB (method) Foo.methodB(): void' ),
+            self.CompletionEntryMatcher( 'methodC',
+                                         'methodC (method) Foo.methodC(): void' ),
+          )
+        } )
+      }
+    } )
+
+
+  @patch( 'ycmd.completers.typescript.typescript_completer.MAX_DETAILED_COMPLETIONS', 2 )
+  def MaxDetailedCompletion_test( self ):
+    self._RunTest( {
+      'expect': {
+        'data': has_entries( {
+          'completions': contains_inanyorder(
+            self.CompletionEntryMatcher( 'methodA' ),
+            self.CompletionEntryMatcher( 'methodB' ),
+            self.CompletionEntryMatcher( 'methodC' )
+          )
+        } )
+      }
+    } )

--- a/ycmd/tests/typescript/typescript_handlers_test.py
+++ b/ycmd/tests/typescript/typescript_handlers_test.py
@@ -24,3 +24,12 @@ class Typescript_Handlers_test( Handlers_test ):
 
   def __init__( self ):
     self._file = __file__
+
+
+  def CompletionEntryMatcher( self, insertion_text, menu_text = None ):
+    if not menu_text:
+      menu_text = insertion_text
+
+    extra_params = { 'menu_text': menu_text }
+    return self._CompletionEntryMatcher( insertion_text,
+                                         extra_params = extra_params )


### PR DESCRIPTION
The typescript completer have some feature that are not tested; this is one of them that was also found by a user in https://github.com/Valloric/YouCompleteMe/issues/1878. I'm going to add tests for GoTo in a separate PR.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/317)
<!-- Reviewable:end -->
