### PR TITLE
[READY] Clear completions cache when sharing the application between tests

### DIFF
--- a/ycmd/tests/__init__.py
+++ b/ycmd/tests/__init__.py
@@ -26,7 +26,7 @@ from builtins import *  # noqa
 import functools
 import os
 
-from ycmd.tests.test_utils import SetUpApp
+from ycmd.tests.test_utils import ClearCompletionsCache, SetUpApp
 
 shared_app = None
 
@@ -55,5 +55,6 @@ def SharedYcmd( test ):
 
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
+    ClearCompletionsCache()
     return test( shared_app, *args, **kwargs )
   return Wrapper

--- a/ycmd/tests/clang/__init__.py
+++ b/ycmd/tests/clang/__init__.py
@@ -27,7 +27,7 @@ import functools
 import os
 
 from ycmd import handlers
-from ycmd.tests.test_utils import SetUpApp
+from ycmd.tests.test_utils import ClearCompletionsCache, SetUpApp
 
 shared_app = None
 
@@ -56,6 +56,7 @@ def SharedYcmd( test ):
 
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
+    ClearCompletionsCache()
     return test( shared_app, *args, **kwargs )
   return Wrapper
 

--- a/ycmd/tests/cs/__init__.py
+++ b/ycmd/tests/cs/__init__.py
@@ -29,7 +29,7 @@ import os
 import time
 
 from ycmd import handlers
-from ycmd.tests.test_utils import BuildRequest, SetUpApp
+from ycmd.tests.test_utils import BuildRequest, ClearCompletionsCache, SetUpApp
 
 shared_app = None
 shared_filepaths = []
@@ -123,6 +123,7 @@ def SharedYcmd( test ):
 
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
+    ClearCompletionsCache()
     return test( shared_app, *args, **kwargs )
   return Wrapper
 

--- a/ycmd/tests/go/__init__.py
+++ b/ycmd/tests/go/__init__.py
@@ -26,7 +26,7 @@ from builtins import *  # noqa
 import functools
 import os
 
-from ycmd.tests.test_utils import BuildRequest, SetUpApp
+from ycmd.tests.test_utils import BuildRequest, ClearCompletionsCache, SetUpApp
 
 shared_app = None
 
@@ -68,5 +68,6 @@ def SharedYcmd( test ):
 
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
+    ClearCompletionsCache()
     return test( shared_app, *args, **kwargs )
   return Wrapper

--- a/ycmd/tests/javascript/__init__.py
+++ b/ycmd/tests/javascript/__init__.py
@@ -28,7 +28,7 @@ import os
 import time
 
 from ycmd import handlers
-from ycmd.tests.test_utils import BuildRequest, SetUpApp
+from ycmd.tests.test_utils import BuildRequest, ClearCompletionsCache, SetUpApp
 
 shared_app = None
 shared_current_dir = None
@@ -100,6 +100,7 @@ def SharedYcmd( test ):
 
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
+    ClearCompletionsCache()
     return test( shared_app, *args, **kwargs )
   return Wrapper
 

--- a/ycmd/tests/python/__init__.py
+++ b/ycmd/tests/python/__init__.py
@@ -28,7 +28,7 @@ import os
 import time
 
 from ycmd import handlers
-from ycmd.tests.test_utils import BuildRequest, SetUpApp
+from ycmd.tests.test_utils import BuildRequest, ClearCompletionsCache, SetUpApp
 
 shared_app = None
 
@@ -90,6 +90,7 @@ def SharedYcmd( test ):
 
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
+    ClearCompletionsCache()
     return test( shared_app, *args, **kwargs )
   return Wrapper
 

--- a/ycmd/tests/rust/__init__.py
+++ b/ycmd/tests/rust/__init__.py
@@ -27,7 +27,7 @@ import functools
 import os
 import time
 
-from ycmd.tests.test_utils import BuildRequest, SetUpApp
+from ycmd.tests.test_utils import BuildRequest, ClearCompletionsCache, SetUpApp
 from ycmd import handlers
 
 shared_app = None
