### PR TITLE
TypeScript: Allow concurrent requests

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -156,8 +156,8 @@ class TypeScriptCompleter( Completer ):
         seq = message[ 'request_seq' ]
         with self._pendinglock:
           if seq in self._pending:
-            self._pending[seq].resolve( message )
-            del self._pending[seq]
+            self._pending[ seq ].resolve( message )
+            del self._pending[ seq ]
       except Exception as e:
         _logger.error( 'ReaderLoop error: {0}'.format( str( e ) ) )
 
@@ -200,8 +200,9 @@ class TypeScriptCompleter( Completer ):
 
   def _SendCommand( self, command, arguments = None ):
     """
-    Send a request message to TSServer but don't
-    wait for the response.
+    Send a request message to TSServer but don't wait for the response.
+    This function is to be used when we don't care about the response
+    to the message that is sent.
     """
 
     request = self._BuildRequest( command, arguments )

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -105,7 +105,7 @@ class TypeScriptCompleter( Completer ):
     self._sequenceid = itertools.count()
 
     # Used to prevent threads from concurrently accessing the sequence counter
-    self._sequenceidlock = Lock()
+    self._sequenceid_lock = Lock()
 
     # TSServer ignores the fact that newlines are two characters on Windows
     # (\r\n) instead of one on other platforms (\n), so we use the
@@ -190,7 +190,7 @@ class TypeScriptCompleter( Completer ):
   def _BuildRequest( self, command, arguments = None ):
     """Build TSServer request object."""
 
-    with self._sequenceidlock:
+    with self._sequenceid_lock:
       seq = self._sequenceid.next()
     request = {
       'seq':     seq,

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -104,6 +104,9 @@ class TypeScriptCompleter( Completer ):
     # Responses contain the id sent in the corresponding request.
     self._sequenceid = itertools.count()
 
+    # Used to prevent threads from concurrently accessing the sequence counter
+    self._sequenceidlock = Lock()
+
     # TSServer ignores the fact that newlines are two characters on Windows
     # (\r\n) instead of one on other platforms (\n), so we use the
     # universal_newlines option to convert those newlines to \n. See the issue
@@ -187,7 +190,8 @@ class TypeScriptCompleter( Completer ):
   def _BuildRequest( self, command, arguments = None ):
     """Build TSServer request object."""
 
-    seq = self._sequenceid.next()
+    with self._sequenceidlock:
+      seq = self._sequenceid.next()
     request = {
       'seq':     seq,
       'type':    'request',


### PR DESCRIPTION
The way it currently works, each sequence of requests/responses acquire a global lock. This restricts the usage of tsserver commands/functionality that can take a bit of time to complete (syntax checking / compilation errors).

**I need help with naming things**

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/344)
<!-- Reviewable:end -->
