### PR TITLE
Now always passing --with-id to nosetests

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -87,7 +87,9 @@ def BuildYcmdLibs( args ):
 
 
 def NoseTests( parsed_args, extra_nosetests_args ):
-  nosetests_args = [ '-v' ]
+  # Always passing --with-id to nosetests enables non-surprising usage of
+  # its --failed flag.
+  nosetests_args = [ '-v', '--with-id' ]
   if parsed_args.no_clang_completer:
     nosetests_args.append( '--exclude=.*Clang.*' )
 


### PR DESCRIPTION
Passing it doesn't hurt and makes it possible to sensibly use the `--failed` flag.

Without `--with-id`, the first time we use `--failed`, it runs _all_ the tests, not just the failing ones. Only the second run with `--failed` runs only the failing tests. The reason for this is that the test name ID map needs to be generated, which passing `--with-id` enables by default.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/341)
<!-- Reviewable:end -->
