### PR TITLE
[READY] ToBytes/ToUnicode return empty bytes/str for None

### DIFF
--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -85,6 +85,12 @@ def ToBytes_Int_test():
   eq_( type( value ), bytes )
 
 
+def ToBytes_None_test():
+  value = utils.ToBytes( None )
+  eq_( value, bytes( b'' ) )
+  eq_( type( value ), bytes )
+
+
 if PY2:
   def ToUnicode_Py2Bytes_test():
     value = utils.ToUnicode( bytes( 'abc' ) )
@@ -131,6 +137,12 @@ def ToUnicode_Str_test():
 def ToUnicode_Int_test():
   value = utils.ToUnicode( 123 )
   eq_( value, u'123' )
+  ok_( isinstance( value, str ) )
+
+
+def ToUnicode_None_test():
+  value = utils.ToUnicode( None )
+  eq_( value, u'' )
   ok_( isinstance( value, str ) )
 
 

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -79,6 +79,8 @@ def ToCppStringCompatible( value ):
 # Returns a unicode type; either the new python-future str type or the real
 # unicode type. The difference shouldn't matter.
 def ToUnicode( value ):
+  if not value:
+    return str()
   if isinstance( value, str ):
     return value
   if isinstance( value, bytes ):
@@ -90,6 +92,9 @@ def ToUnicode( value ):
 # Consistently returns the new bytes() type from python-future. Assumes incoming
 # strings are either UTF-8 or unicode (which is converted to UTF-8).
 def ToBytes( value ):
+  if not value:
+    return bytes()
+
   # This is tricky. On py2, the bytes type from builtins (from python-future) is
   # a subclass of str. So all of the following are true:
   #   isinstance(str(), bytes)


### PR DESCRIPTION
They used to return `u'None'`/`b'None'`, which we don't want.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/383)
<!-- Reviewable:end -->
