### PR TITLE
[READY] Add RefactorRename support to typescript

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -615,13 +615,13 @@ def _BuildChunks( request_data, new_buffer ):
   start_index = 0
   end_index = min_length
   for i in range( 0, min_length - 1 ):
-      if new_buffer[ i ] != old_buffer[ i ]:
-          start_index = i
-          break
+    if new_buffer[ i ] != old_buffer[ i ]:
+      start_index = i
+      break
   for i in range( 1, min_length ):
-      if new_buffer[ new_length - i ] != old_buffer[ old_length - i ]:
-          end_index = i - 1
-          break
+    if new_buffer[ new_length - i ] != old_buffer[ old_length - i ]:
+      end_index = i - 1
+      break
   # To handle duplicates, i.e aba => a
   if ( start_index + end_index > min_length ):
     start_index -= start_index + end_index - min_length

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -439,17 +439,24 @@ class TypeScriptCompleter( Completer ):
             start = responses.Location(
                                 source_range[ 'start' ][ 'line' ],
                                 source_range[ 'start' ][ 'offset' ],
-                                file_replacement[ 'file' ] ),
+                                file_name ),
             end = responses.Location(
                                 source_range[ 'end' ][ 'line' ],
                                 source_range[ 'end' ][ 'offset' ],
-                                file_replacement[ 'file' ] ) ) )
+                                file_name ) ) )
 
 
     def BuildFixItChunksForFile( file_replacement ):
       """ returns a list of FixItChunk for each replacement range for the
       supplied file"""
-      return [ BuildFixItChunkForRange( file_replacement[ 'file' ], r )
+
+      # On windows, tsserver annoyingly returns file path as C:/blah/blah,
+      # whereas all other paths in Python are of the C:\\blah\\blah form. We use
+      # normpath to have python do the conversion for us.
+      file_path = os.path.normpath( file_replacement[ 'file' ] )
+      _logger.debug( 'Converted {0} to {1}'.format( file_replacement[ 'file' ],
+                                                    file_path ) )
+      return [ BuildFixItChunkForRange( file_path, r )
                for r in file_replacement[ 'locs' ] ]
 
 

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -158,3 +158,21 @@ class DummyCompleter( Completer ):
   # This method is here for testing purpose, so it can be mocked during tests
   def CandidatesList( self ):
     return []
+
+
+def LocationMatcher( filepath, line_num, column_num ):
+  return has_entries( {
+    'line_num': line_num,
+    'column_num': column_num,
+    'filepath': filepath
+  } )
+
+
+def ChunkMatcher( replacement_text, start, end ):
+  return has_entries( {
+    'replacement_text': replacement_text,
+    'range': has_entries( {
+      'start': start,
+      'end': end
+    } )
+  } )

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -116,6 +116,24 @@ def MessageMatcher( msg ):
   return has_entry( 'message', contains_string( msg ) )
 
 
+def LocationMatcher( filepath, line_num, column_num ):
+  return has_entries( {
+    'line_num': line_num,
+    'column_num': column_num,
+    'filepath': filepath
+  } )
+
+
+def ChunkMatcher( replacement_text, start, end ):
+  return has_entries( {
+    'replacement_text': replacement_text,
+    'range': has_entries( {
+      'start': start,
+      'end': end
+    } )
+  } )
+
+
 @contextlib.contextmanager
 def PatchCompleter( completer, filetype ):
   user_options = handlers._server_state._user_options
@@ -158,21 +176,3 @@ class DummyCompleter( Completer ):
   # This method is here for testing purpose, so it can be mocked during tests
   def CandidatesList( self ):
     return []
-
-
-def LocationMatcher( filepath, line_num, column_num ):
-  return has_entries( {
-    'line_num': line_num,
-    'column_num': column_num,
-    'filepath': filepath
-  } )
-
-
-def ChunkMatcher( replacement_text, start, end ):
-  return has_entries( {
-    'replacement_text': replacement_text,
-    'range': has_entries( {
-      'start': start,
-      'end': end
-    } )
-  } )

--- a/ycmd/tests/typescript/testdata/file2.ts
+++ b/ycmd/tests/typescript/testdata/file2.ts
@@ -1,0 +1,1 @@
+new Bar().testMethod();

--- a/ycmd/tests/typescript/testdata/file3.ts
+++ b/ycmd/tests/typescript/testdata/file3.ts
@@ -1,0 +1,2 @@
+var bar = new Bar();
+bar.testMethod();

--- a/ycmd/tests/typescript/testdata/tsconfig.json
+++ b/ycmd/tests/typescript/testdata/tsconfig.json
@@ -3,6 +3,8 @@
     "noEmit": true
   },
   "files": [
-    "test.ts"
+    "test.ts",
+    "file2.ts",
+    "file3.ts"
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/Valloric/YouCompleteMe/issues/2018

This also contains a pretty important fix to the javascript tests where the tests weren't actually executing a matcher on `RefactorRename` tests.

Currently RFC because this was done pretty quickly and tested fairly casually. I'm pretty confident it works because it is almost identical to the javascript implementation (In the sense that the hard work is still done by the client, which is unchanged), but still worth some additional testing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/417)
<!-- Reviewable:end -->
