### PR TITLE
[READY] Wait longer for JediHTTP to be ready in tests

### DIFF
--- a/ycmd/tests/python/python_handlers_test.py
+++ b/ycmd/tests/python/python_handlers_test.py
@@ -30,7 +30,7 @@ class Python_Handlers_test( Handlers_test ):
 
 
   def WaitUntilJediHTTPServerReady( self ):
-    retries = 10
+    retries = 100
 
     while retries > 0:
       result = self._app.get( '/ready', { 'subserver': 'python' } ).json


### PR DESCRIPTION
I've tried to debug and reproduce the flakiness of JediHTTP but I couldn't. So for now let's just bump the number of tries to 100 and see how it goes. If it will happen again I'll take a deeper look.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/357)
<!-- Reviewable:end -->
