### PR TITLE
Add netrw to the default filetype blacklist

### DIFF
--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -25,6 +25,7 @@
     "qf": 1,
     "notes": 1,
     "markdown": 1,
+    "netrw": 1,
     "unite": 1,
     "text": 1,
     "vimwiki": 1,


### PR DESCRIPTION
As Netrw is a browser for either local or remote files, it doesn't need completion. When YCM is compiled with `--clang-completer` and user doesn't have set `g:ycm_global_ycm_extra_conf`, browsing any directory in which doesn't have `.ycm_extra_conf.py` using Netrw makes YCM print an error message.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/456)
<!-- Reviewable:end -->
