### PR TITLE
[READY] Enable many more flake8 warnings

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -44,9 +44,6 @@ def RunFlake8():
   print( 'Running flake8' )
   subprocess.check_call( [
     'flake8',
-    '--select=F,C9',
-    '--max-complexity=10',
-    '--exclude=testdata',
     p.join( DIR_OF_THIS_SCRIPT, 'ycmd' )
   ] )
 
@@ -98,7 +95,7 @@ def CompleterType( value ):
     aliases_to_completer = dict( ( i, k ) for k, v in COMPLETERS.items()
                                  for i in v[ 'aliases' ] )
     if value in aliases_to_completer:
-      return aliases_to_completer[ value ];
+      return aliases_to_completer[ value ]
     else:
       raise argparse.ArgumentTypeError(
         '{0} is not a valid completer - should be one of {1}'.format(

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E111,E114,E121,E125,E126,E127,E128,E129,E131,E133,E201,E202,E203,E211,E221,E222,E241,E251,E261,E303,E402,W503
+max-complexity = 10
+max-line-length = 80
+exclude = testdata

--- a/ycmd/__main__.py
+++ b/ycmd/__main__.py
@@ -47,6 +47,7 @@ from ycmd.watchdog_plugin import WatchdogPlugin
 from ycmd.hmac_plugin import HmacPlugin
 from ycmd.utils import ToBytes, ReadFile, OpenForStdHandle
 
+
 def YcmCoreSanityCheck():
   if 'ycm_core' in sys.modules:
     raise RuntimeError( 'ycm_core already imported, ycmd has a bug!' )
@@ -123,6 +124,7 @@ def SetupLogging( log_level ):
   logging.basicConfig( format = '%(asctime)s - %(levelname)s - %(message)s',
                        level = numeric_level )
 
+
 def SetupOptions( options_file ):
   options = user_options_store.DefaultOptions()
   user_options = json.loads( ReadFile( options_file ) )
@@ -179,4 +181,3 @@ def Main():
 
 if __name__ == "__main__":
   Main()
-

--- a/ycmd/completers/c/hook.py
+++ b/ycmd/completers/c/hook.py
@@ -26,9 +26,9 @@ from builtins import *  # noqa
 import ycm_core
 from ycmd.completers.cpp.clang_completer import ClangCompleter
 
+
 def GetCompleter( user_options ):
   if ycm_core.HasClangSupport():
     return ClangCompleter( user_options )
   else:
     return None
-

--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -32,6 +32,7 @@ from future.utils import with_metaclass
 
 NO_USER_COMMANDS = 'This completer does not define any commands.'
 
+
 class Completer( with_metaclass( abc.ABCMeta, object ) ):
   """A base class for all Completers in YCM.
 
@@ -364,4 +365,3 @@ class CompletionsCache( object ):
   def _CacheValidNoLock( self, current_line, start_column, completion_type ):
     return ( current_line == self._line and start_column == self._column and
              completion_type == self._completion_type )
-

--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -162,21 +162,24 @@ def FilterAndSortCandidatesWrap( candidates, sort_property, query ):
 TRIGGER_REGEX_PREFIX = 're!'
 
 DEFAULT_FILETYPE_TRIGGERS = {
-  'c' : ['->', '.'],
-  'objc' : ['->',
-            '.',
-            r're!\[[_a-zA-Z]+\w*\s',    # bracketed calls
-            r're!^\s*[^\W\d]\w*\s',     # bracketless calls
-            r're!\[.*\]\s',             # method composition
-           ],
-  'ocaml' : ['.', '#'],
-  'cpp,objcpp' : ['->', '.', '::'],
-  'perl' : ['->'],
-  'php' : ['->', '::'],
-  'cs,java,javascript,typescript,d,python,perl6,scala,vb,elixir,go,groovy' : ['.'],
-  'ruby,rust' : ['.', '::'],
-  'lua' : ['.', ':'],
-  'erlang' : [':'],
+  'c' : [ '->', '.' ],
+  'objc' : [
+    '->',
+    '.',
+    r're!\[[_a-zA-Z]+\w*\s',    # bracketed calls
+    r're!^\s*[^\W\d]\w*\s',     # bracketless calls
+    r're!\[.*\]\s',             # method composition
+  ],
+  'ocaml' : [ '.', '#' ],
+  'cpp,objcpp' : [ '->', '.', '::' ],
+  'perl' : [ '->' ],
+  'php' : [ '->', '::' ],
+  'cs,java,javascript,typescript,d,python,perl6,scala,vb,elixir,go,groovy' : [
+    '.'
+  ],
+  'ruby,rust' : [ '.', '::' ],
+  'lua' : [ '.', ':' ],
+  'erlang' : [ ':' ],
 }
 
 PREPARED_DEFAULT_FILETYPE_TRIGGERS = _FiletypeTriggerDictFromSpec(

--- a/ycmd/completers/cpp/clang_helpers.py
+++ b/ycmd/completers/cpp/clang_helpers.py
@@ -23,6 +23,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
+
 # Provided for backwards compatibility with old ycm_extra_conf files.
 def PrepareClangFlags( flags, filename ):
   return flags

--- a/ycmd/completers/cpp/ephemeral_values_set.py
+++ b/ycmd/completers/cpp/ephemeral_values_set.py
@@ -27,6 +27,7 @@ import threading
 
 ALREADY_PARSING_MESSAGE = 'File already being parsed.'
 
+
 # Holds a set of values in a python set. Trying to get an exclusive hold on a
 # provided value results in a context manager that manages the lifetime of the
 # value.

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -51,6 +51,7 @@ FILE_FLAGS_TO_SKIP = set(['-MD', '-MMD', '-MF', '-MT', '-MQ', '-o'])
 # See Valloric/ycmd#266
 CPP_COMPILER_REGEX = re.compile( r'\+\+(-\d+(\.\d+){0,2})?$' )
 
+
 class Flags( object ):
   """Keeps track of the flags necessary to compile a file.
   The flags are loaded from user-created python files (hereafter referred to as
@@ -276,7 +277,7 @@ def _RemoveUnusedFlags( flags, filename ):
       continue
 
     if flag in FILE_FLAGS_TO_SKIP:
-      skip_next = True;
+      skip_next = True
       continue
 
     if flag == filename or os.path.realpath( flag ) == filename:
@@ -305,9 +306,11 @@ def _RemoveUnusedFlags( flags, filename ):
 # Most users have xcode installed, but in order to be as compatible as
 # possible we consider both possible installation locations
 MAC_CLANG_TOOLCHAIN_DIRS = [
-  '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain',
+  '/Applications/Xcode.app/Contents/Developer/Toolchains/'
+    'XcodeDefault.xctoolchain',
   '/Library/Developer/CommandLineTools'
 ]
+
 
 # Returns a list containing the supplied path as a suffix of each of the known
 # Mac toolchains
@@ -378,7 +381,8 @@ def _ExtraClangFlags():
   # This makes GetType and GetParent commands not returning the expected
   # result when the cursor is in templates.
   # Using the -fno-delayed-template-parsing flag disables this behavior.
-  # See http://clang.llvm.org/extra/PassByValueTransform.html#note-about-delayed-template-parsing
+  # See
+  # http://clang.llvm.org/extra/PassByValueTransform.html#note-about-delayed-template-parsing # noqa
   # for an explanation of the flag and
   # https://code.google.com/p/include-what-you-use/source/detail?r=566
   # for a similar issue.
@@ -391,5 +395,3 @@ def _SpecialClangIncludes():
   libclang_dir = os.path.dirname( ycm_core.__file__ )
   path_to_includes = os.path.join( libclang_dir, 'clang_includes' )
   return [ '-resource-dir=' + path_to_includes ]
-
-

--- a/ycmd/completers/cpp/hook.py
+++ b/ycmd/completers/cpp/hook.py
@@ -26,9 +26,9 @@ from builtins import *  # noqa
 import ycm_core
 from ycmd.completers.cpp.clang_completer import ClangCompleter
 
+
 def GetCompleter( user_options ):
   if ycm_core.HasClangSupport():
     return ClangCompleter( user_options )
   else:
     return None
-

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -127,7 +127,7 @@ class CsharpCompleter( Completer ):
   def FilterAndSortCandidates( self, candidates, query ):
     result = super( CsharpCompleter, self ).FilterAndSortCandidates( candidates,
                                                                      query )
-    result.sort( key = _CompleteIsFromImport );
+    result.sort( key = _CompleteIsFromImport )
     return result
 
 
@@ -309,7 +309,7 @@ class CsharpCompleter( Completer ):
 
 
   def _GetSolutionFile( self, filepath ):
-    if not filepath in self._solution_for_file:
+    if filepath not in self._solution_for_file:
       # NOTE: detection could throw an exception if an extra_conf_store needs
       # to be confirmed
       path_to_solutionfile = solutiondetection.FindSolutionPath( filepath )
@@ -454,14 +454,14 @@ class CsharpSolutionCompleter( object ):
     parameters[ 'ForceSemanticCompletion' ] = completion_type
     parameters[ 'WantDocumentationForEveryCompletionResult' ] = True
     completions = self._GetResponse( '/autocomplete', parameters )
-    return completions if completions != None else []
+    return completions if completions is not None else []
 
 
   def _GoToDefinition( self, request_data ):
     """ Jump to definition of identifier under cursor """
     definition = self._GetResponse( '/gotodefinition',
                                     self._DefaultParameters( request_data ) )
-    if definition[ 'FileName' ] != None:
+    if definition[ 'FileName' ] is not None:
       return responses.BuildGoToResponse( definition[ 'FileName' ],
                                           definition[ 'Line' ],
                                           definition[ 'Column' ] )
@@ -489,7 +489,7 @@ class CsharpSolutionCompleter( object ):
     else:
       if ( fallback_to_declaration ):
         return self._GoToDefinition( request_data )
-      elif implementation[ 'QuickFixes' ] == None:
+      elif implementation[ 'QuickFixes' ] is None:
         raise RuntimeError( 'Can\'t jump to implementation' )
       else:
         raise RuntimeError( 'No implementations found' )
@@ -626,7 +626,7 @@ class CsharpSolutionCompleter( object ):
 
 def _CompleteIsFromImport( candidate ):
   try:
-    return candidate[ "extra_data" ][ "required_namespace_import" ] != None
+    return candidate[ "extra_data" ][ "required_namespace_import" ] is not None
   except ( KeyError, TypeError ):
     return False
 

--- a/ycmd/completers/cs/hook.py
+++ b/ycmd/completers/cs/hook.py
@@ -25,5 +25,6 @@ from builtins import *  # noqa
 
 from ycmd.completers.cs.cs_completer import CsharpCompleter
 
+
 def GetCompleter( user_options ):
   return CsharpCompleter( user_options )

--- a/ycmd/completers/cs/solutiondetection.py
+++ b/ycmd/completers/cs/solutiondetection.py
@@ -31,8 +31,8 @@ from inspect import getfile
 from ycmd import extra_conf_store
 from ycmd.utils import ToUnicode
 
-
 __logger = logging.getLogger( __name__ )
+
 
 def FindSolutionPath( filepath ):
     """Try to find suitable solution file given a source file path using all
@@ -71,13 +71,13 @@ def PollModule( module, filepath ):
             path_to_solutionfile = path
             __logger.info(
                 u'Using solution file {0} selected by extra_conf_store'.format(
-                path_to_solutionfile ) )
+                  path_to_solutionfile ) )
             break
     except AttributeError as e:
       # the config script might not provide solution file locations
       __logger.error(
-          u'Could not retrieve solution for {0} from extra_conf_store: {1}'.format(
-          filepath, str( e ) ) )
+          u'Could not retrieve solution for {0}'
+           'from extra_conf_store: {1}'.format( filepath, str( e ) ) )
   return path_to_solutionfile
 
 
@@ -102,25 +102,30 @@ def _SolutionTestCheckHeuristics( candidates, tokens, i ):
     selection = os.path.join( path, candidates[ 0 ] )
     __logger.info(
         u'Selected solution file {0} as it is the first one found'.format(
-        selection ) )
+          selection ) )
+
   # there is more than one file, try some hints to decide
   # 1. is there a solution named just like the subdirectory with the source?
   if ( not selection and i < len( tokens ) - 1 and
-      u'{0}.sln'.format( tokens[ i + 1 ] ) in candidates ) :
+       u'{0}.sln'.format( tokens[ i + 1 ] ) in candidates ):
     selection = os.path.join( path, u'{0}.sln'.format( tokens[ i + 1 ] ) )
     __logger.info(
         u'Selected solution file {0} as it matches source subfolder'.format(
-        selection ) )
-  # 2. is there a solution named just like the directory containing the solution?
+          selection ) )
+
+  # 2. is there a solution named just like the directory containing the
+  # solution?
   if not selection and u'{0}.sln'.format( tokens[ i ] ) in candidates :
     selection = os.path.join( path, u'{0}.sln'.format( tokens[ i ] ) )
     __logger.info(
         u'Selected solution file {0} as it matches containing folder'.format(
-        selection ) )
+          selection ) )
+
   if not selection:
     __logger.error(
         u'Could not decide between multiple solution files:\n{0}'.format(
-        candidates ) )
+          candidates ) )
+
   return selection
 
 
@@ -136,5 +141,3 @@ def _PathComponents( path ):
       break
   path_components.reverse()
   return path_components
-
-

--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -216,7 +216,8 @@ def _GenerateCandidatesForPaths( absolute_paths ):
   # Keep original ordering
   for basename in basenames:
     completion_dicts.append(
-      responses.BuildCompletionData( basename,
-                                     EXTRA_INFO_MAP[ extra_info[ basename ] ] ) )
+      responses.BuildCompletionData(
+        basename,
+        EXTRA_INFO_MAP[ extra_info[ basename ] ] ) )
 
   return completion_dicts

--- a/ycmd/completers/general/general_completer_store.py
+++ b/ycmd/completers/general/general_completer_store.py
@@ -124,5 +124,3 @@ class GeneralCompleterStore( Completer ):
   def Shutdown( self ):
     for completer in self._all_completers:
       completer.Shutdown()
-
-

--- a/ycmd/completers/general/ultisnips_completer.py
+++ b/ycmd/completers/general/ultisnips_completer.py
@@ -56,4 +56,3 @@ class UltiSnipsCompleter( GeneralCompleter ):
       responses.BuildCompletionData( snip[ 'trigger' ],
                                      '<snip> ' + snip[ 'description' ] )
       for snip in raw_candidates ]
-

--- a/ycmd/completers/general_completer.py
+++ b/ycmd/completers/general_completer.py
@@ -25,6 +25,7 @@ from builtins import *  # noqa
 
 from ycmd.completers.completer import Completer
 
+
 class GeneralCompleter( Completer ):
   """
   A base class for General completers in YCM. A general completer is used in all

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -220,7 +220,6 @@ class GoCompleter( Completer ):
     raise RuntimeError( 'Can\'t jump to definition.' )
 
 
-
 # Compute the byte offset in the file given the line and column.
 # TODO(ekfriis): If this is slow, consider moving this to C++ ycm_core,
 # perhaps in RequestWrap.

--- a/ycmd/completers/javascript/hook.py
+++ b/ycmd/completers/javascript/hook.py
@@ -24,7 +24,7 @@ standard_library.install_aliases()
 from builtins import *  # noqa
 
 from ycmd.completers.javascript.tern_completer import (
-        ShouldEnableTernCompleter, TernCompleter )
+  ShouldEnableTernCompleter, TernCompleter )
 
 
 def GetCompleter( user_options ):

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -38,17 +38,17 @@ from ycmd.completers.completer import Completer
 _logger = logging.getLogger( __name__ )
 
 PATH_TO_TERNJS_BINARY = os.path.abspath(
-    os.path.join(
-      os.path.dirname( __file__ ),
-      '..',
-      '..',
-      '..',
-      'third_party',
-      'tern_runtime',
-      'node_modules',
-      'tern',
-      'bin',
-      'tern' ) )
+  os.path.join(
+    os.path.dirname( __file__ ),
+    '..',
+    '..',
+    '..',
+    'third_party',
+    'tern_runtime',
+    'node_modules',
+    'tern',
+    'bin',
+    'tern' ) )
 
 PATH_TO_NODE = utils.PathToFirstExistingExecutable( [ 'node' ] )
 
@@ -74,8 +74,8 @@ def ShouldEnableTernCompleter():
   installed = os.path.exists( PATH_TO_TERNJS_BINARY )
 
   if not installed:
-    _logger.info( 'Not using Tern completer: not installed at '
-                  + PATH_TO_TERNJS_BINARY )
+    _logger.info( 'Not using Tern completer: not installed at ' +
+                  PATH_TO_TERNJS_BINARY )
     return False
 
   return True

--- a/ycmd/completers/objc/hook.py
+++ b/ycmd/completers/objc/hook.py
@@ -26,6 +26,7 @@ from builtins import *  # noqa
 import ycm_core
 from ycmd.completers.cpp.clang_completer import ClangCompleter
 
+
 def GetCompleter( user_options ):
   if ycm_core.HasClangSupport():
     return ClangCompleter( user_options )

--- a/ycmd/completers/objcpp/hook.py
+++ b/ycmd/completers/objcpp/hook.py
@@ -26,9 +26,9 @@ from builtins import *  # noqa
 import ycm_core
 from ycmd.completers.cpp.clang_completer import ClangCompleter
 
+
 def GetCompleter( user_options ):
   if ycm_core.HasClangSupport():
     return ClangCompleter( user_options )
   else:
     return None
-

--- a/ycmd/completers/python/hook.py
+++ b/ycmd/completers/python/hook.py
@@ -25,5 +25,6 @@ from builtins import *  # noqa
 
 from ycmd.completers.python.jedi_completer import JediCompleter
 
+
 def GetCompleter( user_options ):
   return JediCompleter( user_options )

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -156,7 +156,8 @@ class JediCompleter( Completer ):
 
       # JediHTTP will delete the secret_file after it's done reading it
       with NamedTemporaryFile( delete = False, mode = 'w+' ) as hmac_file:
-        json.dump( { 'hmac_secret': str( b64encode( self._hmac_secret ), 'utf8' ) },
+        json.dump( { 'hmac_secret': str( b64encode( self._hmac_secret ),
+                                         'utf8' ) },
                    hmac_file )
         command = [ self._python_binary_path,
                     PATH_TO_JEDIHTTP,
@@ -394,4 +395,3 @@ class JediCompleter( Completer ):
                                                 self._logfile_stderr )
 
        return 'JediHTTP is not running'
-

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -182,7 +182,10 @@ class RustCompleter( Completer ):
     if not body:
       body = bytes()
 
-    hmac = hmac_utils.CreateRequestHmac( method, handler, body, self._hmac_secret )
+    hmac = hmac_utils.CreateRequestHmac( method,
+                                         handler,
+                                         body,
+                                         self._hmac_secret )
     final_hmac_value = native( ToBytes( binascii.hexlify( hmac ) ) )
 
     extra_headers = { 'content-type': 'application/json' }

--- a/ycmd/completers/typescript/hook.py
+++ b/ycmd/completers/typescript/hook.py
@@ -25,5 +25,6 @@ from builtins import *  # noqa
 
 from ycmd.completers.typescript.typescript_completer import TypeScriptCompleter
 
+
 def GetCompleter( user_options ):
   return TypeScriptCompleter( user_options )

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -46,6 +46,7 @@ RESPONSE_TIMEOUT_SECONDS = 10
 
 _logger = logging.getLogger( __name__ )
 
+
 class DeferredResponse( object ):
   """
   A deferred that resolves to a response from TSServer.

--- a/ycmd/extra_conf_store.py
+++ b/ycmd/extra_conf_store.py
@@ -60,7 +60,7 @@ def ModuleFileForSourceFile( filename ):
   If no module was found or allowed to load, None is returned."""
 
   with _module_file_for_source_file_lock:
-    if not filename in _module_file_for_source_file:
+    if filename not in _module_file_for_source_file:
       for module_file in _ExtraConfModuleSourceFilesForFile( filename ):
         if Load( module_file ):
           _module_file_for_source_file[ filename ] = module_file

--- a/ycmd/hmac_plugin.py
+++ b/ycmd/hmac_plugin.py
@@ -35,6 +35,7 @@ from ycmd.bottle_utils import SetResponseHeader
 _HMAC_HEADER = 'x-ycm-hmac'
 _HOST_HEADER = 'host'
 
+
 # This class implements the Bottle plugin API:
 # http://bottlepy.org/docs/dev/plugindev.html
 #
@@ -58,7 +59,8 @@ class HmacPlugin( object ):
     def wrapper( *args, **kwargs ):
       if not HostHeaderCorrect( request ):
         self._logger.info( 'Dropping request with bad Host header.' )
-        abort( http.client.UNAUTHORIZED, 'Unauthorized, received bad Host header.' )
+        abort( http.client.UNAUTHORIZED,
+               'Unauthorized, received bad Host header.' )
         return
 
       body = ToBytes( request.body.read() )

--- a/ycmd/hmac_utils.py
+++ b/ycmd/hmac_utils.py
@@ -28,6 +28,7 @@ from builtins import bytes
 import hmac
 import hashlib
 
+
 def CreateHmac( content, hmac_secret ):
   # Note that py2's str type passes this check (and that's ok)
   if not isinstance( content, bytes ):

--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -132,4 +132,3 @@ def IdentifierAtIndex( text, index, filetype = None ):
     if match.end() > index:
       return match.group()
   return ''
-

--- a/ycmd/request_validation.py
+++ b/ycmd/request_validation.py
@@ -25,6 +25,7 @@ from builtins import *  # noqa
 
 from ycmd.responses import ServerError
 
+
 # Throws an exception if request doesn't have all the required fields.
 # TODO: Accept a request_type param so that we can also verify missing
 # command_arguments and completer_target fields if necessary.

--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -27,6 +27,7 @@ from ycmd.utils import ToUnicode, ToBytes
 from ycmd.identifier_utils import StartOfLongestIdentifierEndingAtIndex
 from ycmd.request_validation import EnsureRequestValid
 
+
 # TODO: Change the custom computed (and other) keys to be actual properties on
 # the object.
 class RequestWrap( object ):
@@ -106,7 +107,7 @@ def CompletionStartColumn( line_value, column_num, filetype ):
   utf8_line_value = ToBytes( line_value )
   unicode_line_value = ToUnicode( line_value )
   codepoint_column_num = len(
-      str( utf8_line_value[ : column_num -1 ], 'utf8' ) ) + 1
+      str( utf8_line_value[ : column_num - 1 ], 'utf8' ) ) + 1
 
   # -1 and then +1 to account for difference betwen 0-based and 1-based
   # indices/columns
@@ -115,5 +116,3 @@ def CompletionStartColumn( line_value, column_num, filetype ):
 
   return len(
       unicode_line_value[ : codepoint_start_column - 1 ].encode( 'utf8' ) ) + 1
-
-

--- a/ycmd/tests/clang/comment_strip_test.py
+++ b/ycmd/tests/clang/comment_strip_test.py
@@ -19,6 +19,8 @@
 method/variable,etc. headers in order to remove non-data-ink from the raw
 comment"""
 
+# flake8: noqa
+
 from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
@@ -129,7 +131,7 @@ Multi-line
  Doxygen-like
    comment   ****/ Entries
 
-""" )
+""" ) # noqa
 
 def ClangCompleter_FormatRawComment_MultiLine_JavaDoc_Inconsistent_test():
   # The dedenting only applies to consistent indent, and leaves any subsequent
@@ -147,7 +149,7 @@ All of the
 Lines in this
 	Comment consistently
 * Have a 2-space indent
-""" )
+""" ) # noqa
 
 
 def ClangCompleter_FormatRawComment_ZeroLine_test():
@@ -170,4 +172,4 @@ def ClangCompleter_FormatRawComment_MultiLine_empty_test():
 
 
 
-""" )
+""" ) # noqa

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -141,8 +141,8 @@ def RemoveUnusedFlags_RemoveFilename_test():
        flags._RemoveUnusedFlags( expected + to_remove, filename ) )
 
   eq_( expected,
-        flags._RemoveUnusedFlags( expected[ :1 ] + to_remove + expected[ 1: ],
-                                  filename ) )
+       flags._RemoveUnusedFlags( expected[ :1 ] + to_remove + expected[ 1: ],
+                                 filename ) )
 
   eq_( expected,
        flags._RemoveUnusedFlags(
@@ -158,8 +158,8 @@ def RemoveUnusedFlags_RemoveFlagWithoutPrecedingDashFlag_test():
        flags._RemoveUnusedFlags( expected + to_remove, filename ) )
 
   eq_( expected,
-        flags._RemoveUnusedFlags( expected[ :1 ] + to_remove + expected[ 1: ],
-                                  filename ) )
+       flags._RemoveUnusedFlags( expected[ :1 ] + to_remove + expected[ 1: ],
+                                 filename ) )
 
 
 def RemoveUnusedFlags_RemoveFilenameWithoutPrecedingInclude_test():

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -137,7 +137,8 @@ class Clang_GetCompletions_test( Clang_Handlers_test ):
         'response': http.client.OK,
         'data': has_entries( {
           'completions': empty(),
-          'errors': has_item( self._ErrorMatcher( RuntimeError, NO_COMPLETIONS_MESSAGE ) ),
+          'errors': has_item( self._ErrorMatcher( RuntimeError,
+                                                  NO_COMPLETIONS_MESSAGE ) ),
         } )
       },
     } )

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -114,8 +114,8 @@ class Clang_Subcommands_test( Clang_Handlers_test ):
 
     # GoToDefinition - identical to GoToDeclaration
     #
-    # The semantics of this seem the wrong way round to me. GoToDefinition should
-    # go to where a method is implemented, not where it is declared.
+    # The semantics of this seem the wrong way round to me. GoToDefinition
+    # should go to where a method is implemented, not where it is declared.
     #
     tests = [
       # Local::x -> declaration of x
@@ -140,8 +140,8 @@ class Clang_Subcommands_test( Clang_Handlers_test ):
 
     # GoTo - identical to GoToDeclaration
     #
-    # The semantics of this seem the wrong way round to me. GoToDefinition should
-    # go to where a method is implemented, not where it is declared.
+    # The semantics of this seem the wrong way round to me. GoToDefinition
+    # should go to where a method is implemented, not where it is declared.
     #
     tests = [
       # Local::x -> declaration of x
@@ -166,8 +166,8 @@ class Clang_Subcommands_test( Clang_Handlers_test ):
 
     # GoToImprecise - identical to GoToDeclaration
     #
-    # The semantics of this seem the wrong way round to me. GoToDefinition should
-    # go to where a method is implemented, not where it is declared.
+    # The semantics of this seem the wrong way round to me. GoToDefinition
+    # should go to where a method is implemented, not where it is declared.
     #
     tests = [
       # Local::x -> declaration of x
@@ -347,13 +347,13 @@ class Clang_Subcommands_test( Clang_Handlers_test ):
       [{'line_num': 28, 'column_num': 16}, 'const auto *'], # sic
 
       # Auto sort of works in usage (but canonical types apparently differ)
-      [{'line_num': 30, 'column_num': 14}, 'const Foo => const Foo'], #sic
+      [{'line_num': 30, 'column_num': 14}, 'const Foo => const Foo'], # sic
       [{'line_num': 30, 'column_num': 21}, 'const int'],
-      [{'line_num': 31, 'column_num': 14}, 'const Foo * => const Foo *'], #sic
+      [{'line_num': 31, 'column_num': 14}, 'const Foo * => const Foo *'], # sic
       [{'line_num': 31, 'column_num': 22}, 'const int'],
-      [{'line_num': 32, 'column_num': 13}, 'Foo => Foo'], #sic
+      [{'line_num': 32, 'column_num': 13}, 'Foo => Foo'], # sic
       [{'line_num': 32, 'column_num': 19}, 'int'],
-      [{'line_num': 33, 'column_num': 13}, 'Foo * => Foo *'], #sic
+      [{'line_num': 33, 'column_num': 13}, 'Foo * => Foo *'], # sic
       [{'line_num': 33, 'column_num': 20}, 'int'],
     ]
 
@@ -423,8 +423,8 @@ class Clang_Subcommands_test( Clang_Handlers_test ):
       },
     }
 
-    # Build the command arguments from the standard ones and the language-specific
-    # arguments.
+    # Build the command arguments from the standard ones and the
+    # language-specific arguments.
     args = {
       'completer_target' : 'filetype_default',
       'contents'         : contents,
@@ -776,7 +776,7 @@ This is a test namespace
 Type: 
 Name: Test
 ---
-This is a test namespace""" } )
+This is a test namespace""" } ) # noqa
 
 
   def GetDoc_Undocumented_test( self ):
@@ -833,7 +833,8 @@ This is a test namespace""" } )
     self._app.post_json( '/event_notification',
                          self._BuildRequest( filepath = filepath,
                                              filetype = 'cpp',
-                                             compilation_flags = [ '-x', 'c++' ],
+                                             compilation_flags = [ '-x',
+                                                                   'c++' ],
                                              contents = contents,
                                              event_name = 'FileReadyToParse' ) )
 
