### PR TITLE
Skip completion cache if force_semantic is set

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -174,21 +174,22 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
 
 
   def _GetCandidatesFromSubclass( self, request_data ):
-    cache_completions = self._completions_cache.GetCompletionsIfCacheValid(
-          request_data[ 'line_num' ],
-          request_data[ 'start_column' ],
-          self.CompletionType( request_data ) )
+    if not ForceSemanticCompletion( request_data ):
+      cache_completions = self._completions_cache.GetCompletionsIfCacheValid(
+            request_data[ 'line_num' ],
+            request_data[ 'start_column' ],
+            self.CompletionType( request_data ) )
 
-    if cache_completions:
-      return cache_completions
-    else:
-      raw_completions = self.ComputeCandidatesInner( request_data )
-      self._completions_cache.Update(
-          request_data[ 'line_num' ],
-          request_data[ 'start_column' ],
-          self.CompletionType( request_data ),
-          raw_completions )
-      return raw_completions
+      if cache_completions:
+        return cache_completions
+
+    raw_completions = self.ComputeCandidatesInner( request_data )
+    self._completions_cache.Update(
+        request_data[ 'line_num' ],
+        request_data[ 'start_column' ],
+        self.CompletionType( request_data ),
+        raw_completions )
+    return raw_completions
 
 
   def ComputeCandidatesInner( self, request_data ):


### PR DESCRIPTION
This is a simple way to deal with the issues described in #430 as suggested by @puremourning in https://github.com/Valloric/ycmd/issues/430#issuecomment-201540248.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/443)
<!-- Reviewable:end -->
