### PR TITLE
[READY] Fix Python support tests on Windows

### DIFF
--- a/ycmd/tests/python_support_test.py
+++ b/ycmd/tests/python_support_test.py
@@ -23,12 +23,24 @@ from future import standard_library
 standard_library.install_aliases()
 # Intentionally not importing all builtins!
 
+import os
+
 from nose.tools import eq_
 from future.utils import native
 
 import ycm_core
-from ycmd.tests.test_utils import ClangOnly, Py2Only, Py3Only, PathToTestFile
-from ycmd.utils import ToBytes, ToUnicode
+from ycmd.tests.test_utils import ClangOnly, Py2Only, Py3Only
+from ycmd.utils import ToBytes, ToUnicode, OnWindows
+
+
+# We don't use PathToTestFile from test_utils module because this module
+# imports future modules that may change the path type.
+PATH_TO_TESTDATA = os.path.abspath( os.path.join( os.path.dirname( __file__ ),
+                                                  'testdata' ) )
+PATH_TO_COMPILE_COMMANDS = (
+  os.path.join( PATH_TO_TESTDATA, 'windows' ) if OnWindows() else
+  os.path.join( PATH_TO_TESTDATA, 'unix' ) )
+COMPILE_COMMANDS_WORKING_DIR = 'C:\\dir' if OnWindows() else '/dir'
 
 
 @Py2Only
@@ -40,9 +52,11 @@ def GetUtf8String_Py2Str_test():
 def GetUtf8String_Py3Bytes_test():
   eq_( 'foo', str( ycm_core.GetUtf8String( b'foo' ) ) )
 
+
 # No test for `bytes` from builtins because it's very difficult to make
 # GetUtf8String work with that and also it should never receive that type in the
 # first place (only py2 str/unicode and py3 bytes/str).
+
 
 def GetUtf8String_Unicode_test():
   eq_( 'foo', str( ycm_core.GetUtf8String( u'foo' ) ) )
@@ -51,13 +65,15 @@ def GetUtf8String_Unicode_test():
 @ClangOnly
 @Py2Only
 def CompilationDatabase_Py2Str_test():
-  testdata_dir = native( ToBytes( PathToTestFile() ) )
+  cc_dir = native( ToBytes( PATH_TO_COMPILE_COMMANDS ) )
+  cc_filename = native( ToBytes( os.path.join( COMPILE_COMMANDS_WORKING_DIR,
+                                               'example.cc' ) ) )
 
-  # Ctor reads ycmd/tests/testdata/compiled_commands.json
-  db = ycm_core.CompilationDatabase( testdata_dir )
-  info = db.GetCompilationInfoForFile( '/dir/example.cc' )
+  # Ctor reads ycmd/tests/testdata/[unix|windows]/compile_commands.json
+  db = ycm_core.CompilationDatabase( cc_dir )
+  info = db.GetCompilationInfoForFile( cc_filename )
 
-  eq_( str( info.compiler_working_dir_ ), '/dir' )
+  eq_( str( info.compiler_working_dir_ ), COMPILE_COMMANDS_WORKING_DIR )
   eq_( str( info.compiler_flags_[ 0 ] ), '/usr/bin/clang++' )
   eq_( str( info.compiler_flags_[ 1 ] ), 'example.cc' )
 
@@ -65,13 +81,15 @@ def CompilationDatabase_Py2Str_test():
 @ClangOnly
 @Py2Only
 def CompilationDatabase_Py2Unicode_test():
-  testdata_dir = native( ToUnicode( PathToTestFile() ) )
+  cc_dir = native( ToUnicode( PATH_TO_COMPILE_COMMANDS ) )
+  cc_filename = native( ToUnicode( os.path.join( COMPILE_COMMANDS_WORKING_DIR,
+                                                 'example.cc' ) ) )
 
-  # Ctor reads ycmd/tests/testdata/compiled_commands.json
-  db = ycm_core.CompilationDatabase( testdata_dir )
-  info = db.GetCompilationInfoForFile( u'/dir/example.cc' )
+  # Ctor reads ycmd/tests/testdata/[unix|windows]/compile_commands.json
+  db = ycm_core.CompilationDatabase( cc_dir )
+  info = db.GetCompilationInfoForFile( cc_filename )
 