@@ -937,7 +938,7 @@ This is a test namespace
 Type: 
 Name: Test
 ---
-This is a test namespace""" } )
+This is a test namespace""" } ) # noqa
 
 
   def GetDocQuick_Undocumented_test( self ):

--- a/ycmd/tests/completer_utils_test.py
+++ b/ycmd/tests/completer_utils_test.py
@@ -55,7 +55,7 @@ def FiletypeTriggerDictFromSpec_Works_test():
            'foo': ['zoo', 'bar'],
            'goo,moo': ['moo'],
            'qux': ['q']
-       } ) ) )
+         } ) ) )
 
 
 def FiletypeDictUnion_Works_test():

--- a/ycmd/tests/cs/cs_handlers_test.py
+++ b/ycmd/tests/cs/cs_handlers_test.py
@@ -103,10 +103,11 @@ class Cs_Handlers_test( Handlers_test ):
     if filepath in Cs_Handlers_test.omnisharp_file_solution:
       return Cs_Handlers_test.omnisharp_file_solution[ filepath ]
 
-    solution_request = self._BuildRequest( completer_target = 'filetype_default',
-                                           filepath = filepath,
-                                           command_arguments = [ "SolutionFile" ],
-                                           filetype = 'cs' )
+    solution_request = self._BuildRequest(
+        completer_target = 'filetype_default',
+        filepath = filepath,
+        command_arguments = [ "SolutionFile" ],
+        filetype = 'cs' )
     solution_path = self._app.post_json( '/run_completer_command',
                                          solution_request ).json
     Cs_Handlers_test.omnisharp_file_solution[ filepath ] = solution_path

