### PR TITLE
[READY] Properly split EXTRA_CMAKE_ARGS environment variable in build.py script

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import os.path as p
 import sys
+import shlex
 
 major, minor = sys.version_info[ 0 : 2 ]
 if major != 2 or minor < 6:
@@ -219,7 +220,8 @@ def GetCmakeArgs( parsed_args ):
     cmake_args.append( '-DUSE_SYSTEM_BOOST=ON' )
 
   extra_cmake_args = os.environ.get( 'EXTRA_CMAKE_ARGS', '' )
-  cmake_args.extend( extra_cmake_args.split() )
+  # We use shlex split to properly parse quoted CMake arguments.
+  cmake_args.extend( shlex.split( extra_cmake_args ) )
   return cmake_args
 
 


### PR DESCRIPTION
While I was playing with `EXTRA_CMAKE_ARGS` environment variable to answer issue Valloric/YouCompleteMe#1925, I found out it was not possible to pass CMake arguments with spaces in it because the variable is split on spaces. For example:
```sh
EXTRA_CMAKE_ARGS="-DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_CXX_FLAGS='-march=native -O3'"
```
gives
```python
['-DCMAKE_VERBOSE_MAKEFILE=ON', "-DCMAKE_CXX_FLAGS='-march=native", "-O3'"]
```
which obviously fail.

This is fixed by using the [`shlex` module and its split feature](https://docs.python.org/2/library/shlex.html). With this, example above results in:
```python
['-DCMAKE_VERBOSE_MAKEFILE=ON', '-DCMAKE_CXX_FLAGS=-march=native -O3']
```
which make us happy.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/318)
<!-- Reviewable:end -->
