### PR TITLE
Removed comment about clients building ycmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ built one.
 
 Building
 --------
-
-[Clients commonly build and set up ycmd for you; you are unlikely to need to
-build ycmd yourself unless you want to build a new client.]
-
 **If you're looking to develop ycmd, see the [instructions for setting up a dev
 environment][dev-setup] and for [running the tests][test-setup].**
 


### PR DESCRIPTION
It seems that all the listed known ycmd clients do in fact require the user to build and set up ycmd on their systems (except for YouCompleteMe, but even that still requires occasional recompilation). Removing this comment reduces potential confusion for people seeking to set up their ycmd client as most client's install instructions link to this section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/434)
<!-- Reviewable:end -->