--- a/ycmd/tests/cs/diagnostics_test.py
+++ b/ycmd/tests/cs/diagnostics_test.py
@@ -86,7 +86,8 @@ class Cs_Diagnostics_test( Cs_Handlers_test ):
                                            filetype = 'cs',
                                            contents = contents )
 
-          results = self._app.post_json( '/event_notification', event_data ).json
+          results = self._app.post_json( '/event_notification',
+                                         event_data ).json
 
         assert_that( results,
                     contains(

--- a/ycmd/tests/cs/get_completions_test.py
+++ b/ycmd/tests/cs/get_completions_test.py
@@ -45,7 +45,8 @@ class Cs_GetCompletions_test( Cs_Handlers_test ):
                                             contents = contents,
                                             line_num = 10,
                                             column_num = 12 )
-      response_data = self._app.post_json( '/completions', completion_data ).json
+      response_data = self._app.post_json( '/completions',
+                                           completion_data ).json
       assert_that( response_data[ 'completions' ],
                   has_items( self._CompletionEntryMatcher( 'CursorLeft' ),
                               self._CompletionEntryMatcher( 'CursorSize' ) ) )
@@ -86,7 +87,8 @@ class Cs_GetCompletions_test( Cs_Handlers_test ):
                                             contents = contents,
                                             line_num = 9,
                                             column_num = 12 )
