### PR TITLE
always use ninja to compile if on the path

### DIFF
--- a/build.py
+++ b/build.py
@@ -203,7 +203,9 @@ def CustomPythonCmakeArgs():
 
 
 def GetGenerator( args ):
-  if OnWindows():
+  if PathToFirstExistingExecutable( ['ninja'] ):
+    return 'Ninja'
+  elif OnWindows():
     if args.msvc == 14:
       generator = 'Visual Studio 14'
     elif args.msvc == 12:
@@ -216,8 +218,6 @@ def GetGenerator( args ):
       generator = generator + ' Win64'
     return generator
 
-  if PathToFirstExistingExecutable( ['ninja'] ):
-    return 'Ninja'
   return 'Unix Makefiles'
 
 


### PR DESCRIPTION
allows to use ninja for building ycmd with gcc in msys64 environment and use ninja with MS compiler:

to build using ninja on windows for msvc 2015:
```
"%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" amd64
set PATH=%PATH%;c:\path\to\cmake-and-ninja;c:\path\to\python
python build.py --all
```

to build in msys64 simply:
```
./build.py --all
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/431)
<!-- Reviewable:end -->
