### PR TITLE
replace `builtins` with `future.builtins`, see Valloric/YouCompleteMe/issues/2024

### DIFF
--- a/ycmd/__main__.py
+++ b/ycmd/__main__.py
@@ -30,7 +30,7 @@ SetUpPythonPath()
 
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import sys
 import logging

--- a/ycmd/bottle_utils.py
+++ b/ycmd/bottle_utils.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from future.utils import PY2
 from ycmd.utils import ToBytes, ToUnicode

--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import os
 import logging

--- a/ycmd/completers/c/hook.py
+++ b/ycmd/completers/c/hook.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import ycm_core
 from ycmd.completers.cpp.clang_completer import ClangCompleter

--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import abc
 import threading

--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 from future.utils import iteritems
 
 # Must not import ycm_core here! Vim imports completer, which imports this file.

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 from future.utils import iteritems
 
 from collections import defaultdict

--- a/ycmd/completers/cpp/clang_helpers.py
+++ b/ycmd/completers/cpp/clang_helpers.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 
 # Provided for backwards compatibility with old ycm_extra_conf files.

--- a/ycmd/completers/cpp/ephemeral_values_set.py
+++ b/ycmd/completers/cpp/ephemeral_values_set.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import threading
 

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import ycm_core
 import os

--- a/ycmd/completers/cpp/hook.py
+++ b/ycmd/completers/cpp/hook.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import ycm_core
 from ycmd.completers.cpp.clang_completer import ClangCompleter

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 from future import standard_library
 standard_library.install_aliases()
 from future.utils import itervalues

--- a/ycmd/completers/cs/hook.py
+++ b/ycmd/completers/cs/hook.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ycmd.completers.cs.cs_completer import CsharpCompleter
 

--- a/ycmd/completers/cs/solutiondetection.py
+++ b/ycmd/completers/cs/solutiondetection.py
@@ -22,7 +22,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import os
 import glob

--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -22,7 +22,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import os
 import re

--- a/ycmd/completers/general/general_completer_store.py
+++ b/ycmd/completers/general/general_completer_store.py
@@ -22,7 +22,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ycmd.completers.completer import Completer
 from ycmd.completers.all.identifier_completer import IdentifierCompleter

--- a/ycmd/completers/general/ultisnips_completer.py
+++ b/ycmd/completers/general/ultisnips_completer.py
@@ -22,7 +22,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ycmd.completers.general_completer import GeneralCompleter
 from ycmd import responses

--- a/ycmd/completers/general_completer.py
+++ b/ycmd/completers/general_completer.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ycmd.completers.completer import Completer
 

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import json
 import logging

--- a/ycmd/completers/go/hook.py
+++ b/ycmd/completers/go/hook.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ycmd.completers.go.go_completer import GoCompleter, ShouldEnableGoCompleter
 

--- a/ycmd/completers/javascript/hook.py
+++ b/ycmd/completers/javascript/hook.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ycmd.completers.javascript.tern_completer import (
   ShouldEnableTernCompleter, TernCompleter )

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -19,7 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 from future.utils import iterkeys
 from future import standard_library
 standard_library.install_aliases()

--- a/ycmd/completers/objc/hook.py
+++ b/ycmd/completers/objc/hook.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import ycm_core
 from ycmd.completers.cpp.clang_completer import ClangCompleter

--- a/ycmd/completers/objcpp/hook.py
+++ b/ycmd/completers/objcpp/hook.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import ycm_core
 from ycmd.completers.cpp.clang_completer import ClangCompleter

--- a/ycmd/completers/python/hook.py
+++ b/ycmd/completers/python/hook.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ycmd.completers.python.jedi_completer import JediCompleter
 

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 from future import standard_library
 from future.utils import native
 standard_library.install_aliases()

--- a/ycmd/completers/rust/hook.py
+++ b/ycmd/completers/rust/hook.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ycmd.completers.rust.rust_completer import RustCompleter
 

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -19,7 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 from future.utils import native, iteritems
 from future import standard_library
 standard_library.install_aliases()

--- a/ycmd/completers/typescript/hook.py
+++ b/ycmd/completers/typescript/hook.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ycmd.completers.typescript.typescript_completer import TypeScriptCompleter
 

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -22,7 +22,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import json
 import logging