-      response_data = self._app.post_json( '/completions', completion_data ).json
+      response_data = self._app.post_json( '/completions',
+                                           completion_data ).json
       assert_that( response_data[ 'completions' ],
                   has_items( self._CompletionEntryMatcher( 'CursorLeft' ),
                               self._CompletionEntryMatcher( 'CursorSize' ) ) )
@@ -105,7 +107,8 @@ class Cs_GetCompletions_test( Cs_Handlers_test ):
                                             column_num = 12,
                                             force_semantic = True,
                                             query = 'Date' )
-      response_data = self._app.post_json( '/completions', completion_data ).json
+      response_data = self._app.post_json( '/completions',
+                                           completion_data ).json
 
       assert_that(
         response_data[ 'completions' ],
@@ -126,7 +129,8 @@ class Cs_GetCompletions_test( Cs_Handlers_test ):
                                             column_num = 12,
                                             force_semantic = True,
                                             query = 'Date' )
-      response_data = self._app.post_json( '/completions', completion_data ).json
+      response_data = self._app.post_json( '/completions',
+                                           completion_data ).json
 
       min_import_index = min(
         loc for loc, val
@@ -155,11 +159,13 @@ class Cs_GetCompletions_test( Cs_Handlers_test ):
                                             column_num = 21,
                                             force_semantic = True,
                                             query = 'Date' )
