### PR TITLE
Adding support for .netcore project file (project.json)

### DIFF
--- a/ycmd/completers/cs/solutiondetection.py
+++ b/ycmd/completers/cs/solutiondetection.py
@@ -87,11 +87,12 @@ def GuessFile( filepath ):
   for i in reversed( range( len( tokens ) - 1 ) ):
     path = os.path.join( *tokens[ : i + 1 ] )
     candidates = glob.glob1( path, '*.sln' )
-    
-    """ If there's no .sln file, try to find a project.json file for dotnetcore (https://dotnet.github.io) projects """
+
+    """ If there's no .sln file, try to find a project.json file for
+    dotnetcore (https://dotnet.github.io) projects """
     if len( candidates ) == 0:
       candidates = glob.glob1( path, 'project.json' )
-    
+
     if len( candidates ) > 0:
       # do the whole procedure only for the first solution file(s) you find
       return _SolutionTestCheckHeuristics( candidates, tokens, i )

--- a/ycmd/completers/cs/solutiondetection.py
+++ b/ycmd/completers/cs/solutiondetection.py
@@ -87,6 +87,11 @@ def GuessFile( filepath ):
   for i in reversed( range( len( tokens ) - 1 ) ):
     path = os.path.join( *tokens[ : i + 1 ] )
     candidates = glob.glob1( path, '*.sln' )
+    
+    """ If there's no .sln file, try to find a project.json file for dotnetcore (https://dotnet.github.io) projects """
+    if len( candidates ) == 0:
+      candidates = glob.glob1( path, 'project.json' )
+    
     if len( candidates ) > 0:
       # do the whole procedure only for the first solution file(s) you find
       return _SolutionTestCheckHeuristics( candidates, tokens, i )


### PR DESCRIPTION
When trying to figure out the solution file, we are sticking to *.sln as if we could only have valid .Net projects when a .sln file is available.

Well, it used to be true, but now with .net core (https://dotnet.github.io) we can have individual .net projects. These project folders are recognized when a project.json file is available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/457)
<!-- Reviewable:end -->
