### PR TITLE
[READY] Include headers from external projects last

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -199,17 +199,6 @@ else()
   set( Boost_LIBRARIES BoostParts )
 endif()
 
-# The SYSTEM flag makes sure that -isystem[header path] is passed to the
-# compiler instead of the standard -I[header path]. Headers included with
-# -isystem do not generate warnings (and they shouldn't; e.g. boost warnings are
-# just noise for us since we won't be changing them).
-include_directories(
-  SYSTEM
-  ${Boost_INCLUDE_DIR}
-  ${PYTHON_INCLUDE_DIRS}
-  ${CLANG_INCLUDES_DIR}
-  )
-
 file( GLOB_RECURSE SERVER_SOURCES *.h *.cpp )
 
 # The test sources are a part of a different target, so we remove them
@@ -233,6 +222,20 @@ else()
     list( REMOVE_ITEM SERVER_SOURCES ${to_remove_clang} )
   endif()
 endif()
+
+# The SYSTEM flag makes sure that -isystem[header path] is passed to the
+# compiler instead of the standard -I[header path]. Headers included with
+# -isystem do not generate warnings (and they shouldn't; e.g. boost warnings are
+# just noise for us since we won't be changing them).
+# Since there is no -isystem flag equivalent on Windows, headers from external
+# projects may conflict with our headers and override them. We prevent that by
+# including these directories after ours.
+include_directories(
+  SYSTEM
+  ${Boost_INCLUDE_DIR}
+  ${PYTHON_INCLUDE_DIRS}
+  ${CLANG_INCLUDES_DIR}
+  )
 
 #############################################################################
 


### PR DESCRIPTION
Currently, headers are included by CMake in this order (when compiling with Clang support):
 - BoostParts
 - Python
 - Clang
 - `cpp\ycm`
 - `cpp\ycm\ClangCompleter`

The issue with this order is that if one of our headers has the same name as one of BoostParts, Python, or Clang headers, the wrong header may be included (depending on how it is included in the code). It can't happen with GCC and Clang compilers because the `-isystem` flag is used for these includes (`-isystem` directories are searched after `-I` directories). However, it is possible on Windows since there is no `-isystem` equivalent for MSVC. See issue in PR #291 where Python `token.h` is included instead of ycmd `Token.h`.

We prevent this by including the Boost, Python, and Clang directories after the ycmd ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/433)
<!-- Reviewable:end -->
