### PR TITLE
[READY] Rename GoCodeCompleter -> GoCompleter

### DIFF
--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -91,10 +91,10 @@ def ShouldEnableGoCompleter( user_options ):
   return all( _HasBinary( binary ) for binary in [ 'gocode', 'godef' ] )
 
 
-class GoCodeCompleter( Completer ):
+class GoCompleter( Completer ):
 
   def __init__( self, user_options ):
-    super( GoCodeCompleter, self ).__init__( user_options )
+    super( GoCompleter, self ).__init__( user_options )
     self._popener = utils.SafePopen # Overridden in test.
     self._binary_gocode = FindBinary( 'gocode', user_options )
     self._binary_godef = FindBinary( 'godef', user_options )

--- a/ycmd/completers/go/hook.py
+++ b/ycmd/completers/go/hook.py
@@ -23,12 +23,11 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycmd.completers.go.gocode_completer import (
-    GoCodeCompleter, ShouldEnableGoCompleter )
+from ycmd.completers.go.go_completer import GoCompleter, ShouldEnableGoCompleter
 
 
 def GetCompleter( user_options ):
   if not ShouldEnableGoCompleter( user_options ):
     return None
 
-  return GoCodeCompleter( user_options )
+  return GoCompleter( user_options )

--- a/ycmd/tests/go/go_completer_test.py
+++ b/ycmd/tests/go/go_completer_test.py
@@ -27,8 +27,7 @@ from builtins import *  # noqa
 
 import os
 from nose.tools import eq_, raises
-from ycmd.completers.go.gocode_completer import ( GoCodeCompleter, GO_BINARIES,
-                                                  FindBinary )
+from ycmd.completers.go.go_completer import GoCompleter, GO_BINARIES, FindBinary
 from ycmd.request_wrap import RequestWrap
 from ycmd import user_options_store
 from ycmd.utils import ReadFile
@@ -52,11 +51,11 @@ REQUEST_DATA = {
 }
 
 
-class GoCodeCompleter_test( object ):
+class GoCompleter_test( object ):
   def setUp( self ):
     user_options = user_options_store.DefaultOptions()
     user_options[ 'gocode_binary_path' ] = DUMMY_BINARY
-    self._completer = GoCodeCompleter( user_options )
+    self._completer = GoCompleter( user_options )
 
 
   def _BuildRequest( self, line_num, column_num ):


### PR DESCRIPTION
Now that we use `godef` along with `gocode` it doesn't make much sense
to keep calling the completer GoCodeCompleter.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/404)
<!-- Reviewable:end -->
