### PR TITLE
[READY] Fix ycm_core_tests linking order on Windows

### DIFF
--- a/cpp/ycm/tests/CMakeLists.txt
+++ b/cpp/ycm/tests/CMakeLists.txt
@@ -104,9 +104,10 @@ if ( MSVC )
   endforeach()
 endif()
 
+# ycm_core must be linked after Boost libraries on Windows.
 target_link_libraries( ${PROJECT_NAME}
-                       ycm_core
                        ${Boost_LIBRARIES}
+                       ycm_core
                        ${GTEST_LIBRARIES}
                        ${GMOCK_LIBRARIES} )
 
@@ -115,17 +116,17 @@ if ( NOT CMAKE_GENERATOR_IS_XCODE )
   # Because there's NO reliable, cross-platform way of getting the directory in
   # which the executable is located.
   add_custom_target( copy_testdata
-                    COMMAND cmake -E copy_directory
-                    ${CMAKE_CURRENT_SOURCE_DIR}/testdata
-                    ${CMAKE_CURRENT_BINARY_DIR}/testdata )
+                     COMMAND cmake -E copy_directory
+                     ${CMAKE_CURRENT_SOURCE_DIR}/testdata
+                     ${CMAKE_CURRENT_BINARY_DIR}/testdata )
 else()
   add_custom_target( copy_testdata
-                    COMMAND cmake -E copy_directory
-                    ${CMAKE_CURRENT_SOURCE_DIR}/testdata
-                    ${CMAKE_CURRENT_BINARY_DIR}/Debug/testdata
-                    COMMAND cmake -E copy_directory
-                    ${CMAKE_CURRENT_SOURCE_DIR}/testdata
-                    ${CMAKE_CURRENT_BINARY_DIR}/Release/testdata )
+                     COMMAND cmake -E copy_directory
+                     ${CMAKE_CURRENT_SOURCE_DIR}/testdata
+                     ${CMAKE_CURRENT_BINARY_DIR}/Debug/testdata
+                     COMMAND cmake -E copy_directory
+                     ${CMAKE_CURRENT_SOURCE_DIR}/testdata
+                     ${CMAKE_CURRENT_BINARY_DIR}/Release/testdata )
 
 endif()
 


### PR DESCRIPTION
Fix the link error:
```
ycm_core_tests.exe : fatal error LNK1169: one or more multiply defined symbols found
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/387)
<!-- Reviewable:end -->
