### PR TITLE
[READY] Defined handling of str vs bytes for FlagsForFile

### DIFF
--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -23,9 +23,23 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from nose.tools import eq_
-from nose.tools import ok_
+from nose.tools import eq_, ok_
 from ycmd.completers.cpp import flags
+from mock import patch, Mock
+
+
+@patch( 'ycmd.extra_conf_store.ModuleForSourceFile', return_value = Mock() )
+def FlagsForFile_BadNonUnicodeFlagsAreAlsoRemoved_test( *args ):
+  fake_flags = {
+    'flags': [ bytes( b'-c' ), '-c', bytes( b'-foo' ), '-bar' ],
+    'do_cache': True
+  }
+
+  with patch( 'ycmd.completers.cpp.flags._CallExtraConfFlagsForFile',
+              return_value = fake_flags ):
+    flags_object = flags.Flags()
+    flags_list = flags_object.FlagsForFile( '/foo', False )
+    eq_( list( flags_list ), [ '-foo', '-bar' ] )
 
 
 def SanitizeFlags_Passthrough_test():

--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -23,14 +23,15 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
+import os
+import subprocess
+from shutil import rmtree
+import ycm_core
 from future.utils import native
 from mock import patch, call
 from nose.tools import eq_, ok_
 from ycmd import utils
-from ycmd.tests.test_utils import PathToTestFile, Py2Only, WindowsOnly
-from shutil import rmtree
-import os
-import subprocess
+from ycmd.tests.test_utils import PathToTestFile, Py2Only, Py3Only, WindowsOnly
 
 # NOTE: isinstance() vs type() is carefully used in this test file. Before
 # changing things here, read the comments in utils.ToBytes.
@@ -160,12 +161,31 @@ def ToCppStringCompatible_Py2Str_test():
   eq_( value, 'abc' )
   eq_( type( value ), type( '' ) )
 
+  vector = ycm_core.StringVector()
+  vector.append( value )
+  eq_( vector[ 0 ], 'abc' )
+
+
+@Py2Only
+def ToCppStringCompatible_Py2Bytes_test():
+  value = utils.ToCppStringCompatible( bytes( b'abc' ) )
+  eq_( value, 'abc' )
+  eq_( type( value ), type( '' ) )
+
+  vector = ycm_core.StringVector()
+  vector.append( value )
+  eq_( vector[ 0 ], 'abc' )
+
 
 @Py2Only
 def ToCppStringCompatible_Py2Unicode_test():
   value = utils.ToCppStringCompatible( u'abc' )
   eq_( value, 'abc' )
   eq_( type( value ), type( '' ) )
+
+  vector = ycm_core.StringVector()
+  vector.append( value )
+  eq_( vector[ 0 ], 'abc' )
 
 
 @Py2Only
@@ -174,29 +194,42 @@ def ToCppStringCompatible_Py2Int_test():
   eq_( value, '123' )
   eq_( type( value ), type( '' ) )
 
+  vector = ycm_core.StringVector()
+  vector.append( value )
+  eq_( vector[ 0 ], '123' )
 
-def ToCppStringCompatible_Bytes_test():
+
+@Py3Only
+def ToCppStringCompatible_Py3Bytes_test():
   value = utils.ToCppStringCompatible( bytes( b'abc' ) )
   eq_( value, bytes( b'abc' ) )
   ok_( isinstance( value, bytes ) )
 
-
-def ToCppStringCompatible_Unicode_test():
-  value = utils.ToCppStringCompatible( u'abc' )
-  eq_( value, bytes( b'abc' ) )
-  ok_( isinstance( value, bytes ) )
+  vector = ycm_core.StringVector()
+  vector.append( value )
+  eq_( vector[ 0 ], 'abc' )
 
 
-def ToCppStringCompatible_Str_test():
+@Py3Only
+def ToCppStringCompatible_Py3Str_test():
   value = utils.ToCppStringCompatible( 'abc' )
   eq_( value, bytes( b'abc' ) )
   ok_( isinstance( value, bytes ) )
 
+  vector = ycm_core.StringVector()
+  vector.append( value )
+  eq_( vector[ 0 ], 'abc' )
 
-def ToCppStringCompatible_Int_test():
+
+@Py3Only
+def ToCppStringCompatible_Py3Int_test():
   value = utils.ToCppStringCompatible( 123 )
   eq_( value, bytes( b'123' ) )
   ok_( isinstance( value, bytes ) )
+
+  vector = ycm_core.StringVector()
+  vector.append( value )
+  eq_( vector[ 0 ], '123' )
 
 
 def PathToCreatedTempDir_DirDoesntExist_test():

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -70,9 +70,9 @@ def OpenForStdHandle( filepath ):
 # plugins. For other code, you likely want to use ToBytes below.
 def ToCppStringCompatible( value ):
   if isinstance( value, str ):
-    return value.encode( 'utf8' )
+    return native( value.encode( 'utf8' ) )
   if isinstance( value, bytes ):
-    return value
+    return native( value )
   return native( str( value ).encode( 'utf8' ) )
 
 


### PR DESCRIPTION
We now ensure that we pass a py2 str object to the user's FlagsForFile
function (in ycm_extra_conf.py) when running in a py2 interpreter. For
py3, we pass a py3 str object (so unicode).

For strings coming in from FlagsForFile, we accept all of [py2 str, py2
unicode, py3 bytes, py3 unicode]. UTF-8 for the encoded types.

Also, fixes a bug in ToCppStringCompatible which would break things with
unicode flags.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/398)
<!-- Reviewable:end -->