@@ -89,6 +89,7 @@ def SharedYcmd( test ):
 
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
+    ClearCompletionsCache()
     return test( shared_app, *args, **kwargs )
   return Wrapper
 

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -26,7 +26,7 @@ from future.utils import iteritems
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from future.utils import PY2
+from future.utils import itervalues, PY2
 from hamcrest import contains_string, has_entry, has_entries, assert_that
 from mock import patch
 from webtest import TestApp
@@ -160,6 +160,23 @@ def SetUpApp():
   bottle.debug( True )
   handlers.SetServerStateToDefaults()
   return TestApp( handlers.app )
+
+
+def ClearCompletionsCache():
+  """Invalidates cached completions for completers stored in the server state:
+  filetype completers and general completers (identifier, filename, and
+  ultisnips completers).
+
+  This function is used when sharing the application between tests so that
+  no completions are cached by previous tests."""
+  server_state = handlers._server_state
+  filetype_completers = server_state._filetype_completers
+  for completer in itervalues( filetype_completers ):
+    if completer:
+      completer._completions_cache.Invalidate()
+  general_completer = server_state.GetGeneralCompleter()
+  for completer in general_completer._all_completers:
+    completer._completions_cache.Invalidate()
 
 
 class DummyCompleter( Completer ):

--- a/ycmd/tests/typescript/__init__.py
+++ b/ycmd/tests/typescript/__init__.py
@@ -26,7 +26,7 @@ from builtins import *  # noqa
 import functools
 import os
 
-from ycmd.tests.test_utils import SetUpApp
+from ycmd.tests.test_utils import ClearCompletionsCache, SetUpApp
 
 shared_app = None
 
@@ -55,5 +55,6 @@ def SharedYcmd( test ):
 
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
+    ClearCompletionsCache()
     return test( shared_app, *args, **kwargs )
   return Wrapper

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -23,7 +23,8 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from hamcrest import assert_that, contains_inanyorder, has_entries
+from hamcrest import ( all_of, any_of, assert_that, contains_inanyorder,
+                       has_entries, has_item, is_not )
 from mock import patch
 
 from ycmd.tests.typescript import PathToTestFile, SharedYcmd
@@ -81,10 +82,24 @@ def GetCompletions_MaxDetailedCompletion_test( app ):
   RunTest( app, {
     'expect': {
       'data': has_entries( {
-        'completions': contains_inanyorder(
-          CompletionEntryMatcher( 'methodA' ),
-          CompletionEntryMatcher( 'methodB' ),
-          CompletionEntryMatcher( 'methodC' )
+        'completions': all_of(
+          contains_inanyorder(
+            CompletionEntryMatcher( 'methodA' ),
+            CompletionEntryMatcher( 'methodB' ),
+            CompletionEntryMatcher( 'methodC' ),
+          ),
+          is_not( any_of(
+            has_item(
+              CompletionEntryMatcher( 'methodA', extra_params = {
+                'menu_text': 'methodA (method) Foo.methodA(): void' } ) ),
+            has_item(
+              CompletionEntryMatcher( 'methodB', extra_params = {
+                'menu_text': 'methodB (method) Foo.methodB(): void' } ) ),
+            has_item(
+              CompletionEntryMatcher( 'methodC', extra_params = {
+                'menu_text': ( 'methodC (method) Foo.methodC(a: '
+                               '{ foo: string; bar: number; }): void' ) } ) )
+          ) )
         )
       } )
     }


### PR DESCRIPTION
### Problem

When sharing the application in tests (using the `@SharedYcmd` decorator), the completions cache is not invalidated between each test. This can make a test not working like expected. For instance, the completions are detailed in the `GetCompletions_MaxDetailedCompletion_test` TypeScript test because of the previous test. However, the test is still passing because the `has_entries` matcher does not check for exact entries.

### Solution

Improve the `GetCompletions_MaxDetailedCompletion_test` TypeScript test by checking that there are no detailed completions.
Invalidate the completions cache for all completers stored by the server state before running each test when sharing the application.

For now, I am only sending the test improvement so that we can confirm the test is failing because we don't clear the completions cache between tests. Then, I'll send the cache invalidation for shared tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/465)
<!-- Reviewable:end -->