-      response_data = self._app.post_json( '/completions', completion_data ).json
+      response_data = self._app.post_json( '/completions',
+                                           completion_data ).json
 
-      assert_that( response_data[ 'completions' ],
-                  has_items( self._CompletionEntryMatcher( 'String' ),
-                              self._CompletionEntryMatcher( 'StringBuilder' ) ) )
+      assert_that(
+          response_data[ 'completions' ],
+          has_items( self._CompletionEntryMatcher( 'String' ),
+                     self._CompletionEntryMatcher( 'StringBuilder' ) ) )
 
 
   def NonForcedReturnsNoResults_test( self ):

--- a/ycmd/tests/detailed_diagnostics_test.py
+++ b/ycmd/tests/detailed_diagnostics_test.py
@@ -56,4 +56,5 @@ class Diagnostics_test( Handlers_test ):
                                       filetype = 'dummy_filetype' )
 
       response = self._app.post_json( '/detailed_diagnostic', diag_data )
-      assert_that( response.json, self._MessageMatcher( "detailed diagnostic" ) )
+      assert_that( response.json,
+                   self._MessageMatcher( "detailed diagnostic" ) )

--- a/ycmd/tests/filename_completer_test.py
+++ b/ycmd/tests/filename_completer_test.py
@@ -32,7 +32,10 @@ from ycmd.request_wrap import RequestWrap
 from ycmd import user_options_store
 
 TEST_DIR = os.path.dirname( os.path.abspath( __file__ ) )
