### PR TITLE
Ignoring HTML template chars `{` and `}`

### DIFF
--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -60,7 +60,8 @@ FILETYPE_TO_IDENTIFIER_REGEX = {
     # Spec: http://www.w3.org/TR/html5/syntax.html#tag-name-state
     # But not quite since not everything we want to pull out is a tag name. We
     # also want attribute names (and probably unquoted attribute values).
-    'html': re.compile( r"[a-zA-Z][^\s/>='\"]*", re.UNICODE ),
+    # And we also want to ignore common template chars like `}` and `{`.
+    'html': re.compile( r"[a-zA-Z][^\s/>='\"}{\.]*", re.UNICODE ),
 
     # Spec: http://cran.r-project.org/doc/manuals/r-release/R-lang.pdf
     # Section 10.3.2.

--- a/ycmd/tests/identifier_utils_test.py
+++ b/ycmd/tests/identifier_utils_test.py
@@ -27,6 +27,7 @@ from builtins import *  # noqa
 
 from nose.tools import eq_, ok_
 from ycmd import identifier_utils as iu
+from hamcrest import assert_that, has_item
 
 
 def RemoveIdentifierFreeText_CppComments_test():
@@ -126,9 +127,14 @@ def ExtractIdentifiersFromText_Css_test():
 
 
 def ExtractIdentifiersFromText_Html_test():
-  eq_( [ "foo", "goo-foo", "zoo", "bar", "aa", "z", "b@g" ],
+  eq_( [ "foo", "goo-foo", "zoo", "bar", "aa", "z", "b@g", "fo", "ba" ],
        iu.ExtractIdentifiersFromText(
-           '<foo> <goo-foo zoo=bar aa="" z=\'\'/> b@g', "html" ) )
+           '<foo> <goo-foo zoo=bar aa="" z=\'\'/> b@g fo.ba', "html" ) )
+
+
+def ExtractIdentifiersFromText_Html_TemplateChars_test():
+  assert_that( iu.ExtractIdentifiersFromText( '<foo>{{goo}}</foo>', 'html' ),
+               has_item( 'goo' ) )
 
 
 def IsIdentifier_generic_test():


### PR DESCRIPTION
These are commonly used for HTML templating; see Handlebars, Angular
etc.

Fixes Valloric/YouCompleteMe#2058

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/436)
<!-- Reviewable:end -->
