### PR TITLE
Persistent Omnisharp in tests

### DIFF
--- a/ycmd/tests/cs/__init__.py
+++ b/ycmd/tests/cs/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2016 ycmd contributors.
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from .cs_handlers_test import StopAllOmniSharpServers
+
+
+def teardownPackage():
+  StopAllOmniSharpServers()

--- a/ycmd/tests/cs/cs_handlers_test.py
+++ b/ycmd/tests/cs/cs_handlers_test.py
@@ -18,9 +18,21 @@
 from ..handlers_test import Handlers_test
 from ycmd.utils import OnTravis
 import time
+from contextlib import contextmanager
+
+# If INSTANCE_PER_TEST is set, each test case will start up and shutdown an
+# instance of Omnisharp server.  Otherwise - the default - it will reuse the
+# Omnisharp instances between individual test cases. Non caching (false) is
+# much faster, but test cases are not totally isolated from each other.
+# For test case isolation, set to true.
+INSTANCE_PER_TEST = False
 
 
 class Cs_Handlers_test( Handlers_test ):
+
+  omnisharp_file_solution = {}
+  omnisharp_solution_port = {}
+  omnisharp_solution_file = {}
 
   def __init__( self ):
     self._file = __file__
@@ -33,17 +45,92 @@ class Cs_Handlers_test( Handlers_test ):
       { 'filepath': self._PathToTestFile( '.ycm_extra_conf.py' ) } )
 
 
-  def _StopOmniSharpServer( self, filename ):
-    self._app.post_json(
-      '/run_completer_command',
-      self._BuildRequest( completer_target = 'filetype_default',
-                          command_arguments = [ 'StopServer' ],
-                          filepath = filename,
-                          filetype = 'cs' )
-    )
+  # See __init__.py for teardownPackage
 
 
-  def _WaitUntilOmniSharpServerReady( self, filename ):
+  @contextmanager
+  def _WrapOmniSharpServer( self, filepath ):
+    self._SetupOmniSharpServer( filepath )
+    yield
+    self._TeardownOmniSharpServer( filepath )
+
+
+  def _SetupOmniSharpServer( self, filepath ):
+    solution_path = self._FindOmniSharpSolutionPath( filepath )
+    if solution_path in Cs_Handlers_test.omnisharp_solution_port:
+      port = Cs_Handlers_test.omnisharp_solution_port[ solution_path ]
+      self._SetOmnisharpPort( filepath, port  )
+      self._WaitUntilOmniSharpServerReady( filepath )
+    else:
+      self._StartOmniSharpServer( filepath )
+      self._WaitUntilOmniSharpServerReady( filepath )
+      port = self._GetOmnisharpPort( filepath )
+      Cs_Handlers_test.omnisharp_solution_port[ solution_path ] = port
+
+
+  def _TeardownOmniSharpServer( self, filepath ):
+    if INSTANCE_PER_TEST:
+      self._StopOmniSharpServer( filepath )
+      try:
+        solution = self._FindOmniSharpSolutionPath( filepath )
+        del Cs_Handlers_test.omnisharp_solution_port[ solution ]
+        del Cs_Handlers_test.omnisharp_solution_file[ solution ]
+      except KeyError:
+        pass
+
+
+  def _StartOmniSharpServer( self, filepath ):
+    self._app.post_json( '/run_completer_command',
+                    self._BuildRequest( completer_target = 'filetype_default',
+                                        command_arguments = [ "StartServer" ],
+                                        filepath = filepath,
+                                        filetype = 'cs' ) )
+
+
+  def _FindOmniSharpSolutionPath( self, filepath ):
+    if filepath in Cs_Handlers_test.omnisharp_file_solution:
+      return Cs_Handlers_test.omnisharp_file_solution[ filepath ]
+
+    solution_request = self._BuildRequest( completer_target = 'filetype_default',
+                                           filepath = filepath,
+                                           command_arguments = [ "SolutionFile" ],
+                                           filetype = 'cs' )
+    solution_path = self._app.post_json( '/run_completer_command',
+                                         solution_request ).json
+    Cs_Handlers_test.omnisharp_file_solution[ filepath ] = solution_path
+    Cs_Handlers_test.omnisharp_solution_file[ solution_path ] = filepath
+
+    return solution_path
+
+
+  def _SetOmnisharpPort( self, filepath, port ):
+    command_arguments = [ 'SetOmnisharpPort', port ]
+    self._app.post_json( '/run_completer_command',
+                    self._BuildRequest( completer_target = 'filetype_default',
+                                        command_arguments = command_arguments,
+                                        filepath = filepath,
+                                        filetype = 'cs' ) )
+
+
+  def _GetOmnisharpPort( self, filepath ):
+    request = self._BuildRequest( completer_target = 'filetype_default',
+                                  command_arguments = [ "GetOmnisharpPort" ],
+                                  filepath = filepath,
+                                  filetype = 'cs' )
+    result = self._app.post_json( '/run_completer_command', request ).json
+
+    return int( result[ "message" ] )
+
+
+  def _StopOmniSharpServer( self, filepath ):
+    self._app.post_json( '/run_completer_command',
+                  self._BuildRequest( completer_target = 'filetype_default',
+                                      command_arguments = [ 'StopServer' ],
+                                      filepath = filepath,
+                                      filetype = 'cs' ) )
+
+
+  def _WaitUntilOmniSharpServerReady( self, filepath ):
     retries = 100
     success = False
 