-DATA_DIR = os.path.join( TEST_DIR, "testdata", "filename_completer", "inner_dir" )
+DATA_DIR = os.path.join( TEST_DIR,
+                         "testdata",
+                         "filename_completer",
+                         "inner_dir" )
 PATH_TO_TEST_FILE = os.path.join( DATA_DIR, "test.cpp" )
 
 REQUEST_DATA = {
@@ -139,11 +142,12 @@ class FilenameCompleter_test( object ):
   def EnvVar_AtStart_File_Partial_test( self ):
     # The reason all entries in the directory are returned is that the
     # RequestWrapper tells the completer to effectively return results for
-    # $YCM_TEST_DIR/testdata/filename_completer/inner_dir/ and the client filters based
-    # on the additional characters.
+    # $YCM_TEST_DIR/testdata/filename_completer/inner_dir/ and the client
+    # filters based on the additional characters.
     os.environ[ 'YCM_TEST_DIR' ] = TEST_DIR
     data = sorted( self._CompletionResultsForLine(
-                    'set x = $YCM_TEST_DIR/testdata/filename_completer/inner_dir/te' ) )
+                    'set x = $YCM_TEST_DIR/testdata/filename_completer/'
+                      'inner_dir/te' ) )
     os.environ.pop( 'YCM_TEST_DIR' )
 
     eq_( [
@@ -158,7 +162,7 @@ class FilenameCompleter_test( object ):
     os.environ[ 'YCMTESTDIR' ] = TEST_DIR
 
     data = sorted( self._CompletionResultsForLine(
-                            'set x = $YCMTESTDIR/testdata/filename_completer/' ) )
+                      'set x = $YCMTESTDIR/testdata/filename_completer/' ) )
 
     os.environ.pop( 'YCMTESTDIR' )
 
@@ -168,7 +172,7 @@ class FilenameCompleter_test( object ):
   def EnvVar_AtStart_Dir_Partial_test( self ):
     os.environ[ 'ycm_test_dir' ] = TEST_DIR
     data = sorted( self._CompletionResultsForLine(
-                            'set x = $ycm_test_dir/testdata/filename_completer/inn' ) )
+                    'set x = $ycm_test_dir/testdata/filename_completer/inn' ) )
 
     os.environ.pop( 'ycm_test_dir' )
     eq_( [ ('inner_dir', '[Dir]') ], data )
@@ -177,7 +181,9 @@ class FilenameCompleter_test( object ):
   def EnvVar_InMiddle_File_test( self ):
     os.environ[ 'YCM_TEST_filename_completer' ] = 'inner_dir'
     data = sorted( self._CompletionResultsForLine(
-      'set x = ' + TEST_DIR + '/testdata/filename_completer/$YCM_TEST_filename_completer/' ) )
+      'set x = '
+      + TEST_DIR
+      + '/testdata/filename_completer/$YCM_TEST_filename_completer/' ) )
     os.environ.pop( 'YCM_TEST_filename_completer' )
     eq_( [
           ( u'foo漢字.txt', '[File]' ),
@@ -190,7 +196,9 @@ class FilenameCompleter_test( object ):
   def EnvVar_InMiddle_File_Partial_test( self ):
     os.environ[ 'YCM_TEST_filename_c0mpleter' ] = 'inner_dir'
     data = sorted( self._CompletionResultsForLine(
-      'set x = ' + TEST_DIR + '/testdata/filename_completer/$YCM_TEST_filename_c0mpleter/te' ) )
+      'set x = '
+      + TEST_DIR
+      + '/testdata/filename_completer/$YCM_TEST_filename_c0mpleter/te' ) )
     os.environ.pop( 'YCM_TEST_filename_c0mpleter' )
     eq_( [
           ( u'foo漢字.txt', '[File]' ),
@@ -203,7 +211,7 @@ class FilenameCompleter_test( object ):
   def EnvVar_InMiddle_Dir_test( self ):
     os.environ[ 'YCM_TEST_td' ] = 'testd'
     data = sorted( self._CompletionResultsForLine(
-                    'set x = ' + TEST_DIR + '/${YCM_TEST_td}ata/filename_completer/' ) )
+          'set x = ' + TEST_DIR + '/${YCM_TEST_td}ata/filename_completer/' ) )
 
     os.environ.pop( 'YCM_TEST_td' )
     eq_( [ ('inner_dir', '[Dir]') ], data )
@@ -212,7 +220,7 @@ class FilenameCompleter_test( object ):
   def EnvVar_InMiddle_Dir_Partial_test( self ):
     os.environ[ 'YCM_TEST_td' ] = 'tdata'
     data = sorted( self._CompletionResultsForLine(
-                    'set x = ' + TEST_DIR + '/tes${YCM_TEST_td}/filename_completer/' ) )
+          'set x = ' + TEST_DIR + '/tes${YCM_TEST_td}/filename_completer/' ) )
     os.environ.pop( 'YCM_TEST_td' )
 
     eq_( [ ('inner_dir', '[Dir]') ], data )
@@ -220,7 +228,7 @@ class FilenameCompleter_test( object ):
 
   def EnvVar_Undefined_test( self ):
     data = sorted( self._CompletionResultsForLine(
-                    'set x = ' + TEST_DIR + '/testdata/filename_completer${YCM_TEST_td}/' ) )
+      'set x = ' + TEST_DIR + '/testdata/filename_completer${YCM_TEST_td}/' ) )
 
     eq_( [ ], data )
 
@@ -228,7 +236,9 @@ class FilenameCompleter_test( object ):
   def EnvVar_Empty_Matches_test( self ):
     os.environ[ 'YCM_empty_var' ] = ''
     data = sorted( self._CompletionResultsForLine(
-                    'set x = ' + TEST_DIR + '/testdata/filename_completer${YCM_empty_var}/' ) )
+      'set x = '
+      + TEST_DIR
+      + '/testdata/filename_completer${YCM_empty_var}/' ) )
     os.environ.pop( 'YCM_empty_var' )
 
     eq_( [ ('inner_dir', '[Dir]') ], data )

--- a/ycmd/tests/go/go_handlers_test.py
+++ b/ycmd/tests/go/go_handlers_test.py
@@ -37,7 +37,8 @@ class Go_Handlers_test( Handlers_test ):
 
 
   def _StopGoCodeServer( self ):
