### PR TITLE
[READY] Allow --system-libclang with --all

### DIFF
--- a/build.py
+++ b/build.py
@@ -253,9 +253,11 @@ def ParseArguments():
 
   args = parser.parse_args()
 
-  if args.system_libclang and not args.clang_completer:
+  if ( args.system_libclang and
+       not args.clang_completer and
+       not args.all_completers ):
     sys.exit( "You can't pass --system-libclang without also passing "
-              "--clang-completer as well." )
+              "--clang-completer or --all as well." )
   return args
 
 


### PR DESCRIPTION
Previously you had to specify both `--all` and `--clang-completer` in order to have `--system-libclang`.

This fixes that, and updates the error message when you have neither.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/407)
<!-- Reviewable:end -->
