### PR TITLE
Fixing travis Mac runs with stable mono

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 sudo: false
 mono:
-  - beta
+  - 4.2.3
 before_install:
   - git submodule update --init --recursive
 install:


### PR DESCRIPTION
Currently we use beta mono for some reason, which seems to be blowing up
in our face.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/473)
<!-- Reviewable:end -->