@@ -56,7 +143,7 @@ class Cs_Handlers_test( Handlers_test ):
         break
       request = self._BuildRequest( completer_target = 'filetype_default',
                                     command_arguments = [ 'ServerIsRunning' ],
-                                    filepath = filename,
+                                    filepath = filepath,
                                     filetype = 'cs' )
       result = self._app.post_json( '/run_completer_command', request ).json
       if not result:
@@ -66,3 +153,15 @@ class Cs_Handlers_test( Handlers_test ):
 
     if not success:
       raise RuntimeError( "Timeout waiting for OmniSharpServer" )
+
+
+def StopAllOmniSharpServers():
+  self = Cs_Handlers_test()
+  with self.UserOption( 'auto_start_csharp_server', False ):
+    with self.UserOption( 'confirm_extra_conf', False ):
+      self.setUp()
+      while Cs_Handlers_test.omnisharp_solution_port:
+        ( solution, port ) = Cs_Handlers_test.omnisharp_solution_port.popitem()
+        filepath = Cs_Handlers_test.omnisharp_solution_file[ solution ]
+        self._SetOmnisharpPort( filepath, port )
+        self._StopOmniSharpServer( filepath )

--- a/ycmd/tests/cs/get_completions_test.py
+++ b/ycmd/tests/cs/get_completions_test.py
@@ -28,27 +28,19 @@ class Cs_GetCompletions_test( Cs_Handlers_test ):
 
   def Basic_test( self ):
     filepath = self._PathToTestFile( 'testy', 'Program.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
-
-    completion_data = self._BuildRequest( filepath = filepath,
-                                          filetype = 'cs',
-                                          contents = contents,
-                                          line_num = 10,
-                                          column_num = 12 )
-    response_data = self._app.post_json( '/completions', completion_data ).json
-    assert_that( response_data[ 'completions' ],
-                 has_items( self._CompletionEntryMatcher( 'CursorLeft' ),
-                            self._CompletionEntryMatcher( 'CursorSize' ) ) )
-    eq_( 12, response_data[ 'completion_start_column' ] )
-
-    self._StopOmniSharpServer( filepath )
+      completion_data = self._BuildRequest( filepath = filepath,
+                                            filetype = 'cs',
+                                            contents = contents,
+                                            line_num = 10,
+                                            column_num = 12 )
+      response_data = self._app.post_json( '/completions', completion_data ).json
+      assert_that( response_data[ 'completions' ],
+                  has_items( self._CompletionEntryMatcher( 'CursorLeft' ),
+                              self._CompletionEntryMatcher( 'CursorSize' ) ) )
+      eq_( 12, response_data[ 'completion_start_column' ] )
 
 
   def MultipleSolution_test( self ):
@@ -59,241 +51,193 @@ class Cs_GetCompletions_test( Cs_Handlers_test ):
                                         'Program.cs' ) ]
     lines = [ 10, 9 ]
     for filepath, line in zip( filepaths, lines ):
