### PR TITLE
[READY] Fix and improve pyenv setup in Travis script

### DIFF
--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -15,16 +15,16 @@ source ci/travis/travis_install.${TRAVIS_OS_NAME}.sh
 # pyenv setup
 #############
 
-# DON'T exit if error
-set +e
-git clone https://github.com/yyuu/pyenv.git ~/.pyenv
-git fetch --tags
-git checkout v20160202
-# Exit if error
-set -e
+export PYENV_ROOT="${HOME}/.pyenv"
 
-export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PATH"
+if [ ! -d "${PYENV_ROOT}" ]; then
+  git clone https://github.com/yyuu/pyenv.git ${PYENV_ROOT}
+fi
+pushd ${PYENV_ROOT}
+git checkout v20160202
+popd
+
+export PATH="${PYENV_ROOT}/bin:${PATH}"
 
 eval "$(pyenv init -)"
 


### PR DESCRIPTION
These Git commands:
```sh
git fetch --tags
git checkout v20160202
```
are not executed in the right folder when setting up pyenv on Travis. Execute them in the pyenv folder.

Instead of using `set +e`  and `set -e`, check if the `~/.pyenv` folder exists before cloning the pyenv repository.

Remove the `git fetch --tags` command because it is not needed after cloning a repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/459)
<!-- Reviewable:end -->
