### PR TITLE
[READY] Remove interpreter line from Python sources

### DIFF
--- a/examples/.ycm_extra_conf.py
+++ b/examples/.ycm_extra_conf.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2014  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/examples/example_client.py
+++ b/examples/example_client.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2014  Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -380,7 +378,7 @@ def PythonSemanticCompletionResults( server ):
 
   server.SendCodeCompletionRequest( test_filename = 'some_python.py',
                                     filetype = 'python',
-                                    line_num = 27,
+                                    line_num = 25,
                                     column_num = 6 )
 
 

--- a/examples/samples/some_python.py
+++ b/examples/samples/some_python.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2014  Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,5 +21,5 @@ class Example( object ):
 
 if __name__ == "__main__":
   ex = Example()
-  # location after the dot is line 29, column 6
+  # location after the dot is line 25, column 6
   ex.

--- a/ycmd/__main__.py
+++ b/ycmd/__main__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/all/tests/identifier_completer_test.py
+++ b/ycmd/completers/all/tests/identifier_completer_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/c/hook.py
+++ b/ycmd/completers/c/hook.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012, 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/completer_utils_test.py
+++ b/ycmd/completers/completer_utils_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/cpp/clang_helpers.py
+++ b/ycmd/completers/cpp/clang_helpers.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/cpp/ephemeral_values_set.py
+++ b/ycmd/completers/cpp/ephemeral_values_set.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2014  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/cpp/hook.py
+++ b/ycmd/completers/cpp/hook.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/cpp/tests/comment_strip_test.py
+++ b/ycmd/completers/cpp/tests/comment_strip_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015  YouCompleteMe contributors
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/cpp/tests/flags_test.py
+++ b/ycmd/completers/cpp/tests/flags_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Chiel ten Brinke <ctenbrinke@gmail.com>
 #                           Google Inc.
 #

--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013 Stanislav Golovanov <stgolovanov@gmail.com>
 #                    Google Inc.
 #

--- a/ycmd/completers/general/general_completer_store.py
+++ b/ycmd/completers/general/general_completer_store.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Stanislav Golovanov <stgolovanov@gmail.com>
 #                     Google Inc.
 #

--- a/ycmd/completers/general/tests/filename_completer_test.py
+++ b/ycmd/completers/general/tests/filename_completer_test.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# coding: utf-8
 #
 # Copyright (C) 2014  Davit Samvelyan <davitsamvelyan@gmail.com>
 #

--- a/ycmd/completers/general/ultisnips_completer.py
+++ b/ycmd/completers/general/ultisnips_completer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013 Stanislav Golovanov <stgolovanov@gmail.com>
 #                    Google Inc.
 #

--- a/ycmd/completers/general_completer.py
+++ b/ycmd/completers/general_completer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/go/gocode_completer.py
+++ b/ycmd/completers/go/gocode_completer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/go/hook.py
+++ b/ycmd/completers/go/hook.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/go/tests/gocode_completer_test.py
+++ b/ycmd/completers/go/tests/gocode_completer_test.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# coding: utf-8
 #
 # Copyright (C) 2015 Google Inc.
 #

--- a/ycmd/completers/javascript/hook.py
+++ b/ycmd/completers/javascript/hook.py
@@ -1,4 +1,3 @@
-#
 # Copyright (C) 2015  YCMD contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -1,4 +1,3 @@
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/completers/objc/hook.py
+++ b/ycmd/completers/objc/hook.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/objcpp/hook.py
+++ b/ycmd/completers/objcpp/hook.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Stephen Sugden <me@stephensugden.com>
 #                           Google Inc.
 #                           Stanislav Golovanov <stgolovanov@gmail.com>

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015  ycmd contributors
 #
 # This file is part of ycmd.

--- a/ycmd/completers/typescript/hook.py
+++ b/ycmd/completers/typescript/hook.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/extra_conf_store.py
+++ b/ycmd/extra_conf_store.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/hmac_plugin.py
+++ b/ycmd/hmac_plugin.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2014  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/hmac_utils.py
+++ b/ycmd/hmac_utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2014  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/request_validation.py
+++ b/ycmd/request_validation.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2014  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2014 Google Inc.
 #
 # YouCompleteMe is free software: you can redistribute it and/or modify

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/server_state.py
+++ b/ycmd/server_state.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/tests/check_core_version_test.py
+++ b/ycmd/tests/check_core_version_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors
 #
 # This file is part of ycmd.

