### PR TITLE
[READY] Fixing Travis issues with setuptools

### DIFF
--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -33,7 +33,7 @@ if [ "${YCMD_PYTHON_VERSION}" == "2.6" ]; then
 elif [ "${YCMD_PYTHON_VERSION}" == "2.7" ]; then
   PYENV_VERSION="2.7.6"
 else
-  PYENV_VERSION="3.3.0"
+  PYENV_VERSION="3.3.6"
 fi
 
 pyenv install --skip-existing ${PYENV_VERSION}


### PR DESCRIPTION
For some reason, when using python 3.3.0 setuptools [ends up being
broken](https://travis-ci.org/Valloric/ycmd/jobs/109484455) which breaks out Travis config. But using python 3.3.6 fixes it
(other versions >3.3.0 & <3.3.6 might also work).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/371)
<!-- Reviewable:end -->
