### PR TITLE
[READY] Update Travis and AppVeyor caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,11 +76,9 @@ addons:
 cache:
   directories:
     - $HOME/.cache/pip  # Python packages from pip
-    - $HOME/.dnx/packages  # .Net packages?
-    - $HOME/.multirust  # what multirust downloads
-    - $HOME/.cargo  # cargo package deps
+    - $HOME/.npm  # Node packages from npm
+    - $HOME/.multirust  # What multirust downloads
+    - $HOME/.cargo  # Cargo package deps
     - $HOME/.pyenv  # pyenv
-    - $TRAVIS_BUILD_DIR/clang_archives  # clang downloads
-    # dependency compilation output
-    - $TRAVIS_BUILD_DIR/third_party/racerd/target
-    - $TRAVIS_BUILD_DIR/third_party/OmniSharpServer/OmniSharp/bin/Release
+    - $TRAVIS_BUILD_DIR/clang_archives  # Clang downloads
+    - $TRAVIS_BUILD_DIR/third_party/racerd/target  # Racerd compilation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,8 @@ build_script:
 # Disable automatic tests
 test: off
 cache:
-  - '%USERPROFILE%\.cargo -> third_party\racerd'
-  - 'third_party\racerd\target -> third_party\racerd'
-  - '%LOCALAPPDATA%\pip\cache'
-  - '%APPDATA%\npm-cache'
+  - '%LOCALAPPDATA%\pip\cache'  # Python packages from pip
+  - '%APPDATA%\npm-cache'  # Node packages from npm
+  - '%USERPROFILE%\.cargo'  # Cargo package deps
+  - '%APPVEYOR_BUILD_FOLDER%\clang_archives'  # Clang downloads
+  - '%APPVEYOR_BUILD_FOLDER%\third_party\racerd\target'  # Racerd compilation


### PR DESCRIPTION
This introduces the following changes with Travis and AppVeyor caches:
 - remove DNX cache on Travis. It is not related to OmniSharp server but Omnisharp Roslyn;
 - add NPM cache on Travis (`TypeScript` and `Tern` packages);
 - remove OmniSharp compilation folder from cache because the gain is negligible: it takes 6s to compile and its the OmniSharp dependencies that takes the most time to compile, not OmniSharp itself (it is almost instantaneous);
 - add Clang downloads to cache on AppVeyor: avoid network issues when downloading Clang;
 - disable cache invalidation for Rust on AppVeyor: apparently, it is not needed.

Overall, try to uniformize the cache rules between CI services.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/392)
<!-- Reviewable:end -->
