### PR TITLE
[READY] Add debugging instructions and tools

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -102,9 +102,9 @@ debugger, e.g. [pyclewn][] in Vim), there are a few things you need to do:
 2. Build ycm_core.so with debugging information (and link against debug Python):
 
 ```
-    export EXTRA_CMAKE_ARGS=‘-DPYTHON_LIBRARY=$HOME/.pyenv/versions/2.7.11/lib/libpython2.7.so -DPYTHON_INCLUDE_DIR=$HOME/.pyenv/versions/2.7.11/include/python2.7’ -DCMAKE_BUILD_TYPE=Debug
+    export EXTRA_CMAKE_ARGS=‘-DPYTHON_LIBRARY=$HOME/.pyenv/versions/2.7.11/lib/libpython2.7.so -DPYTHON_INCLUDE_DIR=$HOME/.pyenv/versions/2.7.11/include/python2.7’
    pyenv shell 2.7.11
-   ./build.sh —all
+   ./build.sh —all --enable-debug
 ```
 
 3. Enable debugging in the OS. On Linux (Ubuntu at least, which is what all of

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -24,4 +24,122 @@ global 3.3.0`.
 If you ever feel like you've screwed up the VM, just kill it with
 `vagrant destroy` and then run `vagrant up` again to get to a clean state.
 
+# Debugging the Python layer
+
+There are a number of Python debuggers. Presented here are just a couple of
+options known to work for certain developers on the ycmd project.
+
+The options presented are:
+
+- Using [`ipdb`][ipdb] (this is known not to work well on OS X).
+- Using [pyclewn][] and attaching to the running Python process.
+
+## Using `ipdb`
+
+1. If you're not using vagrant, install `ipdb` (`pip install ipdb`).
+2. At the point in the code you want to break, add the following lines:
+
+```python
+import ipdb; ipdb.set_trace()
+```
+
+3. Run the tests without `flake8`, e.g.
+
+```
+./run_tests --skip-build --no-flake8 ycmd/tests/get_completions_test.py
+```
+
+4. The test breaks at your code breakpoint and offers a command interface to
+   debug.
+
+See the `ipdb` docs for more info.
+
+## Using `pyclewn` in Vim
+
+The procedure is similar to using `ipdb` but you attach to the suspended process
+and use Vim as a graphical debugger:
+
+1. Install [pyclewna][pyclewn-install]
+
+2. At the point you want to break, add the following lines:
+
+```python
+import clewn.vim as clewn; clewn.pdb()
+```
+
+3. Run the tests without `flake8`, e.g.
+
+```
+./run_tests --skip-build --no-flake8 ycmd/tests/get_completions_test.py
+```
+
+4. The tests will pause at the breakpoint. Now within Vim attach the debugger
+   with `:Pyclewn pdb`. Hope that it works. It can be a bit flaky.
+
+See the pyclewn docs for more info.
+
+# Debugging the C++ layer (C++ Python library)
+
+If you want to debug the c++ code using gdb (or your favourite graphical
+debugger, e.g. [pyclewn][] in Vim), there are a few things you need to do:
+
+1. Ensure your Python is built with debug enabled. In the vagrant system that's
+   as simple as:
+
+```
+    vagrant up
+    vagrant ssh
+    export OPT=“-g” # Ensure Python binary has debugging info
+    export PYTHON_CONFIGURE_OPTS=‘—enable-shared —-with-pydebug’
+    pyenv install 2.7.11 # or whatever version
+```
+
+   On OS X, you need a working debugger. You can either use `lldb`
+   which comes with XCode or `brew install gdb`. Note: If you use `gdb` from
+   homebrew, the you need to sign the binary otherwise you can't debug anything.
+   See later steps for a link.
+
+2. Build ycm_core.so with debugging information (and link against debug Python):
+
+```
+    export EXTRA_CMAKE_ARGS=‘-DPYTHON_LIBRARY=$HOME/.pyenv/versions/2.7.11/lib/libpython2.7.so -DPYTHON_INCLUDE_DIR=$HOME/.pyenv/versions/2.7.11/include/python2.7’ -DCMAKE_BUILD_TYPE=Debug
+   pyenv shell 2.7.11
+   ./build.sh —all
+```
+
+3. Enable debugging in the OS. On Linux (Ubuntu at least, which is what all of
+   our tests are run on), you must set the following sysctl parameter (you can
+   make it permanent if you like by adding it to `/etc/sysctl.conf` or via any
+   other appropriate mechanism):
+
+```
+     sudo sysctl kernel.yama.ptrace_scope=0
+```
+
+   On OS X it is more fiddly:
+     - The binary must be signed. See
+       https://sourceware.org/gdb/wiki/BuildingOnDarwin
+     - You *can not* debug system Python. Again: you *must* use a Python that is
+       *not* the one provided by Apple. Use pyenv. That is the rule.
+       Don't argue.
+
+  Don't ask why. It's for security.
+
+3. Here you have choices: either use a Python debugger to break the tests, or
+   manually use Vim to simulate the scenario you want to debug. In any case, you
+   will need the PID of the running Python process hosting ycmd to attach to.
+   Getting this is left as an exercise, but one approach is to simply
+   install vim with `apt-get install vim` and to get a copy of YouCompleteMe
+   into `$HOME/.vim/bundle` and symlink `/vargant` as
+   `$HOME/.vim/bundle/third_party/ycmd`. Anyway, once you have the PID you can
+   simply attach to the Python process, for example:
+
+   - `:YcmDebugInfo` to get the pid
+   - `gdb: attach <PID>`
+   - `break YouCompleteMe::FilterAndSortCandidates`
+
+
 [vagrant]: https://www.vagrantup.com/
+[pyclewn]: http://pyclewn.sourceforge.net
+[pyclewn-install]: http://pyclewn.sourceforge.net/install.html
+[ipdb]: https://pypi.python.org/pypi/ipdb

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -45,7 +45,7 @@ import ipdb; ipdb.set_trace()
 
 3. Run the tests without `flake8`, e.g.
 
-```
+```sh
 ./run_tests --skip-build --no-flake8 ycmd/tests/get_completions_test.py
 ```
 
@@ -69,7 +69,7 @@ import clewn.vim as clewn; clewn.pdb()
 
 3. Run the tests without `flake8`, e.g.
 
-```
+```sh
 ./run_tests --skip-build --no-flake8 ycmd/tests/get_completions_test.py
 ```
 
@@ -86,7 +86,7 @@ debugger, e.g. [pyclewn][] in Vim), there are a few things you need to do:
 1. Ensure your Python is built with debug enabled. In the vagrant system that's
    as simple as:
 
-```
+```sh
     vagrant up
     vagrant ssh
     export OPT=“-g” # Ensure Python binary has debugging info
@@ -99,12 +99,13 @@ debugger, e.g. [pyclewn][] in Vim), there are a few things you need to do:
    homebrew, the you need to sign the binary otherwise you can't debug anything.
    See later steps for a link.
 
-2. Build ycm_core.so with debugging information (and link against debug Python):
+2. Build ycm_core library with debugging information (and link against debug
+   Python):
 
-```
+```sh
     export EXTRA_CMAKE_ARGS=‘-DPYTHON_LIBRARY=$HOME/.pyenv/versions/2.7.11/lib/libpython2.7.so -DPYTHON_INCLUDE_DIR=$HOME/.pyenv/versions/2.7.11/include/python2.7’
-   pyenv shell 2.7.11
-   ./build.sh —all --enable-debug
+    pyenv shell 2.7.11
+    ./build.py —all --enable-debug
 ```
 
 3. Enable debugging in the OS. On Linux (Ubuntu at least, which is what all of
@@ -112,7 +113,7 @@ debugger, e.g. [pyclewn][] in Vim), there are a few things you need to do:
    make it permanent if you like by adding it to `/etc/sysctl.conf` or via any
    other appropriate mechanism):
 
