### PR TITLE
[READY] Fixing issues with setting headers on py2

### DIFF
--- a/ycmd/bottle_utils.py
+++ b/ycmd/bottle_utils.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2016 ycmd contributors.
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from future.utils import PY2
+from ycmd.utils import ToBytes, ToUnicode
+import bottle
+
+
+# Bottle.py is stupid when it comes to bytes vs unicode so we have to carefully
+# conform to its stupidity when setting headers.
+# Bottle docs state that the response.headers dict-like object stores keys and
+# values as bytes on py2 and unicode on py3. What it _actually_ does is store
+# keys in this variable state while values are always unicode (on both py2 and
+# py3).
+# Both the documented and actual behavior are dumb and cause needless problems.
+# Bottle should just consistently store unicode objects on both Python versions,
+# making life easier for codebases that work across versions, thus preventing
+# tracebacks in the depths of WSGI server frameworks.
+def SetResponseHeader( name, value ):
+  name = ToBytes( name ) if PY2 else ToUnicode( name )
+  bottle.response.set_header( name, ToUnicode( value ) )

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -41,13 +41,14 @@ import json
 import bottle
 import http.client
 import traceback
-from bottle import request, response
+from bottle import request
 from . import server_state
 from ycmd import user_options_store
 from ycmd.responses import BuildExceptionResponse, BuildCompletionResponse
 from ycmd import hmac_plugin
 from ycmd import extra_conf_store
 from ycmd.request_wrap import RequestWrap
+from ycmd.bottle_utils import SetResponseHeader
 
 
 # num bytes for the request body buffer; request.json only works if the request
@@ -228,7 +229,7 @@ def ErrorHandler( httperror ):
 
 
 def _JsonResponse( data ):
-  response.set_header( 'Content-Type', 'application/json' )
+  SetResponseHeader( 'Content-Type', 'application/json' )
   return json.dumps( data, default = _UniversalSerialize )
 
 

--- a/ycmd/hmac_plugin.py
+++ b/ycmd/hmac_plugin.py
@@ -27,9 +27,10 @@ import logging
 import http.client
 from urllib.parse import urlparse
 from base64 import b64decode, b64encode
-from bottle import request, response, abort
+from bottle import request, abort
 from ycmd import hmac_utils
-from ycmd.utils import ToBytes, ToUnicode
+from ycmd.utils import ToBytes
+from ycmd.bottle_utils import SetResponseHeader
 
 _HMAC_HEADER = 'x-ycm-hmac'
 _HOST_HEADER = 'host'
@@ -91,5 +92,6 @@ def RequestAuthenticated( method, path, body, hmac_secret ):
 
 
 def SetHmacHeader( body, hmac_secret ):
-  response.headers[ _HMAC_HEADER ] = ToUnicode( b64encode(
-      hmac_utils.CreateHmac( ToBytes( body ), ToBytes( hmac_secret ) ) ) )
+  value = b64encode( hmac_utils.CreateHmac( ToBytes( body ),
+                                            ToBytes( hmac_secret ) ) )
+  SetResponseHeader( _HMAC_HEADER, value )

--- a/ycmd/tests/bottle_utils_test.py
+++ b/ycmd/tests/bottle_utils_test.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2016 ycmd contributors.
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+# Intentionally not importing unicode_literals!
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from future.utils import PY2
+from nose.tools import eq_
+from mock import patch, call
+from ycmd import bottle_utils
+import bottle
+
+
+if PY2:
+  @patch( 'bottle.response' )
+  def SetResponseHeader_Py2CorrectTypesWithStr_test( *args ):
+    bottle_utils.SetResponseHeader( 'foo', 'bar' )
+    eq_( bottle.response.set_header.call_args, call( 'foo', u'bar' ) )
+
+
+  @patch( 'bottle.response' )
+  def SetResponseHeader_Py2CorrectTypesWithUnicode_test( *args ):
+    bottle_utils.SetResponseHeader( u'foo', u'bar' )
+    eq_( bottle.response.set_header.call_args, call( 'foo', u'bar' ) )
+
+else:
+  @patch( 'bottle.response' )
+  def SetResponseHeader_Py3CorrectTypesWithBytes_test( *args ):
+    bottle_utils.SetResponseHeader( b'foo', b'bar' )
+    eq_( bottle.response.set_header.call_args, call( u'foo', u'bar' ) )
+
+
+  @patch( 'bottle.response' )
+  def SetResponseHeader_Py3CorrectTypesWithUnicode_test( *args ):
+    bottle_utils.SetResponseHeader( u'foo', u'bar' )
+    eq_( bottle.response.set_header.call_args, call( u'foo', u'bar' ) )

--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -22,8 +22,8 @@ from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
-from future.utils import PY2, native
 
+from future.utils import PY2, native
 from hamcrest import raises, assert_that, calling
 from mock import patch, call
 from nose.tools import eq_, ok_


### PR DESCRIPTION
Bottle is dumb when it comes to headers and bytes vs unicode. Details in source comments.

Funny thing: the reason why I didn't notice this problem while working on the py3 compatibility PR is that all our tests skip the main WSGI interface, so to test that part too since we don't have ycmd smoke tests (yet, but I'll be fixing that), I used the example_client to talk to ycmd. This worked great, but since the example_client only works on py3, I only tested in a py3 pyenv, which ran ycmd in a py3 interpreter... but this problem only appears on a py2 interpreter, which I'm using now while trying to make YCM work with latest ycmd.

Yet another case of "having more tests would have caught this early and saved you a ton of effort and hair-pulling" (which I'm naming _The Perennial Lesson_ AKA _MOAR TESTS!_). Here we needed ycmd smoke tests that bring up the whole server (on both pythons) and send a `/healthy` ping. It would have caught this.

Second funny thing: I was literally working on such smoke tests this morning before I realized it will be a lot of work and decided to work on something else (YCM with latest ycmd) instead. Serves me right.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/376)
<!-- Reviewable:end -->