--- a/ycmd/extra_conf_store.py
+++ b/ycmd/extra_conf_store.py
@@ -23,7 +23,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import os
 import random

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from os import path
 

--- a/ycmd/hmac_plugin.py
+++ b/ycmd/hmac_plugin.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import logging
 import http.client

--- a/ycmd/hmac_utils.py
+++ b/ycmd/hmac_utils.py
@@ -21,9 +21,9 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
-from builtins import bytes
+from future.builtins import bytes
 
 import hmac
 import hashlib

--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import re
 

--- a/ycmd/request_validation.py
+++ b/ycmd/request_validation.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ycmd.responses import ServerError
 

--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ycmd.utils import ToUnicode, ToBytes
 from ycmd.identifier_utils import StartOfLongestIdentifierEndingAtIndex

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import os
 

--- a/ycmd/server_state.py
+++ b/ycmd/server_state.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import os
 import threading

--- a/ycmd/tests/__init__.py
+++ b/ycmd/tests/__init__.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import functools
 import os

--- a/ycmd/tests/bottle_utils_test.py
+++ b/ycmd/tests/bottle_utils_test.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import eq_
 from mock import patch, call

--- a/ycmd/tests/check_core_version_test.py
+++ b/ycmd/tests/check_core_version_test.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from ..server_utils import CompatibleWithCurrentCoreVersion
 from nose.tools import eq_

--- a/ycmd/tests/clang/__init__.py
+++ b/ycmd/tests/clang/__init__.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import functools
 import os

--- a/ycmd/tests/clang/comment_strip_test.py
+++ b/ycmd/tests/clang/comment_strip_test.py
@@ -27,7 +27,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import eq_
 from ycmd.completers.cpp import clang_completer

