### PR TITLE
[WIP] Add RefactorRename subcommand to Python completer

### DIFF
--- a/ycmd/tests/python/subcommands_test.py
+++ b/ycmd/tests/python/subcommands_test.py
@@ -23,13 +23,16 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from hamcrest import assert_that
+from hamcrest import assert_that, contains, has_entries
 from nose.tools import eq_
+from pprint import pformat
 import os.path
+import http.client
 
 from ycmd.utils import ReadFile
 from ycmd.tests.python import PathToTestFile, SharedYcmd
-from ycmd.tests.test_utils import BuildRequest, ErrorMatcher
+from ycmd.tests.test_utils import ( BuildRequest, ChunkMatcher, ErrorMatcher,
+                                    LocationMatcher )
 
 
 @SharedYcmd
@@ -224,3 +227,166 @@ def Subcommands_GoToReferences_test( app ):
       'description': 'c = f()',
       'line_num': 6
     } ] )
+
+
+def RunTest( app, test ):
+  contents = ReadFile( test[ 'request' ][ 'filepath' ] )
+
+  def CombineRequest( request, data ):
+    kw = request
+    request.update( data )
+    return BuildRequest( **kw )
+
+  # Because we aren't testing this command, we *always* ignore errors. This
+  # is mainly because we (may) want to test scenarios where the completer
+  # throws an exception and the easiest way to do that is to throw from
+  # within the FlagsForFile function.
+  app.post_json( '/event_notification',
+                 CombineRequest( test[ 'request' ], {
+                                 'event_name': 'FileReadyToParse',
+                                 'contents': contents,
+                                 } ),
+                 expect_errors = True )
+
+  # We also ignore errors here, but then we check the response code
+  # ourself. This is to allow testing of requests returning errors.
+  response = app.post_json(
+    '/run_completer_command',
+    CombineRequest( test[ 'request' ], {
+      'completer_target': 'filetype_default',
+      'contents': contents,
+      'filetype': 'python',
+      'command_arguments': ( [ test[ 'request' ][ 'command' ] ]
+                             + test[ 'request' ].get( 'arguments', [] ) )
+    } ),
+    expect_errors = True
+  )
+
+  print( 'completer response: {0}'.format( pformat( response.json ) ) )
+
+  eq_( response.status_code, test[ 'expect' ][ 'response' ] )
+
+  assert_that( response.json, test[ 'expect' ][ 'data' ] )
+
+
+@SharedYcmd
+def Subcommands_RefactorRename_MissingNewName_test( app ):
+  filepath = PathToTestFile( 'refactor_rename1.py' )
+  RunTest( app, {
+    'description': 'RefactorRename raises an error without new name',
+    'request': {
+      'command': 'RefactorRename',
+      'arguments': [],
+      'filepath': filepath,
+      'line_num': 7,
+      'column_num': 14,
+    },
+    'expect': {
+      'response': http.client.INTERNAL_SERVER_ERROR,
+      'data': ErrorMatcher( ValueError,
+                            'Please specify a new name to rename it to.\n'
+                            'Usage: RefactorRename <new name>' ),
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_RefactorRename_NotPossible_test( app ):
+  filepath = PathToTestFile( 'refactor_rename1.py' )
+  RunTest( app, {
+    'description': 'RefactorRename raises an error '
+                   'when there is no reference',
+    'request': {
+      'command': 'RefactorRename',
+      'arguments': [ 'whatever' ],
+      'filepath': filepath,
+      'line_num': 1,
+      'column_num': 17,
+    },
+    'expect': {
+      'response': http.client.INTERNAL_SERVER_ERROR,
+      'data': ErrorMatcher( RuntimeError, 'Can\'t find references.' ),
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_RefactorRename_SingleFile_test( app ):
+  filepath = PathToTestFile( 'refactor_rename1.py' )
+  RunTest( app, {
+    'description': 'RefactorRename works within a single file',
+    'request': {
+      'command': 'RefactorRename',
+      'arguments': [ 'a_new_variable_name' ],
+      'filepath': filepath,
+      'line_num': 7,
+      'column_num': 14,
+    },
+    'expect': {
+      'response': http.client.OK,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+              ChunkMatcher( 'a_new_variable_name',
+                            LocationMatcher( filepath, 1, 1 ),
+                            LocationMatcher( filepath, 1, 14 ) ),
+              ChunkMatcher( 'a_new_variable_name',
+                            LocationMatcher( filepath, 5, 10 ),
+                            LocationMatcher( filepath, 5, 23 ) ),
+              ChunkMatcher( 'a_new_variable_name',
+                            LocationMatcher( filepath, 7, 10 ),
+                            LocationMatcher( filepath, 7, 23 ) ),
+              # On the same line, ensuring offsets are as expected (as
+              # unmodified source, similar to clang)
+              ChunkMatcher( 'a_new_variable_name',
+                            LocationMatcher( filepath, 7, 26 ),
+                            LocationMatcher( filepath, 7, 39 ) ),
+          ),
+          'location': LocationMatcher( filepath, 7, 14 )
+        } ) )
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_RefactorRename_MultipleFiles_test( app ):
+  current_filepath = PathToTestFile( 'refactor_rename1.py' )
+  filepath2 = PathToTestFile( 'refactor_rename2.py' )
+  filepath3 = PathToTestFile( 'refactor_rename3.py' )
+  RunTest( app, {
+    'description': 'RefactorRename works across files',
+    'request': {
+      'command': 'RefactorRename',
+      'arguments': [ 'a_new_function_name' ],
+      'filepath': current_filepath,
+      'line_num': 4,
+      'column_num': 5,
+    },
+    'expect': {
+      'response': http.client.OK,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+            ChunkMatcher(
+              'a_new_function_name',
+              LocationMatcher( current_filepath, 4, 5 ),
+              LocationMatcher( current_filepath, 4, 18 ) ),
+            ChunkMatcher(
+              'a_new_function_name',
+              LocationMatcher( filepath2, 1, 30 ),
+              LocationMatcher( filepath2, 1, 43 ) ),
+            ChunkMatcher(
+              'a_new_function_name',
+              LocationMatcher( filepath2, 3, 1 ),
+              LocationMatcher( filepath2, 3, 14 ) ),
+            ChunkMatcher(
+              'a_new_function_name',
+              LocationMatcher( filepath3, 5, 20 ),
+              LocationMatcher( filepath3, 5, 33 ) ),
+          ),
+          'location': LocationMatcher( current_filepath, 4, 5 )
+        } ) )
+      } )
+    }
+  } )

