### PR TITLE
[READY] Add python-future to sys.path just before packages path

### DIFF
--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -101,7 +101,7 @@ def AddNearestThirdPartyFoldersToSysPath( filepath ):
                            if DIR_PACKAGES_REGEX.search( path ) )
       sys.path.insert( next( packages_indices, len( sys.path ) ),
                        os.path.realpath( os.path.join( path_to_third_party,
-                                         folder ) ) )
+                                                       folder ) ) )
       continue
     sys.path.insert( 0, os.path.realpath( os.path.join( path_to_third_party,
                                                         folder ) ) )

--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import
 import sys
 import os
 import io
+import re
 
 VERSION_FILENAME = 'CORE_VERSION'
 CORE_NOT_COMPATIBLE_MESSAGE = (
@@ -32,6 +33,7 @@ CORE_NOT_COMPATIBLE_MESSAGE = (
 )
 
 DIR_OF_CURRENT_SCRIPT = os.path.dirname( os.path.abspath( __file__ ) )
+DIR_PACKAGES_REGEX = re.compile( '(site|dist)-packages$' )
 
 
 def SetUpPythonPath():
@@ -86,12 +88,20 @@ def AddNearestThirdPartyFoldersToSysPath( filepath ):
     # under its 'src' folder, but SOME of its modules are only meant to be
     # accessible under py2, not py3. This is because these modules (like
     # `queue`) are implementations of modules present in the py3 standard
-    # library. So to work around issues, we place the python-future last on
-    # sys.path so that they can be overriden by the standard library.
+    # library. Furthermore, we need to be sure that they are not overriden by
+    # already installed packages (for example, the 'builtins' module from
+    # 'pies2overrides' or a different version of 'python-future'). To work
+    # around these issues, we place the python-future just before the first
+    # path ending with 'site-packages' (or 'dist-packages' for Debian-like
+    # distributions) so that its modules can be overridden by the standard
+    # library but not by installed packages.
     if folder == 'python-future':
       folder = os.path.join( folder, 'src' )
-      sys.path.append( os.path.realpath( os.path.join( path_to_third_party,
-                                                       folder ) ) )
+      packages_indices = ( sys.path.index( path ) for path in sys.path
+                           if DIR_PACKAGES_REGEX.search( path ) )
+      sys.path.insert( next( packages_indices, len( sys.path ) ),
+                       os.path.realpath( os.path.join( path_to_third_party,
+                                         folder ) ) )
       continue
     sys.path.insert( 0, os.path.realpath( os.path.join( path_to_third_party,
                                                         folder ) ) )


### PR DESCRIPTION
### Problem

Modules from our `python-future` package may be overridden by ones from already installed packages: a package using the same name for its modules (ex: `builtins`) or a different version of `python-future`.

### How to reproduce

With a package installing a `builtins` module:
```sh
pip install pies2overrides
```
results in:
```
Traceback (most recent call last):
  File "<string>", line 24, in <module>
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\..\python\ycm\setup.py", line 49, in SetUpYCM
    base.LoadJsonDefaultsIntoVim()
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\..\python\ycm\base.py", line 55, in LoadJsonDefaultsIntoVim
    defaults = user_options_store.DefaultOptions()
  File "C:\Users\micbou\.vim\bundle\YouCompleteMe\python\ycm\..\..\third_party\ycmd\ycmd\user_options_store.py", line 55, in DefaultOptions
    options = json.loads( ReadFile( settings_path ) )
  File "C:\Users\micbou\.vim\bundle\YouCompleteMe\python\ycm\..\..\third_party\ycmd\ycmd\utils.py", line 55, in ReadFile
    with open( filepath, encoding = 'utf8' ) as f:
TypeError: 'encoding' is an invalid keyword argument for this function
```

With a different version of `python-future`:
```sh
pip install future==0.10.0
```
gives this error:
```
Traceback (most recent call last):
  File "<string>", line 22, in <module>
  File "C:\\Users\\micbou\\.vim\\bundle\\YouCompleteMe\\autoload\..\python\ycm\base.py", line 23, in <module>
    standard_library.install_aliases()
AttributeError: 'module' object has no attribute 'install_aliases'
```

### Solution

Instead of appending `python-future` to `sys.path`, insert it just before the first `site-packages` (`dist-packages` on Debian-like distributions) path. If no `site/dist-packages` are found, fall back to appending it.

Tested on Windows 7, Ubuntu 14.04, and OS X 10.11.

Fixes Valloric/YouCompleteMe#2024
Closes #446

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/448)
<!-- Reviewable:end -->
