### PR TITLE
[READY] Storing path to Python used in build.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ nosetests.xml
 
 # custom
 ycm_core_tests
+PYTHON_USED_DURING_BUILDING
 
 # When we use the bcp tool to copy over the parts of boost we care about, it
 # also copies some cruft files we don't need; this ignores them

--- a/build.py
+++ b/build.py
@@ -427,6 +427,12 @@ def SetUpTern():
   subprocess.check_call( [ paths[ 'npm' ], 'install', '--production' ] )
 
 
+def WritePythonUsedDuringBuild():
+  path = p.join( DIR_OF_THIS_SCRIPT, 'PYTHON_USED_DURING_BUILDING' )
+  with open( path, 'w' ) as f:
+    f.write( sys.executable )
+
+
 def Main():
   CheckDeps()
   args = ParseArguments()
@@ -440,6 +446,8 @@ def Main():
     SetUpTern()
   if args.racer_completer or args.all_completers:
     BuildRacerd()
+  WritePythonUsedDuringBuild()
+
 
 if __name__ == '__main__':
   Main()


### PR DESCRIPTION
We'll use this in YCM to ensure we start ycmd with the same version of
Python that was used for building the C++ libraries loaded into ycmd.

Related to https://github.com/Valloric/YouCompleteMe/issues/2136

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/466)
<!-- Reviewable:end -->
