### PR TITLE
[READY] Fix issue when first candidate contains keywords as its substring

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -230,14 +230,15 @@ class Completer( object ):
 
     # We need to handle both an omni_completer style completer and a server
     # style completer
-    if 'words' in candidates:
+    if isinstance( candidates, dict ) and 'words' in candidates:
       candidates = candidates[ 'words' ]
 
     sort_property = ''
-    if 'word' in candidates[ 0 ]:
-      sort_property = 'word'
-    elif 'insertion_text' in candidates[ 0 ]:
-      sort_property = 'insertion_text'
+    if isinstance( candidates[ 0 ], dict ):
+      if 'word' in candidates[ 0 ]:
+        sort_property = 'word'
+      elif 'insertion_text' in candidates[ 0 ]:
+        sort_property = 'insertion_text'
 
     matches = FilterAndSortCandidates( candidates,
                                        sort_property,

--- a/ycmd/tests/completer_test.py
+++ b/ycmd/tests/completer_test.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2016 ycmd contributors.
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from ycmd.tests.test_utils import DummyCompleter
+from ycmd.user_options_store import DefaultOptions
+from nose.tools import eq_
+
+
+def _FilterAndSortCandidates_Match( candidates, query, expected_matches ):
+  completer = DummyCompleter( DefaultOptions() )
+  matches = completer.FilterAndSortCandidates( candidates, query )
+  eq_( expected_matches, matches )
+
+
+def FilterAndSortCandidates_OmniCompleter_List_test():
+  _FilterAndSortCandidates_Match( [ 'password' ],
+                                  'p',
+                                  [ 'password' ] )
+  _FilterAndSortCandidates_Match( [ 'words' ],
+                                  'w',
+                                  [ 'words' ] )
+
+
+def FilterAndSortCandidates_OmniCompleter_Dictionary_test():
+  _FilterAndSortCandidates_Match( { 'words': [ 'password' ] },
+                                  'p',
+                                  [ 'password' ] )
+  _FilterAndSortCandidates_Match( { 'words': [ { 'word': 'password' } ] },
+                                  'p',
+                                  [ { 'word': 'password' } ] )
+
+
+def FilterAndSortCandidates_ServerCompleter_test():
+  _FilterAndSortCandidates_Match( [ { 'insertion_text': 'password' } ],
+                                  'p',
+                                  [ { 'insertion_text': 'password' } ] )


### PR DESCRIPTION
### Problem

When the first candidate from the Omnifunc candidates list is the string `words` or contains the substring `word`, the following error is raised:
```python
TypeError: string/list indices must be integers, not str
```
Reason is that the condition `<key> in <dictionary>` can also return true if `<dictionary>` is a list or a string.

### Solution

Add tests covering these edge cases. Check if `candidates` and `candidate[ 0 ]` are dictionaries before looking at the existence of the `word` and `words` keys.

This PR fixes Valloric/YouCompleteMe#1953.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/349)
<!-- Reviewable:end -->
