### PR TITLE
[READY] Convert triggers to unicode before compiling them as a regex

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -29,7 +29,7 @@ from future.utils import iteritems
 import os
 import re
 from collections import defaultdict
-from ycmd.utils import ToCppStringCompatible
+from ycmd.utils import ToCppStringCompatible, ToUnicode
 
 
 class PreparedTriggers( object ):
@@ -134,6 +134,7 @@ def _MatchesSemanticTrigger( line_value, start_column, column_num,
 
 
 def _PrepareTrigger( trigger ):
+  trigger = ToUnicode( trigger )
   if trigger.startswith( TRIGGER_REGEX_PREFIX ):
     return re.compile( trigger[ len( TRIGGER_REGEX_PREFIX ) : ], re.UNICODE )
   return re.compile( re.escape( trigger ), re.UNICODE )

--- a/ycmd/tests/completer_utils_test.py
+++ b/ycmd/tests/completer_utils_test.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+#
 # Copyright (C) 2013 Google Inc.
 #
 # This file is part of ycmd.
@@ -15,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
+# Intentionally not importing unicode_literals!
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
@@ -72,6 +74,11 @@ def FiletypeDictUnion_Works_test():
          'bla': set(['boo']),
          'qux': set(['q'])
        } ) ) )
+
+
+def PrepareTrigger_UnicodeTrigger_Test():
+  regex = cu._PrepareTrigger( 'æ' )
+  eq_( regex.pattern, u'\\æ' )
 
 
 def MatchesSemanticTrigger_Basic_test():


### PR DESCRIPTION
Fixes Valloric/YouCompleteMe#2022.

Here's the full traceback from the error:
```python
Traceback (most recent call last):
  File "<string>", line 24, in <module>
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\..\python\ycm\setup.py", line 59, in SetUpYCM
    return YouCompleteMe( user_options_store.GetAll() )
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\..\python\ycm\youcompleteme.py", line 95, in __init__
    self._omnicomp = OmniCompleter( user_options )
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\..\python\ycm\omni_completer.py", line 38, in __init__
    super( OmniCompleter, self ).__init__( user_options )
  File "C:\Users\micbou\.vim\bundle\YouCompleteMe\python\ycm\..\..\third_party\ycmd\ycmd\completers\completer.py", line 113, in __init__
    if user_options[ 'auto_trigger' ] else None )
  File "C:\Users\micbou\.vim\bundle\YouCompleteMe\python\ycm\..\..\third_party\ycmd\ycmd\completers\completer_utils.py", line 38, in __init__
    dict( user_trigger_map ) ) if user_trigger_map else
  File "C:\Users\micbou\.vim\bundle\YouCompleteMe\python\ycm\..\..\third_party\ycmd\ycmd\completers\completer_utils.py", line 75, in _FiletypeTriggerDictFromSpec
    regexes = [ _PrepareTrigger( x ) for x in triggers ]
  File "C:\Users\micbou\.vim\bundle\YouCompleteMe\python\ycm\..\..\third_party\ycmd\ycmd\completers\completer_utils.py", line 138, in _PrepareTrigger
    if trigger.startswith( TRIGGER_REGEX_PREFIX ):
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```

This is the most straightforward way to fix the issue but not sure if it is the right place. This is why I put the `RFC` tag. I would also like to add tests for this.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/410)
<!-- Reviewable:end -->
