### PR TITLE
[READY] Running ./style_format.sh to reformat C++

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -213,7 +213,7 @@ ClangCompleter::GetFixItsForLocationInFile(
   int column,
   const std::vector< UnsavedFile > &unsaved_files,
   const std::vector< std::string > &flags,
-  bool reparse) {
+  bool reparse ) {
 
   ReleaseGil unlock;
 
@@ -237,7 +237,7 @@ DocumentationData ClangCompleter::GetDocsForLocationInFile(
   int column,
   const std::vector< UnsavedFile > &unsaved_files,
   const std::vector< std::string > &flags,
-  bool reparse) {
+  bool reparse ) {
 
   ReleaseGil unlock;
 

--- a/cpp/ycm/ClangCompleter/ClangCompleter.h
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.h
@@ -97,7 +97,7 @@ public:
     int column,
     const std::vector< UnsavedFile > &unsaved_files,
     const std::vector< std::string > &flags,
-    bool reparse = true);
+    bool reparse = true );
 
   DocumentationData GetDocsForLocationInFile(
     const std::string &filename,
@@ -105,7 +105,7 @@ public:
     int column,
     const std::vector< UnsavedFile > &unsaved_files,
     const std::vector< std::string > &flags,
-    bool reparse = true);
+    bool reparse = true );
 
   void DeleteCachesForFile( const std::string &filename );
 

--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -100,7 +100,7 @@ std::vector< Range > GetRanges( const DiagnosticWrap &diagnostic_wrap ) {
 
   for ( uint i = 0; i < num_ranges; ++i ) {
     ranges.push_back(
-        Range( clang_getDiagnosticRange( diagnostic_wrap.get(), i ) ) );
+      Range( clang_getDiagnosticRange( diagnostic_wrap.get(), i ) ) );
   }
 
   return ranges;
@@ -117,19 +117,21 @@ Range GetLocationExtent( CXSourceLocation source_location,
   // situations.
 
   CXSourceRange range = clang_getCursorExtent(
-      clang_getCursor( translation_unit, source_location ) );
+                          clang_getCursor( translation_unit, source_location ) );
   CXToken *tokens;
   uint num_tokens;
   clang_tokenize( translation_unit, range, &tokens, &num_tokens );
 
   Location location( source_location );
   Range final_range;
