### PR TITLE
[READY] Ignore file created by nosetests --with-id option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ pip-log.txt
 cover/
 .tox
 nosetests.xml
+.noseids
 
 # custom
 ycm_core_tests


### PR DESCRIPTION
Now that we pass the `--with-id` option to nosetests (PR #341), the `.noseids` file is created. We ignore it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/345)
<!-- Reviewable:end -->
