### PR TITLE
CsCompleter: Revert to trapping all exceptions for status checks

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -537,7 +537,7 @@ class CsharpSolutionCompleter:
 
     try:
       return self._GetResponse( '/checkalivestatus', timeout = .2 )
-    except requests.exceptions.RequestException:
+    except Exception:
       return False
 
 
@@ -548,7 +548,7 @@ class CsharpSolutionCompleter:
 
     try:
       return self._GetResponse( '/checkreadystatus', timeout = .2 )
-    except requests.exceptions.RequestException:
+    except Exception:
       return False
 
 


### PR DESCRIPTION
I ran into a case where the Omnisharp server returned invalid json while starting up, which caused a ValueError.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/323)
<!-- Reviewable:end -->
