### PR TITLE
Find system-libclang on Debian x386 systems

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -289,7 +289,11 @@ if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
     # On Debian-based systems, llvm installs into /usr/lib/llvm-x.y.
     file( GLOB SYS_LLVM_PATHS "/usr/lib/llvm*/lib" )
     # Need TEMP because find_library does not work with an option variable
-    find_library( TEMP clang
+    # On Debian-based systems only a symlink to libclang.so.1 is created
+    find_library( TEMP
+                  NAMES
+                  clang
+                  libclang.so.1
                   PATHS
                   ${ENV_LIB_PATHS}
                   /usr/lib


### PR DESCRIPTION
Search not only for clang, but also for libclang.so.1.
This way the system-wide installed libclang is found on Debian-based systems.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/361)
<!-- Reviewable:end -->
