### PR TITLE
[READY] Make Python version checking more robust

### DIFF
--- a/build.py
+++ b/build.py
@@ -15,7 +15,7 @@ import shlex
 import errno
 
 PY_MAJOR, PY_MINOR = sys.version_info[ 0 : 2 ]
-if not ( ( PY_MAJOR == 2 and PY_MINOR in [ 6, 7 ] ) or
+if not ( ( PY_MAJOR == 2 and PY_MINOR >= 6 ) or
          ( PY_MAJOR == 3 and PY_MINOR >= 3 ) or
          PY_MAJOR > 3 ):
   sys.exit( 'ycmd requires Python 2.6, 2.7 or >= 3.3; '

--- a/build.py
+++ b/build.py
@@ -18,7 +18,7 @@ PY_MAJOR, PY_MINOR = sys.version_info[ 0 : 2 ]
 if not ( ( PY_MAJOR == 2 and PY_MINOR >= 6 ) or
          ( PY_MAJOR == 3 and PY_MINOR >= 3 ) or
          PY_MAJOR > 3 ):
-  sys.exit( 'ycmd requires Python 2.6, 2.7 or >= 3.3; '
+  sys.exit( 'ycmd requires Python >= 2.6 or >= 3.3; '
             'your version of Python is ' + sys.version )
 
 DIR_OF_THIS_SCRIPT = p.dirname( p.abspath( __file__ ) )


### PR DESCRIPTION
We're currently hard-coding 2.6 or 2.7 for the supported version of the 2.x Python branch instead of checking for >= 2.6.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/405)
<!-- Reviewable:end -->
