### PR TITLE
[READY] Prevent annoying on OS X El Capitan when using system python

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -326,6 +326,35 @@ if( LIBCLANG_TARGET )
       POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy "${LIBCLANG_TARGET}" "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
     )
+
+    if( APPLE )
+      # In OS X El Capitan, Apple introduced System Integrity Protection.
+      # Amongst other things, this introduces features to the dynamic loader
+      # (dyld) which cause it to "sanitise" (and complain about) embedded
+      # LC_RPATH entries which contain @executable_path when then are loaded
+      # into "restricted" binaries.  For our purposes, "restricted" here means
+      # "supplied by Apple" and includes the system versions of python.  For
+      # unknown reasons, the libclang.dylib that comes from llvm.org includes an
+      # LC_RPATH entry '@executable_path/../lib' which causes the OS X dynamic
+      # loader to print a cryptic warning to stderr of the form:
+      #
+      #    dyld: warning, LC_RPATH @executable_path/../lib in
+      #    /path/to/ycmd/libclang.dylib being ignored in restricted program
+      #    because of @executable_path
+      #
+      # In order to prevent this harmless and annoying message appearing, we
+      # simply strip the rpath entry from the dylib.  There's no way any
+      # @executable_path that python might have could be in any way useful to
+      # libclang.dylib, so this seems perfectly safe.
+      get_filename_component( LIBCLANG_TAIL ${LIBCLANG_TARGET} NAME )
+      add_custom_command( TARGET ${PROJECT_NAME}
+                          POST_BUILD
+                          COMMAND install_name_tool
+                          "-delete_rpath"
+                          "@executable_path/../lib"
+                          "$<TARGET_FILE_DIR:${PROJECT_NAME}>/${LIBCLANG_TAIL}"
+                        )
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
# Problem

In OS X El Capitan, Apple introduced System Integrity Protection.  Amongst other things, this introduces features to the dynamic loader (dyld) which cause it to "sanitise" (and complain about) embedded LC_RPATH entries which contain @executable_path when then are loaded into "restricted" binaries.  For our purposes, "restricted" here means "supplied by Apple" and includes the system versions of python.  For unknown reasons, the libclang.dylib that comes from llvm.org includes an LC_RPATH entry '@executable_path/../lib' which causes the OS X dynamic loader to print a cryptic warning to stderr of the form:

> dyld: warning, LC_RPATH @executable_path/../lib in /path/to/ycmd/libclang.dylib being ignored in restricted program because of @executable_path

Note: This does not happen when using homebrew, pyenv or any other non-Apple versions of python.

# Mysteries

As far as I can tell, this warning/behaviour should have been present (at least) since OS X 10.11 (El Capitan), though it only started printing to the terminal (and interfering with terminal vim's default display) after commit 599de71575d542d4fc5c33344c65b3931e4d7ed2.

It is not clear precisely why this is now visible, but the change to remove `ycm_client_support.so` was the change when this started to *become* visible.

I'm almost certain that previously the warning (which is printed to stderr I believe) was getting eaten by the specific series of initialisations that was going on, but I have literally no evidence to this other than provably checking out `599de71575d542d4fc5c33344c65b3931e4d7ed2^` and building/running does not have the problem, whereas anything at `599de71575d542d4fc5c33344c65b3931e4d7ed2` or after it does.

# Solution

In order to prevent this harmless and annoying message appearing, we simply strip the rpath entry from the dylib.  There's no way any @executable_path that python might have could be in any way useful to libclang.dylib, and we always take a _copy_ of any system or externally supplied libclang, so this seems perfectly safe.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/406)
<!-- Reviewable:end -->
