### PR TITLE
[READY] Ignore the branch used by Homu on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,8 @@
 version: '{build}'
+branches:
+  # Since Homu does not support AppVeyor, we ignore the branch it uses.
+  except:
+    - auto
 environment:
   USE_CLANG_COMPLETER: true
   matrix:


### PR DESCRIPTION
Homu does not support AppVeyor so there is no need to run the `auto` branch on AppVeyor.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/324)
<!-- Reviewable:end -->