+
   for ( uint i = 0; i < num_tokens; ++i ) {
     Location token_location( clang_getTokenLocation( translation_unit,
                                                      tokens[ i ] ) );
+
     if ( token_location == location ) {
       std::string name = CXStringToString(
-          clang_getTokenSpelling( translation_unit, tokens[ i ] ) );
+                           clang_getTokenSpelling( translation_unit, tokens[ i ] ) );
       Location end_location = location;
       end_location.column_number_ += name.length();
       final_range = Range( location, end_location );
@@ -215,7 +217,7 @@ Diagnostic BuildDiagnostic( DiagnosticWrap diagnostic_wrap,
     return diagnostic;
 
   CXSourceLocation source_location =
-      clang_getDiagnosticLocation( diagnostic_wrap.get() );
+    clang_getDiagnosticLocation( diagnostic_wrap.get() );
   diagnostic.location_ = Location( source_location );
   diagnostic.location_extent_ = GetLocationExtent( source_location,
                                                    translation_unit );
@@ -229,14 +231,15 @@ Diagnostic BuildDiagnostic( DiagnosticWrap diagnostic_wrap,
   // If there are any fixits supplied by libclang, cache them in the diagnostic
   // object.
   diagnostic.fixits_.reserve( num_fixits );
+
   for ( uint fixit_idx = 0; fixit_idx < num_fixits; ++fixit_idx ) {
     FixItChunk chunk;
     CXSourceRange sourceRange;
 
     chunk.replacement_text = CXStringToString(
-                                clang_getDiagnosticFixIt( diagnostic_wrap.get(),
-                                                          fixit_idx,
-                                                          &sourceRange) );
+                               clang_getDiagnosticFixIt( diagnostic_wrap.get(),
+                                                         fixit_idx,
+                                                         &sourceRange ) );
 
     chunk.range = sourceRange;
 

--- a/cpp/ycm/ClangCompleter/CompletionData.cpp
+++ b/cpp/ycm/ClangCompleter/CompletionData.cpp
@@ -256,11 +256,14 @@ void CompletionData::ExtractDataFromChunk( CXCompletionString completion_string,
     case CXCompletionChunk_ResultType:
       return_type_ = ChunkToString( completion_string, chunk_num );
       break;
+
     case CXCompletionChunk_Placeholder:
       saw_placeholder = true;
       break;
+
     case CXCompletionChunk_TypedText:
     case CXCompletionChunk_Text:
+
       // need to add paren to insert string
       // when implementing inherited methods or declared methods in objc.
     case CXCompletionChunk_LeftParen:
@@ -269,7 +272,9 @@ void CompletionData::ExtractDataFromChunk( CXCompletionString completion_string,
       if ( !saw_placeholder ) {
         original_string_ += ChunkToString( completion_string, chunk_num );
       }
+
       break;
+
     default:
       break;
   }

--- a/cpp/ycm/ClangCompleter/CompletionData.h
+++ b/cpp/ycm/ClangCompleter/CompletionData.h
@@ -119,7 +119,7 @@ private:
                              uint chunk_num,
                              bool &saw_left_paren,
                              bool &saw_function_params,
-                             bool &saw_placeholder);
+                             bool &saw_placeholder );
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/ClangCompleter/Documentation.cpp
+++ b/cpp/ycm/ClangCompleter/Documentation.cpp
@@ -24,25 +24,26 @@ namespace YouCompleteMe {
 
 namespace {
 
-bool CXCommentValid( const CXComment & comment ) {
+bool CXCommentValid( const CXComment &comment ) {
   return clang_Comment_getKind( comment ) != CXComment_Null;
 }
 
 }
 
-DocumentationData::DocumentationData( const CXCursor& cursor )
+DocumentationData::DocumentationData( const CXCursor &cursor )
   : raw_comment( CXStringToString( clang_Cursor_getRawCommentText( cursor ) ) )
   , brief_comment( CXStringToString(
-                                 clang_Cursor_getBriefCommentText( cursor ) ) )
+                     clang_Cursor_getBriefCommentText( cursor ) ) )
   , canonical_type( CXStringToString(
-                    clang_getTypeSpelling( clang_getCursorType( cursor ) ) ) )
+                      clang_getTypeSpelling( clang_getCursorType( cursor ) ) ) )
   , display_name( CXStringToString( clang_getCursorSpelling( cursor ) ) ) {
 
 
   CXComment parsed_comment = clang_Cursor_getParsedComment( cursor );
+
   if ( CXCommentValid( parsed_comment ) ) {
     comment_xml = CXStringToString(
-                                clang_FullComment_getAsXML( parsed_comment ) );
+                    clang_FullComment_getAsXML( parsed_comment ) );
   }
 }
 

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -45,7 +45,7 @@ unsigned EditingOptions() {
 }
 
 unsigned ReparseOptions( CXTranslationUnit translationUnit ) {
-    return clang_defaultReparseOptions( translationUnit );
+  return clang_defaultReparseOptions( translationUnit );
 }
 
 
