### PR TITLE
Modify C triggers for completer_utils.py

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -143,7 +143,7 @@ def FiletypeCompleterExistsForFiletype( filetype ):
 TRIGGER_REGEX_PREFIX = 're!'
 
 DEFAULT_FILETYPE_TRIGGERS = {
-  'c' : ['->', '.'],
+  'c' : ['->', '.', r're![_a-zA-Z][_a-zA-Z0-9]*'],
   'objc' : ['->',
             '.',
             r're!\[[_a-zA-Z]+\w*\s',    # bracketed calls


### PR DESCRIPTION
For C programmers, there are lots of long function and macro names, such as a_foo_bar, which is similar to a->foo->bar in c++, ycmd may be better for c programmers to add `DEFAULT_FILETYPE_TRIGGERS` for C. Before changing this, ycmd can only complete for struct members in C, which is not very useful. Since it's only a minor change, I didn't write a test, but only test it in my emacs. As for completion speed, it runs with no extra time when adding GLib and all standard librarys for C.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/364)
<!-- Reviewable:end -->