-  eq_( str( info.compiler_working_dir_ ), '/dir' )
+  eq_( str( info.compiler_working_dir_ ), COMPILE_COMMANDS_WORKING_DIR )
   eq_( str( info.compiler_flags_[ 0 ] ), '/usr/bin/clang++' )
   eq_( str( info.compiler_flags_[ 1 ] ), 'example.cc' )
 
@@ -79,25 +97,28 @@ def CompilationDatabase_Py2Unicode_test():
 @ClangOnly
 @Py3Only
 def CompilationDatabase_Py3Bytes_test():
-  testdata_dir = native( ToBytes( PathToTestFile() ) )
+  cc_dir = native( ToBytes( PATH_TO_COMPILE_COMMANDS ) )
+  cc_filename = native( ToBytes( os.path.join( COMPILE_COMMANDS_WORKING_DIR,
+                                               'example.cc' ) ) )
 
-  # Ctor reads ycmd/tests/testdata/compiled_commands.json
-  db = ycm_core.CompilationDatabase( testdata_dir )
-  info = db.GetCompilationInfoForFile( b'/dir/example.cc' )
+  # Ctor reads ycmd/tests/testdata/[unix|windows]/compile_commands.json
+  db = ycm_core.CompilationDatabase( cc_dir )
+  info = db.GetCompilationInfoForFile( cc_filename )
 
-  eq_( str( info.compiler_working_dir_ ), '/dir' )
+  eq_( str( info.compiler_working_dir_ ), COMPILE_COMMANDS_WORKING_DIR )
   eq_( str( info.compiler_flags_[ 0 ] ), '/usr/bin/clang++' )
   eq_( str( info.compiler_flags_[ 1 ] ), 'example.cc' )
 
 
 @ClangOnly
 def CompilationDatabase_NativeString_test():
-  testdata_dir = PathToTestFile()
+  cc_dir = PATH_TO_COMPILE_COMMANDS
+  cc_filename = os.path.join( COMPILE_COMMANDS_WORKING_DIR, 'example.cc' )
 
-  # Ctor reads ycmd/tests/testdata/compiled_commands.json
-  db = ycm_core.CompilationDatabase( testdata_dir )
-  info = db.GetCompilationInfoForFile( '/dir/example.cc' )
+  # Ctor reads ycmd/tests/testdata/[unix|windows]/compile_commands.json
+  db = ycm_core.CompilationDatabase( cc_dir )
+  info = db.GetCompilationInfoForFile( cc_filename )
 
-  eq_( str( info.compiler_working_dir_ ), '/dir' )
+  eq_( str( info.compiler_working_dir_ ), COMPILE_COMMANDS_WORKING_DIR )
   eq_( str( info.compiler_flags_[ 0 ] ), '/usr/bin/clang++' )
   eq_( str( info.compiler_flags_[ 1 ] ), 'example.cc' )

--- a/ycmd/tests/testdata/unix/compile_commands.json
+++ b/ycmd/tests/testdata/unix/compile_commands.json
@@ -3,4 +3,3 @@
   "command": "/usr/bin/clang++ example.cc",
   "file": "example.cc"
 } ]
-

--- a/ycmd/tests/testdata/windows/compile_commands.json
+++ b/ycmd/tests/testdata/windows/compile_commands.json
@@ -1,0 +1,5 @@
+[ {
+  "directory": "C:\\dir",
+  "command": "/usr/bin/clang++ example.cc",
+  "file": "example.cc"
+} ]

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -330,4 +330,3 @@ def LoadPythonSource( name, pathname ):
   else:
     import importlib
     return importlib.machinery.SourceFileLoader( name, pathname ).load_module()
-


### PR DESCRIPTION
Fix tests by using a specific `compile_commands.json` for Windows. Refactor them to reduce code duplication.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/396)
<!-- Reviewable:end -->
