### PR TITLE
[READY] Fix F999 issues reported by flake8

### DIFF
--- a/ycmd/tests/cs/__init__.py
+++ b/ycmd/tests/cs/__init__.py
@@ -60,9 +60,7 @@ def WaitUntilOmniSharpServerReady( app, filepath ):
   retries = 100
   success = False
 
-  # If running on Travis CI, keep trying forever. Travis will kill the worker
-  # after 10 mins if nothing happens.
-  while retries > 0 or OnTravis():
+  while retries > 0:
     result = app.get( '/ready', { 'subserver': 'cs' } ).json
     if result:
       success = True

--- a/ycmd/tests/cs/get_completions_test.py
+++ b/ycmd/tests/cs/get_completions_test.py
@@ -25,8 +25,8 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from hamcrest import ( assert_that, empty, greater_than, has_item, has_items,
-                       has_entries )
+from hamcrest import ( assert_that, calling, empty, greater_than, has_item,
+                       has_items, has_entries, raises )
 from nose.tools import eq_
 from webtest import AppError
 
@@ -400,20 +400,10 @@ def GetCompletions_DoesntStartWithAmbiguousMultipleSolutions_test( app ):
                              contents = contents,
                              event_name = 'FileReadyToParse' )
 
-  exception_caught = False
-  try:
-    app.post_json( '/event_notification', event_data )
-  except AppError as e:
-    if 'Autodetection of solution file failed' in str( e ):
-      exception_caught = True
-
-  # The test passes if we caught an exception when trying to start it,
-  # so raise one if it managed to start
-  if not exception_caught:
-    WaitUntilOmniSharpServerReady( app, filepath )
-    StopOmniSharpServer( app, filepath )
-    raise Exception( 'The Omnisharp server started, despite us not being '
-                     'able to find a suitable solution file to feed it. Did '
-                     'you fiddle with the solution finding code in '
-                     'cs_completer.py? Hopefully you\'ve enhanced it: you '
-                     'need to update this test then :)' )
+  assert_that(
+    calling( app.post_json ).with_args( '/event_notification', event_data ),
+    raises( AppError, 'Autodetection of solution file failed' ),
+    "The Omnisharp server started, despite us not being able to find a "
+    "suitable solution file to feed it. Did you fiddle with the solution "
+    "finding code in cs_completer.py? Hopefully you've enhanced it: you need "
+    "to update this test then :)" )

--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -281,16 +281,6 @@ def PathToFirstExistingExecutable_Failure_test():
   ok_( not utils.PathToFirstExistingExecutable( [ 'ycmd-foobar' ] ) )
 
 
-@patch( 'os.environ', { 'TRAVIS': 1 } )
-def OnTravis_IsOnTravis_test():
-  ok_( utils.OnTravis() )
-
-
-@patch( 'os.environ', {} )
-def OnTravis_IsNotOnTravis_test():
-  ok_( not utils.OnTravis() )
-
-
 @patch( 'ycmd.utils.OnWindows', return_value = False )
 @patch( 'subprocess.Popen' )
 def SafePopen_RemovesStdinWindows_test( *args ):

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -243,10 +243,6 @@ def OnMac():
   return sys.platform == 'darwin'
 
 
-def OnTravis():
-  return 'TRAVIS' in os.environ
-
-
 def ProcessIsRunning( handle ):
   return handle is not None and handle.poll() is None
 


### PR DESCRIPTION
By updating the `PyFlakes` component of `flake8` from 1.0.0 to 1.1.0 , I encountered the following errors when running the tests:
```sh
ycmd\tests\cs\__init__.py:65:24: F999 OnTravis may be undefined, or defined from star imports: builtins
ycmd\tests\cs\get_completions_test.py:413:5: F999 WaitUntilOmniSharpServerReady may be undefined, or defined from star imports: builtins
ycmd\tests\cs\get_completions_test.py:414:5: F999 StopOmniSharpServer may be undefined, or defined from star imports: builtins
```
Those are legitimate errors but instead of fixing them by adding the missing imports, I removed the usage of the concerned functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/472)
<!-- Reviewable:end -->
