### PR TITLE
Add tex identifier regex

### DIFF
--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -93,6 +93,10 @@ FILETYPE_TO_IDENTIFIER_REGEX = {
     # Section 2.4
     'haskell': re.compile( r"[_a-zA-Z][\w']*", re.UNICODE ),
 
+    # Spec: ?
+    # Labels like \label{fig:foobar} are very common
+    'tex': re.compile( r"[_a-zA-Z:-]*", re.UNICODE ),
+
     # Spec: http://doc.perl6.org/language/syntax
     'perl6': re.compile( r"[_a-zA-Z](?:\w|[-'](?=[_a-zA-Z]))*", re.UNICODE ),
 }

--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -91,11 +91,11 @@ FILETYPE_TO_IDENTIFIER_REGEX = {
 
     # Spec: http://www.haskell.org/onlinereport/lexemes.html
     # Section 2.4
-    'haskell': re.compile( r"[_a-zA-Z][\w']*", re.UNICODE ),
+    'haskell': re.compile( r"[_a-zA-Z][\w']+", re.UNICODE ),
 
     # Spec: ?
     # Labels like \label{fig:foobar} are very common
-    'tex': re.compile( r"[_a-zA-Z:-]*", re.UNICODE ),
+    'tex': re.compile( r"[_a-zA-Z:-]+", re.UNICODE ),
 
     # Spec: http://doc.perl6.org/language/syntax
     'perl6': re.compile( r"[_a-zA-Z](?:\w|[-'](?=[_a-zA-Z]))*", re.UNICODE ),

--- a/ycmd/tests/identifier_utils_test.py
+++ b/ycmd/tests/identifier_utils_test.py
@@ -183,6 +183,7 @@ def IsIdentifier_Css_test():
   ok_( not iu.IsIdentifier( '-3' , 'css' ) )
   ok_( not iu.IsIdentifier( '3'  , 'css' ) )
   ok_( not iu.IsIdentifier( 'a'  , 'css' ) )
+  ok_( not iu.IsIdentifier( '' , 'css' ) )
 
 
 def IsIdentifier_R_test():
@@ -204,6 +205,7 @@ def IsIdentifier_R_test():
   ok_( not iu.IsIdentifier( '123', 'r' ) )
   ok_( not iu.IsIdentifier( '_1a', 'r' ) )
   ok_( not iu.IsIdentifier( '_a' , 'r' ) )
+  ok_( not iu.IsIdentifier( '' , 'r' ) )
 
 
 def IsIdentifier_Clojure_test():
@@ -229,6 +231,7 @@ def IsIdentifier_Clojure_test():
   ok_( not iu.IsIdentifier( '9'    , 'clojure' ) )
   ok_( not iu.IsIdentifier( 'a/b/c', 'clojure' ) )
   ok_( not iu.IsIdentifier( '(a)'  , 'clojure' ) )
+  ok_( not iu.IsIdentifier( '' , 'clojure' ) )
 
 
 def IsIdentifier_Haskell_test():
@@ -242,6 +245,7 @@ def IsIdentifier_Haskell_test():
   ok_( not iu.IsIdentifier( "'x", 'haskell' ) )
   ok_( not iu.IsIdentifier( "9x", 'haskell' ) )
   ok_( not iu.IsIdentifier( "9" , 'haskell' ) )
+  ok_( not iu.IsIdentifier( '' , 'haskell' ) )
 
 
 def IsIdentifier_Tex_test():
@@ -253,6 +257,7 @@ def IsIdentifier_Tex_test():
 
   ok_( not iu.IsIdentifier( '\section', 'tex' ) )
   ok_( not iu.IsIdentifier( 'some8', 'tex' ) )
+  ok_( not iu.IsIdentifier( '' , 'tex' ) )
 
 
 def IsIdentifier_Perl6_test():
@@ -279,6 +284,7 @@ def IsIdentifier_Perl6_test():
   ok_( not iu.IsIdentifier( "x+"  , 'perl6' ) )
   ok_( not iu.IsIdentifier( "9x"  , 'perl6' ) )
   ok_( not iu.IsIdentifier( "9"   , 'perl6' ) )
+  ok_( not iu.IsIdentifier( '' , 'perl6' ) )
 
 
 def StartOfLongestIdentifierEndingAtIndex_Simple_test():

--- a/ycmd/tests/identifier_utils_test.py
+++ b/ycmd/tests/identifier_utils_test.py
@@ -244,6 +244,17 @@ def IsIdentifier_Haskell_test():
   ok_( not iu.IsIdentifier( "9" , 'haskell' ) )
 
 
+def IsIdentifier_Tex_test():
+  ok_( iu.IsIdentifier( 'foo', 'tex' ) )
+  ok_( iu.IsIdentifier( 'fig:foo', 'tex' ) )
+  ok_( iu.IsIdentifier( 'fig:foo-bar', 'tex' ) )
+  ok_( iu.IsIdentifier( 'sec:summary', 'tex' ) )
+  ok_( iu.IsIdentifier( 'eq:bar_foo', 'tex' ) )
+
+  ok_( not iu.IsIdentifier( '\section', 'tex' ) )
+  ok_( not iu.IsIdentifier( 'some8', 'tex' ) )
+
+
 def IsIdentifier_Perl6_test():
   ok_( iu.IsIdentifier( 'foo'  , 'perl6' ) )
   ok_( iu.IsIdentifier( "f-o"  , 'perl6' ) )


### PR DESCRIPTION
Commonly used latex identifiers are not covered by the default regex.
The new regex is covered by test cases similar to the ones for perl and haskell.

With this regex it is easy to reference with YCM from all figures, sections, etc. in the document. Using `fig:` and so on is best practice in latex but I haven't found a spec that could serve as reference.

I wasn't able to run the full test suite (see message on ycmd-users) but I ran
```
nosetests ycmd/tests/identifier_utils_test.py
```
successfully.

Ultimatively, I think the user should be able to give a custom identifier regex for different filetypes in their .vimrc (and its analogue in other editors).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/480)
<!-- Reviewable:end -->