--- a/ycmd/tests/python/testdata/goto.py
+++ b/ycmd/tests/python/testdata/goto.py
@@ -1,0 +1,8 @@
+def my_func():
+  print('called')
+
+alias = my_func
+my_list = [1, None, alias]
+inception = my_list[2]
+
+inception()

--- a/ycmd/tests/python/testdata/refactor_rename1.py
+++ b/ycmd/tests/python/testdata/refactor_rename1.py
@@ -1,0 +1,7 @@
+some_variable = 10
+
+
+def some_function():
+  global some_variable
+
+  return some_variable + some_variable

--- a/ycmd/tests/python/testdata/refactor_rename2.py
+++ b/ycmd/tests/python/testdata/refactor_rename2.py
@@ -1,0 +1,3 @@
+from refactor_rename1 import some_function
+
+some_function()

--- a/ycmd/tests/python/testdata/refactor_rename3.py
+++ b/ycmd/tests/python/testdata/refactor_rename3.py
@@ -1,0 +1,5 @@
+import refactor_rename1
+
+
+def another_function():
+  refactor_rename1.some_function()


### PR DESCRIPTION
Heavily inspired by PR #417. 

Jedi does not return the end location of a definition so we find it by computing its name length.

Update JediHTTP submodule to include PR vheon/JediHTTP#13.

Refactor the subcommands Python tests to reduce code duplication.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/425)

<!-- Reviewable:end -->
