### PR TITLE
Use current python from environment when launch jedihttp

### DIFF
--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -37,7 +37,6 @@ import logging
 import urllib.parse
 import requests
 import threading
-import sys
 import os
 from distutils.spawn import find_executable
 

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -39,6 +39,7 @@ import requests
 import threading
 import sys
 import os
+from distutils.spawn import find_executable
 
 
 HMAC_SECRET_LENGTH = 16
@@ -69,7 +70,7 @@ class JediCompleter( Completer ):
     self._logfile_stderr = None
     self._keep_logfiles = user_options[ 'server_keep_logfiles' ]
     self._hmac_secret = ''
-    self._python_binary_path = sys.executable
+    self._python_binary_path = find_executable('python')
 
     self._UpdatePythonBinary( user_options.get( 'python_binary_path' ) )
     self._StartServer()

--- a/ycmd/tests/python/user_defined_python_test.py
+++ b/ycmd/tests/python/user_defined_python_test.py
@@ -26,7 +26,7 @@ from builtins import *  # noqa
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest import assert_that, has_item, contains, equal_to, is_not  # noqa
 from mock import patch
-import sys
+from distutils.spawn import find_executable
 
 from ycmd import utils
 from ycmd.completers.python.jedi_completer import BINARY_NOT_FOUND_MESSAGE
@@ -81,7 +81,7 @@ def was_called_with_python( python ):
 @patch( 'ycmd.utils.SafePopen' )
 def UserDefinedPython_WithoutAnyOption_DefaultToYcmdPython_test( app, *args ):
   app.get( '/ready', { 'subserver': 'python' } )
-  assert_that( utils.SafePopen, was_called_with_python( sys.executable ) )
+  assert_that( utils.SafePopen, was_called_with_python( find_executable('python') ) )
 
 
 @IsolatedYcmd
@@ -121,7 +121,7 @@ def UserDefinedPython_RestartServerWithoutArguments_WillReuseTheLastPython_test(
   request = BuildRequest( filetype = 'python',
                           command_arguments = [ 'RestartServer' ] )
   app.post_json( '/run_completer_command', request )
-  assert_that( utils.SafePopen, was_called_with_python( sys.executable ) )
+  assert_that( utils.SafePopen, was_called_with_python( find_executable('python') ) )
 
 
 @IsolatedYcmd
@@ -152,4 +152,4 @@ def UserDefinedPython_RestartServerWithNonExistingPythonArgument_test( app,
 
   msg = BINARY_NOT_FOUND_MESSAGE.format( python )
   assert_that( response, ErrorMatcher( RuntimeError, msg ) )
-  assert_that( utils.SafePopen, was_called_with_python( sys.executable ) )
+  assert_that( utils.SafePopen, was_called_with_python( find_executable('python') ) )

--- a/ycmd/tests/python/user_defined_python_test.py
+++ b/ycmd/tests/python/user_defined_python_test.py
@@ -81,7 +81,8 @@ def was_called_with_python( python ):
 @patch( 'ycmd.utils.SafePopen' )
 def UserDefinedPython_WithoutAnyOption_DefaultToYcmdPython_test( app, *args ):
   app.get( '/ready', { 'subserver': 'python' } )
-  assert_that( utils.SafePopen, was_called_with_python( find_executable('python') ) )
+  assert_that( utils.SafePopen,
+               was_called_with_python( find_executable('python') ) )
 
 
 @IsolatedYcmd
@@ -121,7 +122,8 @@ def UserDefinedPython_RestartServerWithoutArguments_WillReuseTheLastPython_test(
   request = BuildRequest( filetype = 'python',
                           command_arguments = [ 'RestartServer' ] )
   app.post_json( '/run_completer_command', request )
-  assert_that( utils.SafePopen, was_called_with_python( find_executable('python') ) )
+  assert_that( utils.SafePopen,
+               was_called_with_python( find_executable('python') ) )
 
 
 @IsolatedYcmd
@@ -152,4 +154,5 @@ def UserDefinedPython_RestartServerWithNonExistingPythonArgument_test( app,
 
   msg = BINARY_NOT_FOUND_MESSAGE.format( python )
   assert_that( response, ErrorMatcher( RuntimeError, msg ) )
-  assert_that( utils.SafePopen, was_called_with_python( find_executable('python') ) )
+  assert_that( utils.SafePopen,
+               was_called_with_python( find_executable('python') ) )


### PR DESCRIPTION
Here we always use the vim python interpreter when we launch the
jedihttp unless python_binary_path is defined. Now, we use the python
interpreter from the environment, so if we use virtualenv, the
jedihttp is launched with the right python version and the completion
works out of the box for python2/3 with virtualenv

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/424)
<!-- Reviewable:end -->