--- a/ycmd/tests/clang/clang_handlers_test.py
+++ b/ycmd/tests/clang/clang_handlers_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/clang/diagnostics_test.py
+++ b/ycmd/tests/clang/diagnostics_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/cs/cs_handlers_test.py
+++ b/ycmd/tests/cs/cs_handlers_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/cs/diagnostics_test.py
+++ b/ycmd/tests/cs/diagnostics_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/cs/get_completions_test.py
+++ b/ycmd/tests/cs/get_completions_test.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# coding: utf-8
 #
 # Copyright (C) 2015 ycmd contributors.
 #

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/extra_conf_store_test.py
+++ b/ycmd/tests/extra_conf_store_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013 Google Inc.
 #               2015 ycmd contributors
 #

--- a/ycmd/tests/go/get_completions_test.py
+++ b/ycmd/tests/go/get_completions_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/go/go_handlers_test.py
+++ b/ycmd/tests/go/go_handlers_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/go/subcommands_test.py
+++ b/ycmd/tests/go/subcommands_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2016 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/handlers_test.py
+++ b/ycmd/tests/handlers_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/identifier_utils_test.py
+++ b/ycmd/tests/identifier_utils_test.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# coding: utf-8
 #
 # Copyright (C) 2013  Google Inc.
 #

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -1,4 +1,3 @@
-#
 # Copyright (C) 2015 ycmd contributors
 #
 # This file is part of ycmd.

--- a/ycmd/tests/javascript/get_completions_test.py
+++ b/ycmd/tests/javascript/get_completions_test.py
@@ -1,4 +1,3 @@
-#
 # Copyright (C) 2015 ycmd contributors
 #
 # This file is part of ycmd.

--- a/ycmd/tests/javascript/javascript_handlers_test.py
+++ b/ycmd/tests/javascript/javascript_handlers_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -1,4 +1,3 @@
-#
 # Copyright (C) 2015 ycmd contributors
 #
 # This file is part of ycmd.

--- a/ycmd/tests/misc_handlers_test.py
+++ b/ycmd/tests/misc_handlers_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013 Google Inc.
 #               2015 ycmd contributors
 #

--- a/ycmd/tests/python/get_completions_test.py
+++ b/ycmd/tests/python/get_completions_test.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# coding: utf-8
 #
 # Copyright (C) 2015 ycmd contributors.
 #

--- a/ycmd/tests/python/python_handlers_test.py
+++ b/ycmd/tests/python/python_handlers_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/python/subcommands_test.py
+++ b/ycmd/tests/python/subcommands_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/request_validation_test.py
+++ b/ycmd/tests/request_validation_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2014  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/tests/request_wrap_test.py
+++ b/ycmd/tests/request_wrap_test.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# coding: utf-8
 #
 # Copyright (C) 2014 Google Inc.
 #

--- a/ycmd/tests/rust/get_completions_test.py
+++ b/ycmd/tests/rust/get_completions_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/rust/rust_handlers_test.py
+++ b/ycmd/tests/rust/rust_handlers_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/rust/subcommands_test.py
+++ b/ycmd/tests/rust/subcommands_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013 Google Inc.
 #               2015 ycmd contributors
 #

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013 Google Inc.
 #               2015 ycmd contributors
 #

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/tests/typescript/typescript_handlers_test.py
+++ b/ycmd/tests/typescript/typescript_handlers_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2015 ycmd contributors.
 #
 # This file is part of ycmd.

--- a/ycmd/user_options_store.py
+++ b/ycmd/user_options_store.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011, 2012  Google Inc.
 #
 # This file is part of YouCompleteMe.

--- a/ycmd/watchdog_plugin.py
+++ b/ycmd/watchdog_plugin.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2013  Google Inc.
 #
 # This file is part of YouCompleteMe.


### PR DESCRIPTION
We only need the shebang line for Python scripts (`build.py`, `run_tests.py`, and `example_client.py`).

Also, [use `coding: utf-8` for Python encoding instead of `-*- coding: utf-8 -*-`](https://www.python.org/dev/peps/pep-0263/), which is specific to Emacs.

I'll update the copyrights next.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/346)
<!-- Reviewable:end -->