+      with self._WrapOmniSharpServer( filepath ):
+        contents = open( filepath ).read()
+
+        completion_data = self._BuildRequest( filepath = filepath,
+                                              filetype = 'cs',
+                                              contents = contents,
+                                              line_num = line,
+                                              column_num = 12 )
+        response_data = self._app.post_json( '/completions',
+                                            completion_data ).json
+        assert_that( response_data[ 'completions' ],
+                    has_items( self._CompletionEntryMatcher( 'CursorLeft' ),
+                                self._CompletionEntryMatcher( 'CursorSize' ) ) )
+        eq_( 12, response_data[ 'completion_start_column' ] )
+
+
+  def PathWithSpace_test( self ):
+    filepath = self._PathToTestFile( u'неприличное слово', 'Program.cs' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
+
+      completion_data = self._BuildRequest( filepath = filepath,
+                                            filetype = 'cs',
+                                            contents = contents,
+                                            line_num = 9,
+                                            column_num = 12 )
+      response_data = self._app.post_json( '/completions', completion_data ).json
+      assert_that( response_data[ 'completions' ],
+                  has_items( self._CompletionEntryMatcher( 'CursorLeft' ),
+                              self._CompletionEntryMatcher( 'CursorSize' ) ) )
+      eq_( 12, response_data[ 'completion_start_column' ] )
+
+
+  def HasBothImportsAndNonImport_test( self ):
+    filepath = self._PathToTestFile( 'testy', 'ImportTest.cs' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
+
+      completion_data = self._BuildRequest( filepath = filepath,
+                                            filetype = 'cs',
+                                            contents = contents,
+                                            line_num = 9,
+                                            column_num = 12,
+                                            force_semantic = True,
+                                            query = 'Date' )
+      response_data = self._app.post_json( '/completions', completion_data ).json
+
+      assert_that(
+        response_data[ 'completions' ],
+        has_items( self._CompletionEntryMatcher( 'DateTime' ),
+                  self._CompletionEntryMatcher( 'DateTimeStyles' ) )
+      )
+
+
+  def ImportsOrderedAfter_test( self ):
+    filepath = self._PathToTestFile( 'testy', 'ImportTest.cs' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
+
+      completion_data = self._BuildRequest( filepath = filepath,
+                                            filetype = 'cs',
+                                            contents = contents,
+                                            line_num = 9,
+                                            column_num = 12,
+                                            force_semantic = True,
+                                            query = 'Date' )
+      response_data = self._app.post_json( '/completions', completion_data ).json
+
+      min_import_index = min(
+        loc for loc, val
+        in enumerate( response_data[ 'completions' ] )
+        if val[ 'extra_data' ][ 'required_namespace_import' ]
+      )
+
+      max_nonimport_index = max(
+        loc for loc, val
+        in enumerate( response_data[ 'completions' ] )
+        if not val[ 'extra_data' ][ 'required_namespace_import' ]
+      )
+
+      assert_that( min_import_index, greater_than( max_nonimport_index ) ),
+
+
+  def ForcedReturnsResults_test( self ):
+    filepath = self._PathToTestFile( 'testy', 'ContinuousTest.cs' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
+
+      completion_data = self._BuildRequest( filepath = filepath,
+                                            filetype = 'cs',
+                                            contents = contents,
+                                            line_num = 9,
+                                            column_num = 21,
+                                            force_semantic = True,
+                                            query = 'Date' )
+      response_data = self._app.post_json( '/completions', completion_data ).json
+
+      assert_that( response_data[ 'completions' ],
+                  has_items( self._CompletionEntryMatcher( 'String' ),
+                              self._CompletionEntryMatcher( 'StringBuilder' ) ) )
+
+
+  def NonForcedReturnsNoResults_test( self ):
+    filepath = self._PathToTestFile( 'testy', 'ContinuousTest.cs' )
+    with self._WrapOmniSharpServer( filepath ):
       contents = open( filepath ).read()
       event_data = self._BuildRequest( filepath = filepath,
                                        filetype = 'cs',
                                        contents = contents,
                                        event_name = 'FileReadyToParse' )
-
+  
       self._app.post_json( '/event_notification', event_data )
-      self._WaitUntilOmniSharpServerReady( filepath )
 
       completion_data = self._BuildRequest( filepath = filepath,
                                             filetype = 'cs',
                                             contents = contents,
-                                            line_num = line,
-                                            column_num = 12 )
-      response_data = self._app.post_json( '/completions',
-                                           completion_data ).json
-      assert_that( response_data[ 'completions' ],
-                   has_items( self._CompletionEntryMatcher( 'CursorLeft' ),
-                              self._CompletionEntryMatcher( 'CursorSize' ) ) )
-      eq_( 12, response_data[ 'completion_start_column' ] )
+                                            line_num = 9,
+                                            column_num = 21,
+                                            force_semantic = False,
+                                            query = 'Date' )
+      results = self._app.post_json( '/completions', completion_data ).json
 
-      self._StopOmniSharpServer( filepath )
-
-
-  def PathWithSpace_test( self ):
-    filepath = self._PathToTestFile( u'неприличное слово', 'Program.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
-
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
-
-    completion_data = self._BuildRequest( filepath = filepath,
-                                          filetype = 'cs',
-                                          contents = contents,
-                                          line_num = 9,
-                                          column_num = 12 )
-    response_data = self._app.post_json( '/completions', completion_data ).json
-    assert_that( response_data[ 'completions' ],
-                 has_items( self._CompletionEntryMatcher( 'CursorLeft' ),
-                            self._CompletionEntryMatcher( 'CursorSize' ) ) )
-    eq_( 12, response_data[ 'completion_start_column' ] )
-
-    self._StopOmniSharpServer( filepath )
-
-
-  def HasBothImportsAndNonImport_test( self ):
-    filepath = self._PathToTestFile( 'testy', 'ImportTest.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
-
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
-
-    completion_data = self._BuildRequest( filepath = filepath,
-                                          filetype = 'cs',
-                                          contents = contents,
-                                          line_num = 9,
-                                          column_num = 12,
-                                          force_semantic = True,
-                                          query = 'Date' )
-    response_data = self._app.post_json( '/completions', completion_data ).json
-
-    assert_that(
-      response_data[ 'completions' ],
-      has_items( self._CompletionEntryMatcher( 'DateTime' ),
-                 self._CompletionEntryMatcher( 'DateTimeStyles' ) )
-    )
-
-    self._StopOmniSharpServer( filepath )
-
-
-  def ImportsOrderedAfter_test( self ):
-    filepath = self._PathToTestFile( 'testy', 'ImportTest.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
-
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
-
-    completion_data = self._BuildRequest( filepath = filepath,
-                                          filetype = 'cs',
-                                          contents = contents,
-                                          line_num = 9,
-                                          column_num = 12,
-                                          force_semantic = True,
-                                          query = 'Date' )
-    response_data = self._app.post_json( '/completions', completion_data ).json
-
-    min_import_index = min(
-      loc for loc, val
-      in enumerate( response_data[ 'completions' ] )
-      if val[ 'extra_data' ][ 'required_namespace_import' ]
-    )
-
-    max_nonimport_index = max(
-      loc for loc, val
-      in enumerate( response_data[ 'completions' ] )
-      if not val[ 'extra_data' ][ 'required_namespace_import' ]
-    )
-
-    assert_that( min_import_index, greater_than( max_nonimport_index ) ),
-    self._StopOmniSharpServer( filepath )
-
-
-  def ForcedReturnsResults_test( self ):
-    filepath = self._PathToTestFile( 'testy', 'ContinuousTest.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
-
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
-
-    completion_data = self._BuildRequest( filepath = filepath,
-                                          filetype = 'cs',
-                                          contents = contents,
-                                          line_num = 9,
-                                          column_num = 21,
-                                          force_semantic = True,
-                                          query = 'Date' )
-    response_data = self._app.post_json( '/completions', completion_data ).json
-
-    assert_that( response_data[ 'completions' ],
-                 has_items( self._CompletionEntryMatcher( 'String' ),
-                            self._CompletionEntryMatcher( 'StringBuilder' ) ) )
-    self._StopOmniSharpServer( filepath )
-
-
-  def NonForcedReturnsNoResults_test( self ):
-    filepath = self._PathToTestFile( 'testy', 'ContinuousTest.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
-
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
-
-    completion_data = self._BuildRequest( filepath = filepath,
-                                          filetype = 'cs',
-                                          contents = contents,
-                                          line_num = 9,
-                                          column_num = 21,
-                                          force_semantic = False,
-                                          query = 'Date' )
-    results = self._app.post_json( '/completions', completion_data ).json
-
-    # There are no semantic completions. However, we fall back to identifier
-    # completer in this case.
-    assert_that( results, has_entries( {
-      'completions': has_item( has_entries( {
-        'insertion_text' : 'String',
-        'extra_menu_info': '[ID]',
-      } ) ),
-      'errors': empty(),
-    } ) )
-    self._StopOmniSharpServer( filepath )
+      # There are no semantic completions. However, we fall back to identifier
+      # completer in this case.
+      assert_that( results, has_entries( {
+        'completions': has_item( has_entries( {
+          'insertion_text' : 'String',
+          'extra_menu_info': '[ID]',
+        } ) ),
+        'errors': empty(),
+      } ) )
 
 
   def ForcedDividesCache_test( self ):
     filepath = self._PathToTestFile( 'testy', 'ContinuousTest.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
+      event_data = self._BuildRequest( filepath = filepath,
+                                       filetype = 'cs',
+                                       contents = contents,
+                                       event_name = 'FileReadyToParse' )
+  
+      self._app.post_json( '/event_notification', event_data )
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      completion_data = self._BuildRequest( filepath = filepath,
+                                            filetype = 'cs',
+                                            contents = contents,
+                                            line_num = 9,
+                                            column_num = 21,
+                                            force_semantic = True,
+                                            query = 'Date' )
+      results = self._app.post_json( '/completions', completion_data ).json
 
-    completion_data = self._BuildRequest( filepath = filepath,
-                                          filetype = 'cs',
-                                          contents = contents,
-                                          line_num = 9,
-                                          column_num = 21,
-                                          force_semantic = True,
-                                          query = 'Date' )
-    results = self._app.post_json( '/completions', completion_data ).json
+      assert_that( results[ 'completions' ], not( empty() ) )
+      assert_that( results[ 'errors' ], empty() )
 
-    assert_that( results[ 'completions' ], not( empty() ) )
-    assert_that( results[ 'errors' ], empty() )
+      completion_data = self._BuildRequest( filepath = filepath,
+                                            filetype = 'cs',
+                                            contents = contents,
+                                            line_num = 9,
+                                            column_num = 21,
+                                            force_semantic = False,
+                                            query = 'Date' )
+      results = self._app.post_json( '/completions', completion_data ).json
 
-    completion_data = self._BuildRequest( filepath = filepath,
-                                          filetype = 'cs',
-                                          contents = contents,
-                                          line_num = 9,
-                                          column_num = 21,
-                                          force_semantic = False,
-                                          query = 'Date' )
-    results = self._app.post_json( '/completions', completion_data ).json
-
-    # There are no semantic completions. However, we fall back to identifier
-    # completer in this case.
-    assert_that( results, has_entries( {
-      'completions': has_item( has_entries( {
-        'insertion_text' : 'String',
-        'extra_menu_info': '[ID]',
-      } ) ),
-      'errors': empty(),
-    } ) )
-    self._StopOmniSharpServer( filepath )
+      # There are no semantic completions. However, we fall back to identifier
+      # completer in this case.
+      assert_that( results, has_entries( {
+        'completions': has_item( has_entries( {
+          'insertion_text' : 'String',
+          'extra_menu_info': '[ID]',
+        } ) ),
+        'errors': empty(),
+      } ) )
 
 
   def ReloadSolution_Basic_test( self ):
     filepath = self._PathToTestFile( 'testy', 'Program.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      result = self._app.post_json(
+        '/run_completer_command',
+        self._BuildRequest( completer_target = 'filetype_default',
+                            command_arguments = [ 'ReloadSolution' ],
+                            filepath = filepath,
+                            filetype = 'cs' ) ).json
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
-    result = self._app.post_json(
-      '/run_completer_command',
-      self._BuildRequest( completer_target = 'filetype_default',
-                          command_arguments = [ 'ReloadSolution' ],
-                          filepath = filepath,
-                          filetype = 'cs' ) ).json
-
-    self._StopOmniSharpServer( filepath )
-    eq_( result, True )
+      eq_( result, True )
 
 
   def ReloadSolution_MultipleSolution_test( self ):
@@ -303,23 +247,15 @@ class Cs_GetCompletions_test( Cs_Handlers_test ):
                                         'testy',
                                         'Program.cs' ) ]
     for filepath in filepaths:
-      contents = open( filepath ).read()
-      event_data = self._BuildRequest( filepath = filepath,
-                                       filetype = 'cs',
-                                       contents = contents,
-                                       event_name = 'FileReadyToParse' )
+      with self._WrapOmniSharpServer( filepath ):
+        result = self._app.post_json(
+          '/run_completer_command',
+          self._BuildRequest( completer_target = 'filetype_default',
+                              command_arguments = [ 'ReloadSolution' ],
+                              filepath = filepath,
+                              filetype = 'cs' ) ).json
 
-      self._app.post_json( '/event_notification', event_data )
-      self._WaitUntilOmniSharpServerReady( filepath )
-      result = self._app.post_json(
-        '/run_completer_command',
-        self._BuildRequest( completer_target = 'filetype_default',
-                            command_arguments = [ 'ReloadSolution' ],
-                            filepath = filepath,
-                            filetype = 'cs' ) ).json
-
-      self._StopOmniSharpServer( filepath )
-      eq_( result, True )
+        eq_( result, True )
 
 
   def _SolutionSelectCheck( self, sourcefile, reference_solution,

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -27,431 +27,311 @@ class Cs_Subcommands_test( Cs_Handlers_test ):
 
   def GoTo_Basic_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GotoTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      goto_data = self._BuildRequest( completer_target = 'filetype_default',
+                                      command_arguments = [ 'GoTo' ],
+                                      line_num = 9,
+                                      column_num = 15,
+                                      contents = contents,
+                                      filetype = 'cs',
+                                      filepath = filepath )
 
-    goto_data = self._BuildRequest( completer_target = 'filetype_default',
-                                    command_arguments = [ 'GoTo' ],
-                                    line_num = 9,
-                                    column_num = 15,
-                                    contents = contents,
-                                    filetype = 'cs',
-                                    filepath = filepath )
-
-    eq_( {
-      'filepath': self._PathToTestFile( 'testy', 'Program.cs' ),
-      'line_num': 7,
-      'column_num': 3
-    }, self._app.post_json( '/run_completer_command', goto_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( {
+        'filepath': self._PathToTestFile( 'testy', 'Program.cs' ),
+        'line_num': 7,
+        'column_num': 3
+      }, self._app.post_json( '/run_completer_command', goto_data ).json )
 
 
   def GoToImplementation_Basic_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GotoTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      goto_data = self._BuildRequest(
+        completer_target = 'filetype_default',
+        command_arguments = [ 'GoToImplementation' ],
+        line_num = 13,
+        column_num = 13,
+        contents = contents,
+        filetype = 'cs',
+        filepath = filepath
+      )
 
-    goto_data = self._BuildRequest(
-      completer_target = 'filetype_default',
-      command_arguments = [ 'GoToImplementation' ],
-      line_num = 13,
-      column_num = 13,
-      contents = contents,
-      filetype = 'cs',
-      filepath = filepath
-    )
-
-    eq_( {
-      'filepath': self._PathToTestFile( 'testy', 'GotoTestCase.cs' ),
-      'line_num': 30,
-      'column_num': 3
-    }, self._app.post_json( '/run_completer_command', goto_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( {
+        'filepath': self._PathToTestFile( 'testy', 'GotoTestCase.cs' ),
+        'line_num': 30,
+        'column_num': 3
+      }, self._app.post_json( '/run_completer_command', goto_data ).json )
 
 
   def GoToImplementation_NoImplementation_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GotoTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      goto_data = self._BuildRequest(
+        completer_target = 'filetype_default',
+        command_arguments = [ 'GoToImplementation' ],
+        line_num = 17,
+        column_num = 13,
+        contents = contents,
+        filetype = 'cs',
+        filepath = filepath
+      )
 
-    goto_data = self._BuildRequest(
-      completer_target = 'filetype_default',
-      command_arguments = [ 'GoToImplementation' ],
-      line_num = 17,
-      column_num = 13,
-      contents = contents,
-      filetype = 'cs',
-      filepath = filepath
-    )
-
-    try:
-      self._app.post_json( '/run_completer_command', goto_data ).json
-      raise Exception("Expected a 'No implementations found' error")
-    except AppError as e:
-      if 'No implementations found' in str(e):
-        pass
-      else:
-        raise
-    finally:
-      self._StopOmniSharpServer( filepath )
+      try:
+        self._app.post_json( '/run_completer_command', goto_data ).json
+        raise Exception("Expected a 'No implementations found' error")
+      except AppError as e:
+        if 'No implementations found' in str(e):
+          pass
+        else:
+          raise
 
 
   def CsCompleter_InvalidLocation_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GotoTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      goto_data = self._BuildRequest(
+        completer_target = 'filetype_default',
+        command_arguments = [ 'GoToImplementation' ],
+        line_num = 2,
+        column_num = 1,
+        contents = contents,
+        filetype = 'cs',
+        filepath = filepath
+      )
 
-    goto_data = self._BuildRequest(
-      completer_target = 'filetype_default',
-      command_arguments = [ 'GoToImplementation' ],
-      line_num = 2,
-      column_num = 1,
-      contents = contents,
-      filetype = 'cs',
-      filepath = filepath
-    )
-
-    try:
-      self._app.post_json( '/run_completer_command', goto_data ).json
-      raise Exception( 'Expected a "Can\\\'t jump to implementation" error' )
-    except AppError as e:
-      if 'Can\\\'t jump to implementation' in str(e):
-        pass
-      else:
-        raise
-    finally:
-      self._StopOmniSharpServer( filepath )
+      try:
+        self._app.post_json( '/run_completer_command', goto_data ).json
+        raise Exception( 'Expected a "Can\\\'t jump to implementation" error' )
+      except AppError as e:
+        if 'Can\\\'t jump to implementation' in str(e):
+          pass
+        else:
+          raise
 
 
   def GoToImplementationElseDeclaration_NoImplementation_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GotoTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      goto_data = self._BuildRequest(
+        completer_target = 'filetype_default',
+        command_arguments = [ 'GoToImplementationElseDeclaration' ],
+        line_num = 17,
+        column_num = 13,
+        contents = contents,
+        filetype = 'cs',
+        filepath = filepath
+      )
 
-    goto_data = self._BuildRequest(
-      completer_target = 'filetype_default',
-      command_arguments = [ 'GoToImplementationElseDeclaration' ],
-      line_num = 17,
-      column_num = 13,
-      contents = contents,
-      filetype = 'cs',
-      filepath = filepath
-    )
-
-    eq_( {
-      'filepath': self._PathToTestFile( 'testy', 'GotoTestCase.cs' ),
-      'line_num': 35,
-      'column_num': 3
-    }, self._app.post_json( '/run_completer_command', goto_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( {
+        'filepath': self._PathToTestFile( 'testy', 'GotoTestCase.cs' ),
+        'line_num': 35,
+        'column_num': 3
+      }, self._app.post_json( '/run_completer_command', goto_data ).json )
 
 
   def GoToImplementationElseDeclaration_SingleImplementation_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GotoTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      goto_data = self._BuildRequest(
+        completer_target = 'filetype_default',
+        command_arguments = [ 'GoToImplementationElseDeclaration' ],
+        line_num = 13,
+        column_num = 13,
+        contents = contents,
+        filetype = 'cs',
+        filepath = filepath
+      )
 
-    goto_data = self._BuildRequest(
-      completer_target = 'filetype_default',
-      command_arguments = [ 'GoToImplementationElseDeclaration' ],
-      line_num = 13,
-      column_num = 13,
-      contents = contents,
-      filetype = 'cs',
-      filepath = filepath
-    )
-
-    eq_( {
-      'filepath': self._PathToTestFile( 'testy', 'GotoTestCase.cs' ),
-      'line_num': 30,
-      'column_num': 3
-    }, self._app.post_json( '/run_completer_command', goto_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( {
+        'filepath': self._PathToTestFile( 'testy', 'GotoTestCase.cs' ),
+        'line_num': 30,
+        'column_num': 3
+      }, self._app.post_json( '/run_completer_command', goto_data ).json )
 
 
   def GoToImplementationElseDeclaration_MultipleImplementations_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GotoTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      goto_data = self._BuildRequest(
+        completer_target = 'filetype_default',
+        command_arguments = [ 'GoToImplementationElseDeclaration' ],
+        line_num = 21,
+        column_num = 13,
+        contents = contents,
+        filetype = 'cs',
+        filepath = filepath
+      )
 
-    goto_data = self._BuildRequest(
-      completer_target = 'filetype_default',
-      command_arguments = [ 'GoToImplementationElseDeclaration' ],
-      line_num = 21,
-      column_num = 13,
-      contents = contents,
-      filetype = 'cs',
-      filepath = filepath
-    )
-
-    eq_( [ {
-      'filepath': self._PathToTestFile( 'testy', 'GotoTestCase.cs' ),
-      'line_num': 43,
-      'column_num': 3
-    }, {
-      'filepath': self._PathToTestFile( 'testy', 'GotoTestCase.cs' ),
-      'line_num': 48,
-      'column_num': 3
-    } ], self._app.post_json( '/run_completer_command', goto_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( [ {
+        'filepath': self._PathToTestFile( 'testy', 'GotoTestCase.cs' ),
+        'line_num': 43,
+        'column_num': 3
+      }, {
+        'filepath': self._PathToTestFile( 'testy', 'GotoTestCase.cs' ),
+        'line_num': 48,
+        'column_num': 3
+      } ], self._app.post_json( '/run_completer_command', goto_data ).json )
 
 
   def GetType_EmptyMessage_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GetTypeTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      gettype_data = self._BuildRequest( completer_target = 'filetype_default',
+                                        command_arguments = [ 'GetType' ],
+                                        line_num = 1,
+                                        column_num = 1,
+                                        contents = contents,
+                                        filetype = 'cs',
+                                        filepath = filepath )
 
-    gettype_data = self._BuildRequest( completer_target = 'filetype_default',
-                                       command_arguments = [ 'GetType' ],
-                                       line_num = 1,
-                                       column_num = 1,
-                                       contents = contents,
-                                       filetype = 'cs',
-                                       filepath = filepath )
-
-    eq_( {
-      u'message': u""
-    }, self._app.post_json( '/run_completer_command', gettype_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( {
+        u'message': u""
+      }, self._app.post_json( '/run_completer_command', gettype_data ).json )
 
 
   def GetType_VariableDeclaration_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GetTypeTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      gettype_data = self._BuildRequest( completer_target = 'filetype_default',
+                                        command_arguments = [ 'GetType' ],
+                                        line_num = 4,
+                                        column_num = 5,
+                                        contents = contents,
+                                        filetype = 'cs',
+                                        filepath = filepath )
 
-    gettype_data = self._BuildRequest( completer_target = 'filetype_default',
-                                       command_arguments = [ 'GetType' ],
-                                       line_num = 4,
-                                       column_num = 5,
-                                       contents = contents,
-                                       filetype = 'cs',
-                                       filepath = filepath )
-
-    eq_( {
-      u'message': u"string"
-    }, self._app.post_json( '/run_completer_command', gettype_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( {
+        u'message': u"string"
+      }, self._app.post_json( '/run_completer_command', gettype_data ).json )
 
 
   def GetType_VariableUsage_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GetTypeTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      gettype_data = self._BuildRequest( completer_target = 'filetype_default',
+                                        command_arguments = [ 'GetType' ],
+                                        line_num = 5,
+                                        column_num = 5,
+                                        contents = contents,
+                                        filetype = 'cs',
+                                        filepath = filepath )
 
-    gettype_data = self._BuildRequest( completer_target = 'filetype_default',
-                                       command_arguments = [ 'GetType' ],
-                                       line_num = 5,
-                                       column_num = 5,
-                                       contents = contents,
-                                       filetype = 'cs',
-                                       filepath = filepath )
-
-    eq_( {
-      u'message': u"string str"
-    }, self._app.post_json( '/run_completer_command', gettype_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( {
+        u'message': u"string str"
+      }, self._app.post_json( '/run_completer_command', gettype_data ).json )
 
 
   def GetType_Constant_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GetTypeTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      gettype_data = self._BuildRequest( completer_target = 'filetype_default',
+                                        command_arguments = [ 'GetType' ],
+                                        line_num = 4,
+                                        column_num = 14,
+                                        contents = contents,
+                                        filetype = 'cs',
+                                        filepath = filepath )
 
-    gettype_data = self._BuildRequest( completer_target = 'filetype_default',
-                                       command_arguments = [ 'GetType' ],
-                                       line_num = 4,
-                                       column_num = 14,
-                                       contents = contents,
-                                       filetype = 'cs',
-                                       filepath = filepath )
-
-    eq_( {
-      u'message': u"System.String"
-    }, self._app.post_json( '/run_completer_command', gettype_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( {
+        u'message': u"System.String"
+      }, self._app.post_json( '/run_completer_command', gettype_data ).json )
 
 
   def GetType_DocsIgnored_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GetTypeTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      gettype_data = self._BuildRequest( completer_target = 'filetype_default',
+                                        command_arguments = [ 'GetType' ],
+                                        line_num = 9,
+                                        column_num = 34,
+                                        contents = contents,
+                                        filetype = 'cs',
+                                        filepath = filepath )
 
-    gettype_data = self._BuildRequest( completer_target = 'filetype_default',
-                                       command_arguments = [ 'GetType' ],
-                                       line_num = 9,
-                                       column_num = 34,
-                                       contents = contents,
-                                       filetype = 'cs',
-                                       filepath = filepath )
-
-    eq_( {
-      u'message': u"int GetTypeTestCase.an_int_with_docs;",
-    }, self._app.post_json( '/run_completer_command', gettype_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( {
+        u'message': u"int GetTypeTestCase.an_int_with_docs;",
+      }, self._app.post_json( '/run_completer_command', gettype_data ).json )
 
 
   def GetDoc_Variable_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GetDocTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      getdoc_data = self._BuildRequest( completer_target = 'filetype_default',
+                                        command_arguments = [ 'GetDoc' ],
+                                        line_num = 13,
+                                        column_num = 28,
+                                        contents = contents,
+                                        filetype = 'cs',
+                                        filepath = filepath )
 
-    getdoc_data = self._BuildRequest( completer_target = 'filetype_default',
-                                      command_arguments = [ 'GetDoc' ],
-                                      line_num = 13,
-                                      column_num = 28,
-                                      contents = contents,
-                                      filetype = 'cs',
-                                      filepath = filepath )
-
-    eq_( {
-      'detailed_info': 'int GetDocTestCase.an_int;\n'
-                       'an integer, or something',
-    }, self._app.post_json( '/run_completer_command', getdoc_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( {
+        'detailed_info': 'int GetDocTestCase.an_int;\n'
+                        'an integer, or something',
+      }, self._app.post_json( '/run_completer_command', getdoc_data ).json )
 
 
   def GetDoc_Function_test( self ):
     filepath = self._PathToTestFile( 'testy', 'GetDocTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      getdoc_data = self._BuildRequest( completer_target = 'filetype_default',
+                                        command_arguments = [ 'GetDoc' ],
+                                        line_num = 33,
+                                        column_num = 27,
+                                        contents = contents,
+                                        filetype = 'cs',
+                                        filepath = filepath )
 
-    getdoc_data = self._BuildRequest( completer_target = 'filetype_default',
-                                      command_arguments = [ 'GetDoc' ],
-                                      line_num = 33,
-                                      column_num = 27,
-                                      contents = contents,
-                                      filetype = 'cs',
-                                      filepath = filepath )
-
-    # It seems that Omnisharp server eats newlines
-    eq_( {
-      'detailed_info': 'int GetDocTestCase.DoATest();\n'
-                       ' Very important method. With multiple lines of '
-                       'commentary And Format- -ting',
-    }, self._app.post_json( '/run_completer_command', getdoc_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      # It seems that Omnisharp server eats newlines
+      eq_( {
+        'detailed_info': 'int GetDocTestCase.DoATest();\n'
+                        ' Very important method. With multiple lines of '
+                        'commentary And Format- -ting',
+      }, self._app.post_json( '/run_completer_command', getdoc_data ).json )
 
 
   def _RunFixIt( self, line, column, expected_result ):
     filepath = self._PathToTestFile( 'testy', 'FixItTestCase.cs' )
-    contents = open( filepath ).read()
-    event_data = self._BuildRequest( filepath = filepath,
-                                     filetype = 'cs',
-                                     contents = contents,
-                                     event_name = 'FileReadyToParse' )
+    with self._WrapOmniSharpServer( filepath ):
+      contents = open( filepath ).read()
 
-    self._app.post_json( '/event_notification', event_data )
-    self._WaitUntilOmniSharpServerReady( filepath )
+      fixit_data = self._BuildRequest( completer_target = 'filetype_default',
+                                      command_arguments = [ 'FixIt' ],
+                                      line_num = line,
+                                      column_num = column,
+                                      contents = contents,
+                                      filetype = 'cs',
+                                      filepath = filepath )
 
-    fixit_data = self._BuildRequest( completer_target = 'filetype_default',
-                                     command_arguments = [ 'FixIt' ],
-                                     line_num = line,
-                                     column_num = column,
-                                     contents = contents,
-                                     filetype = 'cs',
-                                     filepath = filepath )
-
-    eq_( expected_result,
-         self._app.post_json( '/run_completer_command', fixit_data ).json )
-
-    self._StopOmniSharpServer( filepath )
+      eq_( expected_result,
+          self._app.post_json( '/run_completer_command', fixit_data ).json )
 
 
   def FixIt_RemoveSingleLine_test( self ):


### PR DESCRIPTION
Running all the tests in ycmd takes a long time. The reason for this is
repeatedly starting and stopping Omnisharp servers. To mitigated this, whenever
we start an instance of Omnisharp during testing, we cache it, and reuses it
from the cache whenever a test requires a instance of Omnisharp on the same
solution.

As part of this, add Set/GetOmnisharpPort commands to the C# completer. These
commands allow setting the port it uses to communicate with the Omnisharp
server. This allows sharing of the Omnisharp server by retrieving the port and
using it in other clients, or get the port another client is using and using it
here.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/339)
<!-- Reviewable:end -->