-```
+```sh
      sudo sysctl kernel.yama.ptrace_scope=0
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,4 +19,14 @@ Vagrant.configure(2) do |config|
     v.memory = 3072
     v.cpus = 2
   end
+
+  config.vm.provider "parallels" do |v|
+    config.vm.box = 'parallels/ubuntu-14.04'
+
+    v.memory = 3072
+    v.cpus = 4
+
+    v.linked_clone = true
+    v.update_guest_tools = true
+  end
 end

--- a/build.py
+++ b/build.py
@@ -307,8 +307,8 @@ def ParseArguments():
                        dest   = 'all_completers' )
   parser.add_argument( '--enable-debug',
                        action = 'store_true',
-                       help   = 'For developers: build ycm_core.so with debug '
-                                'symbols' )
+                       help   = 'For developers: build ycm_core library with '
+                                'debug symbols' )
 
   args = parser.parse_args()
 

--- a/build.py
+++ b/build.py
@@ -305,6 +305,10 @@ def ParseArguments():
                        action = 'store_true',
                        help   = 'Enable all supported completers',
                        dest   = 'all_completers' )
+  parser.add_argument( '--enable-debug',
+                       action = 'store_true',
+                       help   = 'For developers: build ycm_core.so with debug '
+                                'symbols' )
 
   args = parser.parse_args()
 
