### PR TITLE
[READY] Fix wrong constant used in Typescript completer

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -43,7 +43,7 @@ class DeferredResponse( object ):
   A deferred that resolves to a response from TSServer.
   """
 
-  def __init__( self, timeout = MAX_DETAILED_COMPLETIONS ):
+  def __init__( self, timeout = RESPONSE_TIMEOUT_SECONDS ):
     self._event = Event()
     self._message = None
     self._timeout = timeout


### PR DESCRIPTION
It sets a timeout of 100 seconds, which is a little long.

Should not conflict with PR #358.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/359)
<!-- Reviewable:end -->