@@ -81,7 +81,7 @@ TranslationUnit::TranslationUnit(
   std::vector< const char * > pointer_flags;
   pointer_flags.reserve( flags.size() );
 
-  foreach ( const std::string &flag, flags ) {
+  foreach ( const std::string & flag, flags ) {
     pointer_flags.push_back( flag.c_str() );
   }
 
@@ -263,7 +263,7 @@ std::string TranslationUnit::GetTypeAtLocation(
   const std::vector< UnsavedFile > &unsaved_files,
   bool reparse ) {
 
-  if (reparse)
+  if ( reparse )
     Reparse( unsaved_files );
 
   unique_lock< mutex > lock( clang_access_mutex_ );
@@ -279,7 +279,7 @@ std::string TranslationUnit::GetTypeAtLocation(
   CXType type = clang_getCursorType( cursor );
 
   std::string type_description =
-                        CXStringToString( clang_getTypeSpelling( type ) );
+    CXStringToString( clang_getTypeSpelling( type ) );
 
   if ( type_description.empty() )
     return "Unknown type";
@@ -308,7 +308,7 @@ std::string TranslationUnit::GetTypeAtLocation(
   if ( !clang_equalTypes( type, canonical_type ) ) {
     type_description += " => ";
     type_description += CXStringToString(
-                                  clang_getTypeSpelling( canonical_type ) );
+                          clang_getTypeSpelling( canonical_type ) );
   }
 
   return type_description;
@@ -320,7 +320,7 @@ std::string TranslationUnit::GetEnclosingFunctionAtLocation(
   const std::vector< UnsavedFile > &unsaved_files,
   bool reparse ) {
 
-  if (reparse)
+  if ( reparse )
     Reparse( unsaved_files );
 
   unique_lock< mutex > lock( clang_access_mutex_ );
@@ -336,9 +336,9 @@ std::string TranslationUnit::GetEnclosingFunctionAtLocation(
   CXCursor parent = clang_getCursorSemanticParent( cursor );
 
   std::string parent_str =
-                  CXStringToString( clang_getCursorDisplayName( parent ) );
+    CXStringToString( clang_getCursorDisplayName( parent ) );
 
-  if (parent_str.empty())
+  if ( parent_str.empty() )
     return "Unknown semantic parent";
 
   return parent_str;
@@ -407,23 +407,23 @@ void TranslationUnit::UpdateLatestDiagnostics() {
 }
 
 namespace {
-  /// Sort a FixIt container by its location's distance from a given column
-  /// (such as the cursor location).
-  ///
-  /// PreCondition: All FixIts in the container are on the same line.
-  struct sort_by_location {
-    sort_by_location( int column ) : column_( column ) { }
+/// Sort a FixIt container by its location's distance from a given column
+/// (such as the cursor location).
+///
+/// PreCondition: All FixIts in the container are on the same line.
+struct sort_by_location {
+  sort_by_location( int column ) : column_( column ) { }
 
-    bool operator()( const FixIt& a, const FixIt& b ) {
-      int a_distance = a.location.column_number_ - column_;
-      int b_distance = b.location.column_number_ - column_;
+  bool operator()( const FixIt &a, const FixIt &b ) {
+    int a_distance = a.location.column_number_ - column_;
+    int b_distance = b.location.column_number_ - column_;
 
-      return std::abs( a_distance ) < std::abs( b_distance );
-    }
+    return std::abs( a_distance ) < std::abs( b_distance );
+  }
 
-  private:
-    int column_;
-  };
+private:
+  int column_;
+};
 }
 
 std::vector< FixIt > TranslationUnit::GetFixItsForLocationInFile(
@@ -441,9 +441,9 @@ std::vector< FixIt > TranslationUnit::GetFixItsForLocationInFile(
     unique_lock< mutex > lock( diagnostics_mutex_ );
 
     for ( std::vector< Diagnostic >::const_iterator it
-                                        = latest_diagnostics_.begin();
+          = latest_diagnostics_.begin();
           it != latest_diagnostics_.end();
-          ++it) {
+          ++it ) {
 
       // Find all fixits for the supplied line
       if ( it->fixits_.size() > 0 &&
@@ -487,6 +487,7 @@ DocumentationData TranslationUnit::GetDocsForLocationInFile(
   // If the original cursor is a reference, then we return the documentation
   // for the type/method/etc. that is referenced
   CXCursor referenced_cursor = clang_getCursorReferenced( cursor );
+
   if ( CursorIsValid( referenced_cursor ) )
     cursor = referenced_cursor;
 

--- a/cpp/ycm/DLLDefines.h
+++ b/cpp/ycm/DLLDefines.h
@@ -21,9 +21,9 @@
 // We need to export symbols for gmock tests on Windows.  The preprocessor
 // symbol ycm_core_EXPORTS is defined by CMake when building a shared library.
 #if defined( _WIN32 ) && defined( ycm_core_EXPORTS )
-  #define YCM_DLL_EXPORT __declspec( dllexport )
+#define YCM_DLL_EXPORT __declspec( dllexport )
 #else
-  #define YCM_DLL_EXPORT
+#define YCM_DLL_EXPORT
 #endif
 
 #endif /* end of include guard: DLLDEFINES_H_0IYA3AQ3 */

--- a/cpp/ycm/IdentifierCompleter.cpp
+++ b/cpp/ycm/IdentifierCompleter.cpp
@@ -58,11 +58,11 @@ void IdentifierCompleter::AddIdentifiersToDatabase(
 
 
 void IdentifierCompleter::ClearForFileAndAddIdentifiersToDatabase(
-    const std::vector< std::string > &new_candidates,
-    const std::string &filetype,
-    const std::string &filepath ) {
+  const std::vector< std::string > &new_candidates,
+  const std::string &filetype,
+  const std::string &filepath ) {
   identifier_database_.ClearCandidatesStoredForFile( filetype, filepath );
-  AddIdentifiersToDatabase(new_candidates, filetype, filepath);
+  AddIdentifiersToDatabase( new_candidates, filetype, filepath );
 }
 
 

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -143,7 +143,7 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
     std::string identifier( matches[ 1 ] );
     fs::path path( matches[ 2 ].str() );
     path = fs::absolute( path, path_to_tag_file.parent_path() )
-      .make_preferred();
+           .make_preferred();
 
     filetype_identifier_map[ filetype ][ path.string() ].push_back( identifier );
   }

--- a/cpp/ycm/Result.cpp
+++ b/cpp/ycm/Result.cpp
@@ -32,25 +32,26 @@ namespace {
 char ChangeCharCase( char c ) {
   if ( std::isupper( c, std::locale() ) )
     return std::tolower( c, std::locale() );
+
   return std::toupper( c, std::locale() );
 }
 
 
-bool CharLessThanWithLowercasePriority(const char &first,
-                                       const char &second) {
+bool CharLessThanWithLowercasePriority( const char &first,
+                                        const char &second ) {
   char swap_first = ChangeCharCase( first );
   char swap_second = ChangeCharCase( second );
   return swap_first < swap_second;
 }
 
 
-bool StringLessThanWithLowercasePriority(const std::string &first,
-                                         const std::string &second) {
+bool StringLessThanWithLowercasePriority( const std::string &first,
+                                          const std::string &second ) {
   return std::lexicographical_compare(
-      first.begin(), first.end(),
-      second.begin(), second.end(),
-      boost::function< bool( const char&, const char& ) >(
-          &CharLessThanWithLowercasePriority ) );
+           first.begin(), first.end(),
+           second.begin(), second.end(),
+           boost::function< bool( const char &, const char & ) >(
+             &CharLessThanWithLowercasePriority ) );
 }
 
 

--- a/cpp/ycm/tests/Candidate_test.cpp
+++ b/cpp/ycm/tests/Candidate_test.cpp
@@ -85,8 +85,7 @@ TEST( GetWordBoundaryCharsTest, UppercaseSequenceInMiddlePunctuation ) {
   EXPECT_EQ( "ssf", GetWordBoundaryChars( "simpleSTUFF_Foo" ) );
 }
 
-TEST( GetWordBoundaryCharsTest, UppercaseSequenceInMiddlePunctuationLowercase )
-{
+TEST( GetWordBoundaryCharsTest, UppercaseSequenceInMiddlePunctuationLowercase ) {
   EXPECT_EQ( "ssf", GetWordBoundaryChars( "simpleSTUFF_foo" ) );
   EXPECT_EQ( "ssf", GetWordBoundaryChars( "simpleSTUFF.foo" ) );
 }

--- a/cpp/ycm/tests/ClangCompleter/ClangCompleter_test.cpp
+++ b/cpp/ycm/tests/ClangCompleter/ClangCompleter_test.cpp
@@ -59,8 +59,8 @@ TEST( ClangCompleterTest, BufferTextNoParens ) {
   EXPECT_TRUE( !completions.empty() );
   EXPECT_THAT( completions,
                Contains(
-                   Property( &CompletionData::TextToInsertInBuffer,
-                             StrEq( "foobar" ) ) ) );
+                 Property( &CompletionData::TextToInsertInBuffer,
+                           StrEq( "foobar" ) ) ) );
 }
 
 
@@ -70,12 +70,12 @@ TEST( ClangCompleterTest, CandidatesObjCForLocationInFile ) {
   flags.push_back( "-x" );
   flags.push_back( "objective-c" );
   std::vector< CompletionData > completions =
-      completer.CandidatesForLocationInFile(
-          PathToTestFile( "SWObject.m" ).string(),
-          6,
-          16,
-          std::vector< UnsavedFile >(),
-          flags );
+    completer.CandidatesForLocationInFile(
+      PathToTestFile( "SWObject.m" ).string(),
+      6,
+      16,
+      std::vector< UnsavedFile >(),
+      flags );
 
   EXPECT_TRUE( !completions.empty() );
   EXPECT_THAT( completions[0].TextToInsertInBuffer(), StrEq( "withArg2:" ) );
@@ -88,17 +88,17 @@ TEST( ClangCompleterTest, CandidatesObjCFuncForLocationInFile ) {
   flags.push_back( "-x" );
   flags.push_back( "objective-c" );
   std::vector< CompletionData > completions =
-      completer.CandidatesForLocationInFile(
-          PathToTestFile( "SWObject.m" ).string(),
-          9,
-          3,
-          std::vector< UnsavedFile >(),
-          flags );
+    completer.CandidatesForLocationInFile(
+      PathToTestFile( "SWObject.m" ).string(),
+      9,
+      3,
+      std::vector< UnsavedFile >(),
+      flags );
 
   EXPECT_TRUE( !completions.empty() );
   EXPECT_THAT(
-      completions[0].TextToInsertInBuffer(),
-      StrEq( "(void)test:(int)arg1 withArg2:(int)arg2 withArg3:(int)arg3" ) );
+    completions[0].TextToInsertInBuffer(),
+    StrEq( "(void)test:(int)arg1 withArg2:(int)arg2 withArg3:(int)arg3" ) );
 }
 
 

--- a/cpp/ycm/tests/IdentifierCompleter_test.cpp
+++ b/cpp/ycm/tests/IdentifierCompleter_test.cpp
@@ -228,7 +228,7 @@ TEST( IdentifierCompleterTest, PreferLowercaseCandidate ) {
                  StringVector(
                    "chatContentExtension",
                    "ChatContentExtension" ) ).CandidatesForQuery(
-                       "chatContent" ),
+                 "chatContent" ),
                ElementsAre( "chatContentExtension",
                             "ChatContentExtension" ) );
 

--- a/cpp/ycm/versioning.h
+++ b/cpp/ycm/versioning.h
@@ -21,7 +21,7 @@
 // The true value of this preprocessor definition is set in a compiler
 // command-line flag. This is done in the main CMakeLists.txt file.
 #if !defined( YCMD_CORE_VERSION )
-  #define YCMD_CORE_VERSION 0
+#define YCMD_CORE_VERSION 0
 #endif
 
 namespace YouCompleteMe {

--- a/vagrant_bootstrap.sh
+++ b/vagrant_bootstrap.sh
@@ -31,6 +31,7 @@ apt-get install -yqq cmake
 apt-get install -yqq git
 apt-get install -yqq golang
 apt-get install -yqq mono-complete
+apt-get install -yqq astyle
 
 # These two are for pyopenssl
 apt-get install -yqq libffi-dev


### PR DESCRIPTION
People forget to run it in PRs so we've accumulated some things that
don't follow the style guide.

Since astyle isn't perfect, this also makes some code worse (like
the #define indents), but we don't want to make manual changes to astyle
output. (If clang-format were more flexible, we could use that, but
currently it produces worse output that astyle for our codebase.)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/372)
<!-- Reviewable:end -->
