### PR TITLE
[READY] ycm_core imported inside wrap function

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -24,10 +24,11 @@ standard_library.install_aliases()
 from builtins import *  # noqa
 from future.utils import iteritems
 
+# Must not import ycm_core here! Vim imports completer, which imports this file.
+# We don't want ycm_core inside Vim.
 import os
 import re
 from collections import defaultdict
-from ycm_core import FilterAndSortCandidates
 from ycmd.utils import ToCppStringCompatible
 
 
@@ -152,6 +153,7 @@ def FiletypeCompleterExistsForFiletype( filetype ):
 
 
 def FilterAndSortCandidatesWrap( candidates, sort_property, query ):
+  from ycm_core import FilterAndSortCandidates
   return FilterAndSortCandidates( candidates,
                                   ToCppStringCompatible( sort_property ),
                                   ToCppStringCompatible( query ) )


### PR DESCRIPTION
We want to prevent Vim from importing ycm_core.

@vheon @micbou You guys noticed the issue in https://github.com/valloric/youcompleteme/pull/2004

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/393)
<!-- Reviewable:end -->
