### PR TITLE
[READY] Fix pyenv setup on Travis

### DIFF
--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -17,10 +17,11 @@ source ci/travis/travis_install.${TRAVIS_OS_NAME}.sh
 
 export PYENV_ROOT="${HOME}/.pyenv"
 
-if [ ! -d "${PYENV_ROOT}" ]; then
+if [ ! -d "${PYENV_ROOT}/.git" ]; then
   git clone https://github.com/yyuu/pyenv.git ${PYENV_ROOT}
 fi
 pushd ${PYENV_ROOT}
+git fetch --tags
 git checkout v20160202
 popd
 


### PR DESCRIPTION
I made two mistakes in [previous PR](https://github.com/Valloric/ycmd/pull/459) (shame on me).
First mistake is that even if Travis don't cache anything, an empty directory is still created so the condition that checks if the `pyenv` directory doesn't exist is always false, resulting in a failure when nothing is cached. We fix this by checking if the `.git` folder exists instead.
Second mistake is the removal of the tags fetching: it is still useful if we bump the `pyenv` tag without clearing the cache (may not be a good idea though).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/460)
<!-- Reviewable:end -->
