### PR TITLE
[READY] More travis run speedups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
   global:
     - MONO_THREADS_PER_CPU=2000
     - MONO_MANAGED_WATCHER=disabled
-    # Travis can run out of RAM when compiling if we don't prevent parallelization.
-    - YCM_CORES=1
+    # Travis can run out of RAM, so we need to be careful here.
+    - YCM_CORES=3
   matrix:
     # Don't forget to take the below matrix exclusions into account.
     - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7
@@ -36,12 +36,20 @@ matrix:
     - os: linux
       env: USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7
 addons:
+  # If this doesn't make much sense to you, see the travis docs:
+  #    https://docs.travis-ci.com/user/migrating-from-legacy/
   apt:
     sources:
-     - ubuntu-toolchain-r-test
-     - deadsnakes
+     # The Travis apt source whitelist can be found here:
+     #   https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
+     - ubuntu-toolchain-r-test  # for new libstdc++
+     - llvm-toolchain-precise-3.7  # for clang
+     - deadsnakes  # for various versions of python
+     - kalakris-cmake # for a more recent version of cmake (needed for ninja-build)
     packages:
-     - g++-4.8
+     - cmake
+     - clang-3.7
+     - ninja-build
      - python2.6
      - python2.6-dev
      - python2.7
@@ -49,5 +57,11 @@ addons:
      - python-virtualenv
 cache:
   directories:
-    - $HOME/.cache/pip
-    - $HOME/.dnx/packages
+    - $HOME/.cache/pip  # Python packages from pip
+    - $HOME/.dnx/packages  # .Net packages?
+    - $HOME/.multirust  # what multirust downloads
+    - $HOME/.cargo  # cargo package deps
+    - $TRAVIS_BUILD_DIR/clang_archives  # clang downloads
+    # dependency compilation output
+    - $TRAVIS_BUILD_DIR/third_party/racerd/target
+    - $TRAVIS_BUILD_DIR/third_party/OmniSharpServer/OmniSharp/bin/Release

--- a/build.py
+++ b/build.py
@@ -172,9 +172,10 @@ def GetGenerator( args ):
     if ( not args.arch and platform.architecture()[ 0 ] == '64bit'
          or args.arch == 64 ):
       generator = generator + ' Win64'
-
     return generator
 
+  if PathToFirstExistingExecutable( ['ninja'] ):
+    return 'Ninja'
   return 'Unix Makefiles'
 
 

--- a/ci/travis/travis_install.linux.sh
+++ b/ci/travis/travis_install.linux.sh
@@ -1,13 +1,19 @@
 # Linux-specific installation
 
 # We can't use sudo, so we have to approximate the behaviour of the following:
-# $ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+# $ sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.7 100
 
 mkdir ${HOME}/bin
 
-ln -s /usr/bin/g++-4.8 ${HOME}/bin/g++
-ln -s /usr/bin/gcc-4.8 ${HOME}/bin/gcc
-ln -s ${HOME}/bin/g++ ${HOME}/bin/c++
+ln -s /usr/bin/clang++-3.7 ${HOME}/bin/clang++
+ln -s /usr/bin/clang-3.7 ${HOME}/bin/clang
+
+ln -s /usr/bin/clang++-3.7 ${HOME}/bin/c++
+ln -s /usr/bin/clang-3.7 ${HOME}/bin/cc
+
+# These shouldn't be necessary, but just in case.
+ln -s /usr/bin/clang++-3.7 ${HOME}/bin/g++
+ln -s /usr/bin/clang-3.7 ${HOME}/bin/gcc
 
 export PATH=${HOME}/bin:${PATH}
 

--- a/ci/travis/travis_install.osx.sh
+++ b/ci/travis/travis_install.osx.sh
@@ -5,6 +5,7 @@
 brew update || brew update
 brew install node.js || brew outdated node.js || brew upgrade node.js
 brew install go || brew outdated go || brew upgrade go
+brew install ninja
 
 # OS X comes with 2 versions of python by default, and a neat system
 # (versioner) to switch between them:


### PR DESCRIPTION
- Using clang instead of gcc; compiles faster and with less memory,
meaning we can build in parallel.
- Caching more stuff so startup is faster. In particular, the Rust
toolchain.
- Using the ninja build tool which tends to be faster than Make.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/336)
<!-- Reviewable:end -->
