### PR TITLE
More helping message at opening: "Found ... Load?"

### DIFF
--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -28,7 +28,7 @@ import os
 YCM_EXTRA_CONF_FILENAME = '.ycm_extra_conf.py'
 
 CONFIRM_CONF_FILE_MESSAGE = ('Found {0}. Load? \n\n(Question can be turned '
-                             'off with options, see YCM docs)')
+                             'off with options, see :h ycm_confirm_extra_conf)')
 
 NO_EXTRA_CONF_FILENAME_MESSAGE = ( 'No {0} file detected, so no compile flags '
   'are available. Thus no semantic support for C/C++/ObjC/ObjC++. Go READ THE '


### PR DESCRIPTION
I found it REALLY frustrating that YouCompleteMe won't provide you more help on error messages. I went to :h YouCompleteMe but no way to find the place where I could eventually turn of that warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/468)
<!-- Reviewable:end -->
