### PR TITLE
[READY] Fix error when removing temporary folder on AppVeyor

### DIFF
--- a/build.py
+++ b/build.py
@@ -38,6 +38,10 @@ def OnWindows():
   return platform.system() == 'Windows'
 
 
+def OnTravisOrAppVeyor():
+  return 'CI' in os.environ
+
+
 # On Windows, distutils.spawn.find_executable only works for .exe files
 # but .bat and .cmd files are also executables, so we use our own
 # implementation.
@@ -266,7 +270,7 @@ def BuildYcmdLibs( args ):
       RunYcmdTests( build_dir )
   finally:
     os.chdir( DIR_OF_THIS_SCRIPT )
-    rmtree( build_dir )
+    rmtree( build_dir, ignore_errors = OnTravisOrAppVeyor() )
 
 
 def BuildOmniSharp():


### PR DESCRIPTION
So there is this new error that occurs occasionally on AppVeyor:
```sh
WindowsError: [Error 145] The directory is not empty: 'c:\\users\\appveyor\\appdata\\local\\temp\\1\\ycm_build.***\\ycm\\tests'
```
It probably happens because the `ycm_core_tests` executable is still used by some process while the build folder is removed.

I see three ways to fix this:
 - ignore the error;
 - ignore it but print a warning;
 - retry several times (`3` should be enough).

I implemented the first approach because it is the simplest but I don't really like the idea of leaving (in rare cases) some files in the temporary folder (Windows does not automatically clean this folder). This is why the PR is marked as RFC. Ideally, we should implement the third approach.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/325)
<!-- Reviewable:end -->
