### PR TITLE
[READY] Support Tern plugins by installing into a sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,5 @@ cpp/BoostParts/libs/*/test
 # Exclude auto generated vim doc tags.
 doc/tags
 
-# Exclude tern instalation area
+# Exclude tern installation area
 third_party/tern_runtime/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ cpp/BoostParts/libs/*/test
 
 # Exclude auto generated vim doc tags.
 doc/tags
+
+# Exclude tern instalation area
+third_party/tern_runtime/node_modules

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "third_party/gocode"]
 	path = third_party/gocode
 	url = https://github.com/nsf/gocode.git
-[submodule "third_party/tern"]
-	path = third_party/tern
-	url = https://github.com/ternjs/tern.git
 [submodule "third_party/JediHTTP"]
 	path = third_party/JediHTTP
 	url = https://github.com/vheon/JediHTTP

--- a/build.py
+++ b/build.py
@@ -305,8 +305,37 @@ def SetUpTern():
     else:
       paths[ exe ] = path
 
-  os.chdir( p.join( DIR_OF_THIS_SCRIPT, 'third_party', 'tern' ) )
+  # We install Tern into a runtime directory. This allows us to control
+  # precisely the version (and/or git commit) that is used by ycmd.  We use a
+  # separate runtime directory rather than a submodule checkout directory
+  # because we want to allow users to install third party plugins to
+  # node_modules of the Tern runtime.  We also want to be able to install our
+  # own plugins to improve the user experience for all users.
+  #
+  # This is not possible if we use a git submodle for Tern and simply run 'npm
+  # install' within the submodule source directory, as subsequent 'npm install
+  # tern-my-plugin' will (heinously) install another (arbitrary) version of Tern
+  # within the Tern source tree (e.g. third_party/tern/node_modules/tern. The
+  # reason for this is that the plugin that gets installed has "tern" as a
+  # dependency, and npm isn't smart enough to know that you're installing
+  # *within* the Tern distribution. Or it isn't intended to work that way.
+  #
+  # So instead, we have a package.json within our "Tern runtime" directory
+  # (third_party/tern_runtime) that defines the packages that we require,
+  # including Tern and any plugins which we require as standard.
+  TERN_RUNTIME_DIR = os.path.join( DIR_OF_THIS_SCRIPT,
+                                   'third_party',
+                                   'tern_runtime' )
+  try:
+    os.makedirs( TERN_RUNTIME_DIR )
+  except Exception:
+    # os.makedirs throws if the dir already exists, it also throws if the
+    # permissions prevent creating the directory. There's no way to know the
+    # difference, so we just let the call to os.chdir below throw if this fails
+    # to create the target directory.
+    pass
 
+  os.chdir( TERN_RUNTIME_DIR )
   subprocess.check_call( [ paths[ 'npm' ], 'install', '--production' ] )
 
 

--- a/third_party/tern_runtime/package.json
+++ b/third_party/tern_runtime/package.json
@@ -1,0 +1,6 @@
+{
+  "description": "ycmd tern runtime area with required tern version and plugins",
+  "dependencies": {
+    "tern": "0.17.0"
+  }
+}

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -31,7 +31,8 @@ PATH_TO_TERNJS_BINARY = os.path.abspath(
       'third_party',
       'tern_runtime',
       'node_modules',
-      '.bin',
+      'tern',
+      'bin',
       'tern' ) )
 
 PATH_TO_NODE = utils.PathToFirstExistingExecutable( [ 'node' ] )

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -29,8 +29,9 @@ PATH_TO_TERNJS_BINARY = os.path.abspath(
       '..',
       '..',
       'third_party',
-      'tern',
-      'bin',
+      'tern_runtime',
+      'node_modules',
+      '.bin',
       'tern' ) )
 
 PATH_TO_NODE = utils.PathToFirstExistingExecutable( [ 'node' ] )
@@ -54,17 +55,11 @@ def ShouldEnableTernCompleter():
 
   _logger.info( 'Using node binary from: ' + PATH_TO_NODE )
 
-  installed = os.path.exists(
-      os.path.join( os.path.abspath( os.path.dirname( __file__ ) ),
-                    '..',
-                    '..',
-                    '..',
-                    'third_party',
-                    'tern',
-                    'node_modules' ) )
+  installed = os.path.exists( PATH_TO_TERNJS_BINARY )
 
   if not installed:
-    _logger.info( 'Not using Tern completer: not installed' )
+    _logger.info( 'Not using Tern completer: not installed at '
+                  + PATH_TO_TERNJS_BINARY )
     return False
 
   return True


### PR DESCRIPTION
# Overview

The Tern server supports a large number of plugins which add both functionality and databases of common libraries, like `express`. We want to allow users to install third party plugins to node_modules of the Tern runtime.  We also want to be able to install our own plugins to improve the user experience for all users.

This is not possible if we use a git submodule for Tern and simply run 'npm install' within the submodule source directory, as subsequent 'npm install tern-my-plugin' will (heinously) install another (arbitrary) version of Tern within the Tern source tree (e.g. third_party/tern/node_modules/tern. The reason for this is that the plugin that gets installed has "tern" as a dependency, and npm isn't smart enough to know that you're installing *within* the Tern distribution. Or it isn't intended to work that way.

So instead, we use a sandbox "runtime" directory and have a package.json within our "Tern runtime" directory (third_party/tern_runtime) that defines the packages that we require, including Tern and any plugins which we require as standard. This allows us to precisely control the version (and/or git commit) that is used by ycmd, while allowing additional plugins to be installed by users manually within a sandbox.  

An additional benefit is that users don't need to check out the history of tern when installing, so we move to a released version of tern (0.17.0) rather than a particular git checkout.

# Summary of the change

- Remove the `third_party/tern` submodule
- Create the sandbox directory and put a `package.json` in it containing just the current dependencies (just tern)
- Update the tern version to 0.17.0, to pick up some recent fixes
- Update the `build.py` to run `npm install` in the sandbox directory instead of a tern submodule checkout

# Background

A user asked about how to install Tern plugins, and I [confidently described how I expected it to work](https://github.com/Valloric/YouCompleteMe/pull/1849#issuecomment-168111295), but to my shame, [it didn't](https://github.com/Valloric/YouCompleteMe/pull/1849#issuecomment-169161304). I wasn't able to find a convenient, canonical and controlled way to continue with the submodule approach, so moving to pure `npm` approach seemed more likely to work in the future. It appears this is the expected way of doing things with npm (at least, where not instilling packages 'globally').

Additionally, there is a [real-time diagnostics plugin](https://github.com/angelozerr/tern-lint) for tern, which we may consider in future. This structure would be required to support that.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/321)
<!-- Reviewable:end -->
