### PR TITLE
Removing special-case handling of two underscores

### DIFF
--- a/cpp/ycm/ClangCompleter/CompletionData.cpp
+++ b/cpp/ycm/ClangCompleter/CompletionData.cpp
@@ -148,17 +148,6 @@ std::string OptionalChunkToString( CXCompletionString completion_string,
 }
 
 
-// NOTE: this function accepts the text param by value on purpose; it internally
-// needs a copy before processing the text so the copy might as well be made on
-// the parameter BUT if this code is compiled in C++11 mode a move constructor
-// can be called on the passed-in value. This is not possible if we accept the
-// param by const ref.
-std::string RemoveTwoConsecutiveUnderscores( std::string text ) {
-  boost::erase_all( text, "__" );
-  return text;
-}
-
-
 // foo( -> foo
 // foo() -> foo
 std::string RemoveTrailingParens( std::string text ) {
@@ -195,16 +184,6 @@ CompletionData::CompletionData( const CXCompletionResult &completion_result ) {
 
   original_string_ = RemoveTrailingParens( boost::move( original_string_ ) );
   kind_ = CursorKindToCompletionKind( completion_result.CursorKind );
-
-  // We remove any two consecutive underscores from the function definition
-  // since identifiers with them are ugly, compiler-reserved names. Functions
-  // from the standard library use parameter names like "__pos" and we want to
-  // show them as just "pos". This will never interfere with client code since
-  // ANY C++ identifier with two consecutive underscores in it is
-  // compiler-reserved.
-  everything_except_return_type_ =
-    RemoveTwoConsecutiveUnderscores(
-      boost::move( everything_except_return_type_ ) );
 
   detailed_info_.append( return_type_ )
   .append( " " )


### PR DESCRIPTION
For C-family languages, we used to remove two consecutive underscores in
identifiers out of a misguided attempt to reduce verbosity of reserved
identifiers. This only produced user confusion.

This logic also had no tests! Oh the shame...

Fixes Valloric/YouCompleteMe#2059

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/437)
<!-- Reviewable:end -->
