### PR TITLE
Fix Boost.Python error in ycm_extra_conf.py

### DIFF
--- a/cpp/ycm/.ycm_extra_conf.py
+++ b/cpp/ycm/.ycm_extra_conf.py
@@ -152,11 +152,11 @@ def GetCompilationInfoForFile( filename ):
       replacement_file = basename + extension
       if os.path.exists( replacement_file ):
         compilation_info = database.GetCompilationInfoForFile(
-          replacement_file )
+          str(replacement_file.encode("utf-8")) )
         if compilation_info.compiler_flags_:
           return compilation_info
     return None
-  return database.GetCompilationInfoForFile( filename )
+  return database.GetCompilationInfoForFile( str(filename.encode("utf-8")) )
 
 
 def FlagsForFile( filename, **kwargs ):


### PR DESCRIPTION
Python loads the compilation database using unicode strings.
However, Boost.Python cannot handle this and throws an error.
This patch converts the paths to utf-8 strings before passing them on to C++.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/389)
<!-- Reviewable:end -->
