### PR TITLE
Fix query passed to OmniFunc in request_data

### DIFF
--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -50,7 +50,7 @@ COMMENT_AND_STRING_REGEX = re.compile(
   #  3. the escaped double quote inside the string
   r'(?<!\\)"(?:\\\\|\\"|.)*?"', re.MULTILINE )
 
-DEFAULT_IDENTIFIER_REGEX = re.compile( r"[_a-zA-Z]\w*", re.UNICODE )
+DEFAULT_IDENTIFIER_REGEX = re.compile( r"[_a-zA-Z][\.\w]*", re.UNICODE )
 
 FILETYPE_TO_IDENTIFIER_REGEX = {
     # Spec: http://www.w3.org/TR/CSS2/syndata.html#characters


### PR DESCRIPTION
During the investigation of this issue https://github.com/slashmili/alchemist.vim/issues/33, I found out the `request_data[ 'query' ]` https://github.com/Valloric/YouCompleteMe/blob/7f419101feb01f32bc1595798291e9cd5143948b/python/ycm/omni_completer.py#L87 passed to OmniFunc is always empty.

It was caused by calculation of `StartOfLongestIdentifierEndingAtIndex` https://github.com/Valloric/ycmd/blob/bc323738c6c07efb707b5d7d06488d270d3140f8/ycmd/identifier_utils.py#L116, DEFAULT_IDENTIFIER_REGEX will never match `List.` (with a trailing dot), so that method will always return the end index, which in return, query will be empty https://github.com/Valloric/ycmd/blob/bc323738c6c07efb707b5d7d06488d270d3140f8/ycmd/request_wrap.py#L89:

```
  def _Query( self ):
    return self[ 'line_value' ][
             self[ 'start_column' ] - 1 : self[ 'column_num' ] - 1 ]
``` 

And since `.` is semantic triggers for a lot of languages:

```
  let g:ycm_semantic_triggers =  {
    \   'c' : ['->', '.'],
    \   'objc' : ['->', '.', 're!\[[_a-zA-Z]+\w*\s', 're!^\s*[^\W\d]\w*\s',
    \             're!\[.*\]\s'],
    \   'ocaml' : ['.', '#'],
    \   'cpp,objcpp' : ['->', '.', '::'],
    \   'perl' : ['->'],
    \   'php' : ['->', '::'],
    \   'cs,java,javascript,typescript,d,python,perl6,scala,vb,elixir,go' : ['.'],
    \   'ruby' : ['.', '::'],
    \   'lua' : ['.', ':'],
    \   'erlang' : [':'],
    \ }
```

Maybe it would be a good idea to update the `DEFAULT_IDENTIFIER_REGEX` to make omnifunc work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/462)
<!-- Reviewable:end -->
