### PR TITLE
Always open a pipe to stdin for the tern command

### DIFF
--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -398,12 +398,11 @@ class TernCompleter( Completer ):
           port = self._server_port,
           std = 'stderr' )
 
-      # On Windows, we need to open a pipe to stdin to prevent Tern crashing
-      # with following error: "Implement me. Unknown stdin file type!"
+      # Tern exits when stdin closes, so we need to open a pipe to it
       with utils.OpenForStdHandle( self._server_stdout ) as stdout:
         with utils.OpenForStdHandle( self._server_stderr ) as stderr:
           self._server_handle = utils.SafePopen( command,
-                                                 stdin_windows = PIPE,
+                                                 stdin = PIPE,
                                                  stdout = stdout,
                                                  stderr = stderr )
     except Exception:


### PR DESCRIPTION
The Tern command exits when its stdin closes. If no stdin is provided,
it exits immediately, so we have to provide a stdin to keep it running.

This caused tern to exit right after it was started by YouCompleteMe. I'm a bit curious to why no one else seem to have this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/450)
<!-- Reviewable:end -->