@@ -326,6 +330,9 @@ def GetCmakeArgs( parsed_args ):
 
   if parsed_args.system_boost:
     cmake_args.append( '-DUSE_SYSTEM_BOOST=ON' )
+
+  if parsed_args.enable_debug:
+    cmake_args.append( '-DCMAKE_BUILD_TYPE=Debug' )
 
   use_python2 = 'ON' if PY_MAJOR == 2 else 'OFF'
   cmake_args.append( '-DUSE_PYTHON2=' + use_python2 )
@@ -389,7 +396,8 @@ def BuildYcmdLib( args ):
 
     build_command = [ 'cmake', '--build', '.', '--target', build_target ]
     if OnWindows():
-      build_command.extend( [ '--config', 'Release' ] )
+      config = 'Debug' if args.enable_debug else 'Release'
+      build_command.extend( [ '--config', config ] )
     else:
       build_command.extend( [ '--', '-j', str( NumCores() ) ] )
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -124,6 +124,9 @@ def ParseArguments():
                        help = 'Enable coverage report (requires coverage pkg)' )
   parser.add_argument( '--no-flake8', action = 'store_true',
                        help = 'Disable flake8 run.' )
+  parser.add_argument( '--dump-path', action = 'store_true',
+                       help = 'Dump the PYTHONPATH required to run tests '
+                              'manually, then exit.' )
 
   parsed_args, nosetests_args = parser.parse_known_args()
 
@@ -202,6 +205,10 @@ def NoseTests( parsed_args, extra_nosetests_args ):
 
 def Main():
   parsed_args, nosetests_args = ParseArguments()
+  if parsed_args.dump_path:
+    print( os.environ[ 'PYTHONPATH' ] )
+    exit()
+
   print( 'Running tests on Python', platform.python_version() )
   if not parsed_args.no_flake8:
     RunFlake8()

--- a/run_tests.py
+++ b/run_tests.py
@@ -207,8 +207,7 @@ def Main():
   parsed_args, nosetests_args = ParseArguments()
   if parsed_args.dump_path:
     print( os.environ[ 'PYTHONPATH' ] )
-    exit()
-
+    sys.exit()
   print( 'Running tests on Python', platform.python_version() )
   if not parsed_args.no_flake8:
     RunFlake8()


### PR DESCRIPTION
Adds some stuff that developers might find useful. I'm totally aware that these changes are probably most useful to me personally, so as usual I won't be offended if you don't want to merge them. Patch contains:
 - instructions on debugging python and the python c++ module (it took me a *long* time to do this successfully)
 - `--enable-debug` flag to the build
 - `--dump-path` flag to `run_tests.py`. This is useful if you want to run `nosetests` directly (e.g. as `env PYTHONPATH=`./run_tests.py --dump-path` pdb nosetests ...`
- Parallels provider to the Vagrantfile (as I seem to have a moral objection to using virtual box when spend hard earned on Parallels :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/454)
<!-- Reviewable:end -->