-    self._app.post_json( '/run_completer_command',
-                         self._BuildRequest( completer_target = 'filetype_default',
-                                             command_arguments = [ 'StopServer' ],
-                                             filetype = 'go' ) )
+    self._app.post_json(
+        '/run_completer_command',
+        self._BuildRequest( completer_target = 'filetype_default',
+                            command_arguments = [ 'StopServer' ],
+                            filetype = 'go' ) )

--- a/ycmd/tests/identifier_completer_test.py
+++ b/ycmd/tests/identifier_completer_test.py
@@ -28,6 +28,7 @@ from ycmd.completers.all import identifier_completer as ic
 from ycmd.request_wrap import RequestWrap
 from ycmd.tests.test_utils import BuildRequest
 
+
 def BuildRequestWrap( contents, column_num, line_num = 1 ):
   return RequestWrap( BuildRequest( column_num = column_num,
                                     line_num = line_num,

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -35,6 +35,7 @@ import http.client
 import os
 from mock import patch
 
+
 class Javascript_EventNotification_test( Javascript_Handlers_test ):
 
   def OnFileReadyToParse_ProjectFile_cwd_test( self ):

--- a/ycmd/tests/python/subcommands_test.py
+++ b/ycmd/tests/python/subcommands_test.py
@@ -99,7 +99,8 @@ inception()
                                     goto_data,
                                     expect_errors = True  ).json
     assert_that( response,
-                 self._ErrorMatcher( RuntimeError, "Can\'t jump to definition." ) )
+                 self._ErrorMatcher( RuntimeError,
+                                     "Can\'t jump to definition." ) )
 
 
   def GoTo_test( self ):
@@ -200,20 +201,17 @@ inception()
       'column_num': 5,
       'description': 'def f',
       'line_num': 1
