### PR TITLE
[READY] Automatically include clang includes on OS X

### DIFF
--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -26,6 +26,7 @@ from builtins import *  # noqa
 from nose.tools import eq_, ok_
 from ycmd.completers.cpp import flags
 from mock import patch, Mock
+from ycmd.tests.test_utils import MacOnly
 
 
 @patch( 'ycmd.extra_conf_store.ModuleForSourceFile', return_value = Mock() )
@@ -248,3 +249,31 @@ def ExtraClangFlags_test():
       num_found += 1
 
   eq_( 1, num_found )
+
+
+@MacOnly
+@patch( 'ycmd.completers.cpp.flags._GetMacClangVersionList',
+        return_value = [ '1.0.0', '7.0.1', '7.0.2', '___garbage__' ] )
+@patch( 'ycmd.completers.cpp.flags._MacClangIncludeDirExists',
+        side_effect = [ False, True, True, True ] )
+def Mac_LatestMacClangIncludes_test( *args ):
+  eq_( flags._LatestMacClangIncludes(),
+       [ '/Applications/Xcode.app/Contents/Developer/Toolchains/'
+         'XcodeDefault.xctoolchain/usr/lib/clang/7.0.2/include' ] )
+
+
+@MacOnly
+def Mac_LatestMacClangIncludes_NoSuchDirectory_test():
+  def RaiseOSError( x ):
+    raise OSError( x )
+
+  with patch( 'os.listdir', side_effect = RaiseOSError ):
+    eq_( flags._LatestMacClangIncludes(), [] )
+
+
+@MacOnly
+def Mac_PathsForAllMacToolchains_test():
+  eq_( flags._PathsForAllMacToolchains( 'test' ),
+       [ '/Applications/Xcode.app/Contents/Developer/Toolchains/'
+         'XcodeDefault.xctoolchain/test',
+         '/Library/Developer/CommandLineTools/test' ] )

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -29,7 +29,7 @@ from builtins import *  # noqa
 from future.utils import PY2
 from ycmd.completers.completer import Completer
 from ycmd.responses import BuildCompletionData
-from ycmd.utils import OnWindows
+from ycmd.utils import OnMac, OnWindows
 import ycm_core
 import os.path
 
@@ -43,6 +43,7 @@ Py3Only = skipIf( PY2, 'Python 3 only' )
 WindowsOnly = skipIf( not OnWindows(), 'Windows only' )
 ClangOnly = skipIf( not ycm_core.HasClangSupport(),
                     'Only when Clang support available' )
+MacOnly = skipIf( not OnMac(), 'Mac only' )
 
 
 def BuildRequest( **kwargs ):


### PR DESCRIPTION
OS X (by default) has 2 ways to set up development environment: Xcode.app and
installation of the CommandLineTools. As previously known, libclang does not
automatically add these system include paths as clang's own driver does.
Previously, ycmd would add the Xcode.app c++ include directories. This change
ensures that we add the system include paths when only the CommandLineTools are
installed (they are significantly lighter weight than xcode and installed
automatically when first attempting to run things like clang).

Additionally, around Xcode 7, additional include paths became required which are
located in versioned directories. These headers are clang-specific headers (such
as stddef.h). This change includes a mechanism to find such includes by
selecting the highest versioned set of headers that can be detected.

Fixes: https://github.com/Valloric/YouCompleteMe/issues/1992
Fixes: https://github.com/Valloric/ycmd/issues/304
Fixes: https://github.com/Valloric/ycmd/issues/254

Replaces: https://github.com/Valloric/ycmd/pull/385

I've tested this with Xcode 7 & Xcode 6 with and without the Command Line Tools. Admittedly I haven't tested the cartesian product of those configurations, but I'm fairly confident that this doesn't introduce a regression and does select a working set of includes on OS X. It shouldn't need fiddling after further changes by Apple either (hopefully!).

It's also worth noting that I believe a future change (waiting on upstream) by @d0k will make this hacking redundant, so we can remove it (yay!).

@indianajohn apologies, I didn't mean to clobber your work (I certainly used it for inspiration!), but this issue has been bugging me so I wanted to fix it anyway. Thanks for your work on it though!

(off topic note: it seems that the PR template is clobbered by the commit message when the PR is a single commit. FWIW - I'm aware of contributing guide/code of conduct, etc. :))

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/415)
<!-- Reviewable:end -->
