### PR TITLE
[READY] Revert "Auto merge of #245 - micbou:clang-download, r=Valloric"

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -88,28 +88,10 @@ if ( USE_CLANG_COMPLETER AND
     message( "Downloading Clang ${CLANG_VERSION}" )
 
     set( CLANG_URL "http://llvm.org/releases/${CLANG_VERSION}" )
-
-    # Try to download Clang several times until successful to prevent failure
-    # from network issues on CI services.
-    set( DOWNLOAD_TRIES 3 )
-    set( DOWNLOAD_TRY 0 )
-    set( DOWNLOAD_ERROR 1 )
-
-    while( DOWNLOAD_ERROR AND DOWNLOAD_TRY LESS DOWNLOAD_TRIES )
-      file(
-        DOWNLOAD "${CLANG_URL}/${CLANG_FILENAME}" "${CLANG_LOCAL_FILE}"
-        STATUS DOWNLOAD_STATUS
-        SHOW_PROGRESS
-        EXPECTED_HASH SHA256=${CLANG_SHA256}
-      )
-      math( EXPR DOWNLOAD_TRY "${DOWNLOAD_TRY} + 1" )
-      list( GET DOWNLOAD_STATUS 0 DOWNLOAD_ERROR )
-    endwhile()
-
-    if( DOWNLOAD_ERROR )
-      message( FATAL_ERROR
-        "Could not download ${CLANG_URL}/${CLANG_FILENAME}" )
-    endif()
+    file(
+      DOWNLOAD "${CLANG_URL}/${CLANG_FILENAME}" "${CLANG_LOCAL_FILE}"
+      SHOW_PROGRESS EXPECTED_HASH SHA256=${CLANG_SHA256}
+    )
   else()
     message( "Using Clang archive: ${CLANG_LOCAL_FILE}" )
   endif()


### PR DESCRIPTION
This is not working as expected because if one download fails, CMake considers the configuration as incomplete even if a subsequent download is successful, and the `build.py` script returns an error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/391)
<!-- Reviewable:end -->