-    },
-    {
+    }, {
       'filepath': self._PathToTestFile( 'goto_references.py' ),
       'column_num': 5,
       'description': 'a = f()',
       'line_num': 4
-    },
-    {
+    }, {
       'filepath': self._PathToTestFile( 'goto_references.py' ),
       'column_num': 5,
       'description': 'b = f()',
       'line_num': 5
-    },
-    {
+    }, {
       'filepath': self._PathToTestFile( 'goto_references.py' ),
       'column_num': 5,
       'description': 'c = f()',

--- a/ycmd/tests/python/user_defined_python_test.py
+++ b/ycmd/tests/python/user_defined_python_test.py
@@ -85,7 +85,8 @@ class UserDefinedPython_test( Python_Handlers_test ):
 
 
   @patch( 'ycmd.utils.SafePopen' )
-  @patch( 'ycmd.completers.python.jedi_completer.JediCompleter._CheckBinaryExists',
+  @patch( 'ycmd.completers.python.jedi_completer.'
+            'JediCompleter._CheckBinaryExists',
           return_value = False )
   def WhenNonExistentPythonIsGiven_ReturnAnError_test( self, *args ):
     python = '/non/existing/path/python'
@@ -100,7 +101,8 @@ class UserDefinedPython_test( Python_Handlers_test ):
 
 
   @patch( 'ycmd.utils.SafePopen' )
-  @patch( 'ycmd.completers.python.jedi_completer.JediCompleter._CheckBinaryExists',
+  @patch( 'ycmd.completers.python.jedi_completer.'
+            'JediCompleter._CheckBinaryExists',
           return_value = True )
   def WhenExistingPythonIsGiven_ThatIsUsed_test( self, *args ):
     python = '/existing/python'
@@ -110,7 +112,8 @@ class UserDefinedPython_test( Python_Handlers_test ):
 
 
   @patch( 'ycmd.utils.SafePopen' )
-  @patch( 'ycmd.completers.python.jedi_completer.JediCompleter._CheckBinaryExists',
+  @patch( 'ycmd.completers.python.jedi_completer.'
+            'JediCompleter._CheckBinaryExists',
           return_value = True )
   def RestartServerWithoutArguments_WillReuseTheLastPython_test( self, *args ):
     request = self._BuildRequest( filetype = 'python',
@@ -120,7 +123,8 @@ class UserDefinedPython_test( Python_Handlers_test ):
 
 
   @patch( 'ycmd.utils.SafePopen' )
-  @patch( 'ycmd.completers.python.jedi_completer.JediCompleter._CheckBinaryExists',
+  @patch( 'ycmd.completers.python.jedi_completer.'
+            'JediCompleter._CheckBinaryExists',
           return_value = True )
   def RestartServerWithArgument_WillUseTheSpecifiedPython_test( self, *args ):
     python = '/existing/python'
@@ -132,7 +136,8 @@ class UserDefinedPython_test( Python_Handlers_test ):
 
 
   @patch( 'ycmd.utils.SafePopen' )
-  @patch( 'ycmd.completers.python.jedi_completer.JediCompleter._CheckBinaryExists',
+  @patch( 'ycmd.completers.python.jedi_completer.'
+            'JediCompleter._CheckBinaryExists',
           return_value = False )
   def RestartServerWithNonExistingPythonArgument_test( self, *args ):
     python = '/non/existing/python'

--- a/ycmd/tests/request_validation_test.py
+++ b/ycmd/tests/request_validation_test.py
@@ -28,6 +28,7 @@ from nose.tools import ok_
 from ycmd.request_validation import EnsureRequestValid
 from ycmd.responses import ServerError
 
+
 def BasicData():
   return {
     'line_num': 1,
@@ -100,4 +101,3 @@ def EnsureRequestValid_MissingEntryForFileInFileData_test():
   data[ 'filepath' ] = '/bar'
   assert_that( calling( EnsureRequestValid ).with_args( data ),
                raises( ServerError, ".*/bar.*" ) )
-

--- a/ycmd/tests/request_wrap_test.py
+++ b/ycmd/tests/request_wrap_test.py
@@ -28,6 +28,7 @@ from builtins import *  # noqa
 from nose.tools import eq_
 from ..request_wrap import RequestWrap
 
+
 def PrepareJson( contents = '', line_num = 1, column_num = 1, filetype = '' ):
   return {
     'line_num': line_num,
@@ -40,6 +41,7 @@ def PrepareJson( contents = '', line_num = 1, column_num = 1, filetype = '' ):
       }
     }
   }
+
 
 def LineValue_OneLine_test():
   eq_( 'zoo',
@@ -91,6 +93,7 @@ def StartColumn_Dot_test():
   eq_( 5,
        RequestWrap( PrepareJson( column_num = 8,
                                  contents = 'foo.bar') )[ 'start_column' ] )
+
 
 def StartColumn_DotWithUnicode_test():
   eq_( 7,

--- a/ycmd/tests/rust/rust_handlers_test.py
+++ b/ycmd/tests/rust/rust_handlers_test.py
@@ -62,4 +62,3 @@ class Rust_Handlers_test( Handlers_test ):
       retries = retries - 1
 
     raise RuntimeError( "Timeout waiting for racerd" )
-

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -29,23 +29,31 @@ from .handlers_test import Handlers_test
 from ycmd.tests.test_utils import DummyCompleter
 from mock import patch
 
+
 class Subcommands_test( Handlers_test ):
 
   @patch( 'ycmd.tests.test_utils.DummyCompleter.GetSubcommandsMap',
-          return_value = { 'A': lambda x: x, 'B': lambda x: x, 'C': lambda x: x } )
+          return_value = { 'A': lambda x: x,
+                           'B': lambda x: x,
+                           'C': lambda x: x } )
   def Basic_test( self, *args ):
     with self.PatchCompleter( DummyCompleter, 'dummy_filetype' ):
-      subcommands_data = self._BuildRequest( completer_target = 'dummy_filetype' )
+      subcommands_data = self._BuildRequest(
+          completer_target = 'dummy_filetype' )
 
       eq_( [ 'A', 'B', 'C' ],
-           self._app.post_json( '/defined_subcommands', subcommands_data ).json )
+           self._app.post_json( '/defined_subcommands',
+                                subcommands_data ).json )
 
 
   @patch( 'ycmd.tests.test_utils.DummyCompleter.GetSubcommandsMap',
-          return_value = { 'A': lambda x: x, 'B': lambda x: x, 'C': lambda x: x } )
+          return_value = { 'A': lambda x: x,
+                           'B': lambda x: x,
+                           'C': lambda x: x } )
   def NoExplicitCompleterTargetSpecified_test( self, *args ):
     with self.PatchCompleter( DummyCompleter, 'dummy_filetype' ):
       subcommands_data = self._BuildRequest( filetype = 'dummy_filetype' )
 
       eq_( [ 'A', 'B', 'C' ],
-           self._app.post_json( '/defined_subcommands', subcommands_data ).json )
+           self._app.post_json( '/defined_subcommands',
+                                subcommands_data ).json )

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -85,7 +85,6 @@ class DummyCompleter( Completer ):
   def __init__( self, user_options ):
     super( DummyCompleter, self ).__init__( user_options )
 
-
   def SupportedFiletypes( self ):
     return []
 

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -58,19 +58,24 @@ class TypeScript_GetCompletions_test( Typescript_Handlers_test ):
       'expect': {
         'data': has_entries( {
           'completions': contains_inanyorder(
-            self.CompletionEntryMatcher( 'methodA',
-                                         'methodA (method) Foo.methodA(): void' ),
-            self.CompletionEntryMatcher( 'methodB',
-                                         'methodB (method) Foo.methodB(): void' ),
-            self.CompletionEntryMatcher( 'methodC',
-                                         'methodC (method) Foo.methodC(): void' ),
+            self.CompletionEntryMatcher(
+              'methodA',
+              'methodA (method) Foo.methodA(): void' ),
+            self.CompletionEntryMatcher(
+              'methodB',
+              'methodB (method) Foo.methodB(): void' ),
+            self.CompletionEntryMatcher(
+              'methodC',
+              'methodC (method) Foo.methodC(): void' ),
           )
         } )
       }
     } )
 
 
-  @patch( 'ycmd.completers.typescript.typescript_completer.MAX_DETAILED_COMPLETIONS', 2 )
+  @patch( 'ycmd.completers.typescript.'
+            'typescript_completer.MAX_DETAILED_COMPLETIONS',
+          2 )
   def MaxDetailedCompletion_test( self ):
     self._RunTest( {
       'expect': {

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -49,7 +49,8 @@ class TypeScript_Subcommands_test( Typescript_Handlers_test ):
                                        filetype = 'typescript',
                                        filepath = filepath )
 
-    response = self._app.post_json( '/run_completer_command', gettype_data ).json
+    response = self._app.post_json( '/run_completer_command',
+                                    gettype_data ).json
     assert_that( response, self._MessageMatcher( 'var foo: Foo' ) )
 
 
@@ -147,13 +148,14 @@ class TypeScript_Subcommands_test( Typescript_Handlers_test ):
 
     self._app.post_json( '/event_notification', event_data )
 
-    references_data = self._BuildRequest( completer_target = 'filetype_default',
-                                          command_arguments = [ 'GoToReferences' ],
-                                          line_num = 28,
-                                          column_num = 6,
-                                          contents = contents,
-                                          filetype = 'typescript',
-                                          filepath = filepath )
+    references_data = self._BuildRequest(
+      completer_target = 'filetype_default',
+      command_arguments = [ 'GoToReferences' ],
+      line_num = 28,
+      column_num = 6,
+      contents = contents,
+      filetype = 'typescript',
+      filepath = filepath )
 
     expected = has_items(
       has_entries( { 'description': 'var bar = new Bar();',
@@ -162,7 +164,8 @@ class TypeScript_Subcommands_test( Typescript_Handlers_test ):
       has_entries( { 'description': 'bar.testMethod();',
                      'line_num'   : 29,
                      'column_num' : 1 } ) )
-    actual = self._app.post_json( '/run_completer_command', references_data ).json
+    actual = self._app.post_json( '/run_completer_command',
+                                  references_data ).json
     assert_that( actual, expected )
 
 

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -39,13 +39,14 @@ CREATE_NO_WINDOW = 0x08000000
 # Executable extensions used on Windows
 WIN_EXECUTABLE_EXTS = [ '.exe', '.bat', '.cmd' ]
 
-# Don't use this! Call PathToCreatedTempDir() instead. This exists for the sake of
-# tests.
+# Don't use this! Call PathToCreatedTempDir() instead. This exists for the sake
+# of tests.
 RAW_PATH_TO_TEMP_DIR = os.path.join( tempfile.gettempdir(), 'ycm_temp' )
 
 # Readable, writable and executable by everyone.
 ACCESSIBLE_TO_ALL_MASK = ( stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH |
                            stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP )
+
 
 # Python 3 complains on the common open(path).read() idiom because the file
 # doesn't get closed. So, a helper func.

--- a/ycmd/watchdog_plugin.py
+++ b/ycmd/watchdog_plugin.py
@@ -29,6 +29,7 @@ import copy
 from ycmd import utils
 from threading import Thread, Lock
 
+
 # This class implements the Bottle plugin API:
 # http://bottlepy.org/docs/dev/plugindev.html
 #
@@ -104,4 +105,3 @@ class WatchdogPlugin( object ):
       self._SetLastRequestTime( time.time() )
       return callback( *args, **kwargs )
     return wrapper
-


### PR DESCRIPTION
We previously only enabled a small number of flake8 warnings, and excluded a number of potentially useful things, like syntax errors, etc.

Instead, we enable all warnings/errors by default and just exclude those specific ones which we find distasteful. The full list is here: http://pep8.readthedocs.org/en/latest/intro.html#error-codes.

Implemented as a list, so that it can remain sorted via something like `:!sort`. I appreciate this makes setting up things like syntastic harder, but I found creating the list this way was simpler and easier to maintain.

NOTE: this PR is actually on top of #415, so please forgive that it includes those changes too (it seemed pointless to fix flake8 errors in a file I know was about to change!)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/416)
<!-- Reviewable:end -->
