### PR TITLE
[READY] Pruning the size of the Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,17 @@ env:
     - YCM_CORES=1
   matrix:
     - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7
-    - USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.7
-    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6
-    - USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6
     - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7 COVERAGE=true
+    - USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6
+    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6
 matrix:
   exclude:
+    # We don't run coverage on mac and we don't run the non-coverage version of
+    # the same run on linux.
     - os: osx
       env: USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7 COVERAGE=true
+    - os: linux
+      env: USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7
 addons:
   apt:
     sources:


### PR DESCRIPTION
We used to have 9 (5 Linux, 4 Mac) rows in our test matrix; these
changes should bring it down to 6 (3 Linux, 3 Mac).

First, we cut out clang on/off for Python 2.7. There's already
two rows for clang on/off on Python 2.6, and testing the same
on/off setup with 2.7 seems wasteful. We now just test 2.7 with clang
on. This is two rows down (Linux & Mac each).

Another row killed is Linux-clang-py2.7, because we also have
Linux-clang-py2.7-coverage. That one runs all the tests and also runs
coverage, so contains the row we're killing.

All together, this should speed up our Travis runs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/335)
<!-- Reviewable:end -->
