### PR TITLE
[READY] Don't look for binaries in user's PATH for Go

### DIFF
--- a/ycmd/completers/go/hook.py
+++ b/ycmd/completers/go/hook.py
@@ -23,7 +23,12 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycmd.completers.go.gocode_completer import GoCodeCompleter
+from ycmd.completers.go.gocode_completer import (
+    GoCodeCompleter, ShouldEnableGoCompleter )
+
 
 def GetCompleter( user_options ):
+  if not ShouldEnableGoCompleter( user_options ):
+    return None
+
   return GoCodeCompleter( user_options )

--- a/ycmd/tests/go/gocode_completer_test.py
+++ b/ycmd/tests/go/gocode_completer_test.py
@@ -27,8 +27,8 @@ from builtins import *  # noqa
 
 import os
 from nose.tools import eq_, raises
-from ycmd.completers.go.gocode_completer import ( GoCodeCompleter,
-                                                  PATH_TO_GOCODE_BINARY )
+from ycmd.completers.go.gocode_completer import ( GoCodeCompleter, GO_BINARIES,
+                                                  FindBinary )
 from ycmd.request_wrap import RequestWrap
 from ycmd import user_options_store
 from ycmd.utils import ReadFile
@@ -71,16 +71,13 @@ class GoCodeCompleter_test( object ):
   def FindGoCodeBinary_test( self ):
     user_options = user_options_store.DefaultOptions()
 
-    eq_( PATH_TO_GOCODE_BINARY,
-         self._completer.FindBinary( "gocode", user_options ) )
+    eq_( GO_BINARIES.get( "gocode" ), FindBinary( "gocode", user_options ) )
 
     user_options[ 'gocode_binary_path' ] = DUMMY_BINARY
-    eq_( DUMMY_BINARY,
-         self._completer.FindBinary( "gocode", user_options ) )
+    eq_( DUMMY_BINARY, FindBinary( "gocode", user_options ) )
 
     user_options[ 'gocode_binary_path' ] = DATA_DIR
-    eq_( None,
-         self._completer.FindBinary( "gocode", user_options ) )
+    eq_( None, FindBinary( "gocode", user_options ) )
 
 
   # Test line-col to offset in the file before any unicode occurrences.

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -194,6 +194,10 @@ def FindExecutable( executable ):
   return None
 
 
+def ExecutableName( executable ):
+  return executable + ( '.exe' if OnWindows() else '' )
+
+
 def OnWindows():
   return sys.platform == 'win32'
 


### PR DESCRIPTION
I believe that looking at the user PATH is not user friendly as showned by https://github.com/Valloric/ycmd/issues/354. If the user really want to use a different binary than the one we ship there's always the user option `gocode_binary_path` and `godef_binary_path` available.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/355)
<!-- Reviewable:end -->