--- a/ycmd/tests/clang/diagnostics_test.py
+++ b/ycmd/tests/clang/diagnostics_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import ( assert_that, contains, contains_string, has_entries,
                        has_entry, has_items, empty, equal_to )

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import eq_, ok_
 from ycmd.completers.cpp import flags

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import eq_
 from hamcrest import ( assert_that, contains, contains_inanyorder, empty,

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import ( assert_that, calling, contains, equal_to,
                        has_entries, raises )

--- a/ycmd/tests/completer_utils_test.py
+++ b/ycmd/tests/completer_utils_test.py
@@ -23,7 +23,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 from future.utils import iteritems
 
 import re

--- a/ycmd/tests/cs/__init__.py
+++ b/ycmd/tests/cs/__init__.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from contextlib import contextmanager
 import functools

--- a/ycmd/tests/cs/diagnostics_test.py
+++ b/ycmd/tests/cs/diagnostics_test.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import ( assert_that, contains, contains_string, equal_to,
                        has_entries, has_entry )

--- a/ycmd/tests/cs/get_completions_test.py
+++ b/ycmd/tests/cs/get_completions_test.py
@@ -23,7 +23,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import ( assert_that, empty, greater_than, has_item, has_items,
                        has_entries )

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import eq_, ok_
 from webtest import AppError

--- a/ycmd/tests/diagnostics_test.py
+++ b/ycmd/tests/diagnostics_test.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import assert_that
 from mock import patch

--- a/ycmd/tests/filename_completer_test.py
+++ b/ycmd/tests/filename_completer_test.py
@@ -23,7 +23,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import os
 from nose.tools import eq_

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -22,7 +22,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import assert_that, equal_to, has_items
 from mock import patch

--- a/ycmd/tests/go/__init__.py
+++ b/ycmd/tests/go/__init__.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import functools
 import os

--- a/ycmd/tests/go/get_completions_test.py
+++ b/ycmd/tests/go/get_completions_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import assert_that, has_item
 

--- a/ycmd/tests/go/go_completer_test.py
+++ b/ycmd/tests/go/go_completer_test.py
@@ -23,7 +23,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import os
 from nose.tools import eq_, raises

--- a/ycmd/tests/go/subcommands_test.py
+++ b/ycmd/tests/go/subcommands_test.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import eq_
 

--- a/ycmd/tests/hmac_utils_test.py
+++ b/ycmd/tests/hmac_utils_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from binascii import hexlify
 from nose.tools import eq_, ok_, raises

--- a/ycmd/tests/identifier_completer_test.py
+++ b/ycmd/tests/identifier_completer_test.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import eq_
 from ycmd.completers.all import identifier_completer as ic

--- a/ycmd/tests/identifier_utils_test.py
+++ b/ycmd/tests/identifier_utils_test.py
@@ -23,7 +23,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import eq_, ok_
 from ycmd import identifier_utils as iu

--- a/ycmd/tests/javascript/__init__.py
+++ b/ycmd/tests/javascript/__init__.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import functools
 import os

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import assert_that, empty
 from mock import patch

--- a/ycmd/tests/javascript/get_completions_test.py
+++ b/ycmd/tests/javascript/get_completions_test.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import ( assert_that, contains, contains_inanyorder, empty,
                        has_entries )

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import assert_that, contains, contains_inanyorder, has_entries
 from nose.tools import eq_

--- a/ycmd/tests/misc_handlers_test.py
+++ b/ycmd/tests/misc_handlers_test.py
@@ -22,7 +22,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import ok_
 from hamcrest import assert_that, contains

--- a/ycmd/tests/python/__init__.py
+++ b/ycmd/tests/python/__init__.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import functools
 import os

--- a/ycmd/tests/python/get_completions_test.py
+++ b/ycmd/tests/python/get_completions_test.py
@@ -23,7 +23,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import eq_
 from hamcrest import ( assert_that, has_item, has_items, has_entry,

--- a/ycmd/tests/python/subcommands_test.py
+++ b/ycmd/tests/python/subcommands_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import assert_that
 from nose.tools import eq_

--- a/ycmd/tests/python/user_defined_python_test.py
+++ b/ycmd/tests/python/user_defined_python_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest import assert_that, has_item, contains, equal_to, is_not  # noqa

--- a/ycmd/tests/python_support_test.py
+++ b/ycmd/tests/python_support_test.py
@@ -53,7 +53,7 @@ def GetUtf8String_Py3Bytes_test():
   eq_( 'foo', str( ycm_core.GetUtf8String( b'foo' ) ) )
 
 
-# No test for `bytes` from builtins because it's very difficult to make
+# No test for `bytes` from future.builtins because it's very difficult to make
 # GetUtf8String work with that and also it should never receive that type in the
 # first place (only py2 str/unicode and py3 bytes/str).
 

--- a/ycmd/tests/request_validation_test.py
+++ b/ycmd/tests/request_validation_test.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import raises, assert_that, calling
 from nose.tools import ok_

--- a/ycmd/tests/request_wrap_test.py
+++ b/ycmd/tests/request_wrap_test.py
@@ -23,7 +23,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import eq_
 from ..request_wrap import RequestWrap

--- a/ycmd/tests/rust/__init__.py
+++ b/ycmd/tests/rust/__init__.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import functools
 import os

--- a/ycmd/tests/rust/get_completions_test.py
+++ b/ycmd/tests/rust/get_completions_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import assert_that, has_entry, has_items, contains_string
 

--- a/ycmd/tests/rust/subcommands_test.py
+++ b/ycmd/tests/rust/subcommands_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from nose.tools import eq_
 

--- a/ycmd/tests/server_utils_test.py
+++ b/ycmd/tests/server_utils_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import raises, assert_that, calling
 from nose.tools import ok_

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -22,7 +22,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from mock import patch
 from nose.tools import eq_

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 from future import standard_library
 from future.utils import iteritems
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from future.utils import PY2
 from hamcrest import contains_string, has_entry, has_entries

--- a/ycmd/tests/typescript/__init__.py
+++ b/ycmd/tests/typescript/__init__.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import functools
 import os

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import assert_that, contains_inanyorder, has_entries
 from mock import patch

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 from hamcrest import ( assert_that,
                        contains,

--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import os
 import subprocess

--- a/ycmd/user_options_store.py
+++ b/ycmd/user_options_store.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import json
 import os

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 from future.utils import PY2, native
 
 import tempfile
@@ -96,7 +96,7 @@ def ToBytes( value ):
   if not value:
     return bytes()
 
-  # This is tricky. On py2, the bytes type from builtins (from python-future) is
+  # This is tricky. On py2, the bytes type from future.builtins (from python-future) is
   # a subclass of str. So all of the following are true:
   #   isinstance(str(), bytes)
   #   isinstance(bytes(), str)
@@ -111,7 +111,7 @@ def ToBytes( value ):
     return bytes( value, encoding = 'utf8' )
 
   if isinstance( value, str ):
-    # On py2, with `from builtins import *` imported, the following is true:
+    # On py2, with `from future.builtins import *` imported, the following is true:
     #
     #   bytes(str(u'abc'), 'utf8') == b"b'abc'"
     #

--- a/ycmd/watchdog_plugin.py
+++ b/ycmd/watchdog_plugin.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *  # noqa
+from future.builtins import *  # noqa
 
 import time
 import os


### PR DESCRIPTION
Basically, I just run:
`find . -type f -iname '*.py' -print0 | xargs -0 -P 2 -n 1 sed -i '' -e 's/from builtins/from future.builtins/g'`
This patch fixed YouCompleteMe on my machine (Mac OS 10.11.3).

> VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Mar 30 2016 11:47:02)
MacOS X (unix) version
Included patches: 1-1655
Compiled by Homebrew
Huge version without GUI.  Features included (+) or not (-):
+acl             +farsi           +mouse_netterm   +tag_binary
+arabic          +file_in_path    +mouse_sgr       +tag_old_static
+autocmd         +find_in_path    -mouse_sysmouse  -tag_any_white
-balloon_eval    +float           +mouse_urxvt     -tcl
-browse          +folding         +mouse_xterm     +terminfo
++builtin_terms  -footer          +multi_byte      +termresponse
+byte_offset     +fork()          +multi_lang      +textobjects
+channel         -gettext         -mzscheme        +timers
+cindent         -hangul_input    +netbeans_intg   +title
-clientserver    +iconv           +packages        -toolbar
+clipboard       +insert_expand   +path_extra      +user_commands
+cmdline_compl   +job             +perl            +vertsplit
+cmdline_hist    +jumplist        +persistent_undo +virtualedit
+cmdline_info    +keymap          +postscript      +visual
+comments        +langmap         +printer         +visualextra
+conceal         +libcall         +profile         +viminfo
+cryptv          +linebreak       +python          +vreplace
+cscope          +lispindent      -python3         +wildignore
+cursorbind      +listcmds        +quickfix        +wildmenu
+cursorshape     +localmap        +reltime         +windows
+dialog_con      -lua             +rightleft       +writebackup
+diff            +menu            +ruby            -X11
+digraphs        +mksession       +scrollbind      -xfontset
-dnd             +modify_fname    +signs           -xim
-ebcdic          +mouse           +smartindent     -xsmp
+emacs_tags      -mouseshape      +startuptime     -xterm_clipboard
+eval            +mouse_dec       +statusline      -xterm_save
+ex_extra        -mouse_gpm       -sun_workshop    -xpm
+extra_search    -mouse_jsbterm   +syntax          
   system vimrc file: "$VIM/vimrc"
     user vimrc file: "$HOME/.vimrc"
 2nd user vimrc file: "~/.vim/vimrc"
      user exrc file: "$HOME/.exrc"
  fall-back for $VIM: "/usr/local/share/vim"
Compilation: /usr/bin/clang -c -I. -Iproto -DHAVE_CONFIG_H   -F/usr/local/Frameworks -DMACOS_X_UNIX  -Os -w -pipe -march=native -mmacosx-version-min=10.11 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1      
Linking: /usr/bin/clang   -L. -fstack-protector -L/usr/local/lib -L/usr/local/opt/libyaml/lib -L/usr/local/opt/openssl/lib -L/usr/local/opt/readline/lib -L/usr/local/lib -F/usr/local/Frameworks -Wl,-headerpad_max_install_names -o vim        -lm  -lncurses -liconv -framework Cocoa   -fstack-protector  -L/System/Library/Perl/5.18/darwin-thread-multi-2level/CORE -lperl -F/usr/local/Cellar/python/2.7.11/Frameworks -framework Python   -lruby.2.3.0 -lobjc -L/usr/local/Cellar/ruby/2.3.0/lib

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/446)
<!-- Reviewable:end -->
