### PR TITLE
[READY] Do not rely on CMake to find Python libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,20 +47,12 @@ addons:
      #   https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
      - ubuntu-toolchain-r-test  # for new libstdc++
      - llvm-toolchain-precise-3.7  # for clang
-     - deadsnakes  # for various versions of python
-     - kalakris-cmake # for a more recent version of cmake (needed for ninja-build)
+     - george-edison55-precise-backports # for a more recent version of cmake (3.2.3)
     packages:
+     - cmake-data
      - cmake
      - clang-3.7
      - ninja-build
-     # The confusing part is that on Travis Linux with YCMD_PYTHON_VERSION=3.3,
-     # we build the C++ parts against the below system python3.3, but run
-     # against the pyenv python3.3. This is because stupid cmake 2.8.11 has a
-     # bug preventing it from finding the pyenv pythons (ostensibly; I haven't
-     # checked, but online reports say the issue is gone with cmake 3.4).
-     # Everything still works though, it's just weird.
-     - python3.3
-     - python3.3-dev
      # Everything below is a Python build dep (though it depends on Python
      # version). We need them because pyenv builds Python.
      - libssl-dev

--- a/ci/appveyor/appveyor_install.bat
+++ b/ci/appveyor/appveyor_install.bat
@@ -33,13 +33,6 @@ if %python% == 27 (
   set PYTHONHOME=%python_path%
 )
 
-:: When using Python 3 on AppVeyor, CMake will always pick the 64 bits
-:: libraries. We specifically tell CMake the right path to the libraries
-:: according to the architecture.
-if %python% == 35 (
-  set EXTRA_CMAKE_ARGS="-DPYTHON_LIBRARY=%python_path%\libs\python%python%.lib"
-)
-
 appveyor DownloadFile https://bootstrap.pypa.io/get-pip.py
 python get-pip.py
 pip install -r test_requirements.txt

--- a/ci/travis/travis_install.linux.sh
+++ b/ci/travis/travis_install.linux.sh
@@ -17,3 +17,6 @@ ln -s /usr/bin/clang-3.7 ${HOME}/bin/gcc
 
 export PATH=${HOME}/bin:${PATH}
 
+# In order to work with ycmd, python *must* be built as a shared library. This
+# is set via the PYTHON_CONFIGURE_OPTS option.
+export PYTHON_CONFIGURE_OPTS="--enable-shared"

--- a/ci/travis/travis_install.osx.sh
+++ b/ci/travis/travis_install.osx.sh
@@ -15,13 +15,13 @@ REQUIREMENTS="node.js
               pkg-config
               openssl"
 
-# Install node, go, ninja, pyenv and dependencies
+# Install node, go, ninja, pyenv and dependencies.
 for pkg in $REQUIREMENTS; do
-  # Install package, or upgrade it if it is already installed
+  # Install package, or upgrade it if it is already installed.
   brew install $pkg || brew outdated $pkg || brew upgrade $pkg
 done
 
 # In order to work with ycmd, python *must* be built as a shared library. The
 # most compatible way to do this on OS X is with --enable-framework. This is
-# set via the PYTHON_CONFIGURE_OPTS option
+# set via the PYTHON_CONFIGURE_OPTS option.
 export PYTHON_CONFIGURE_OPTS="--enable-framework"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -15,18 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
-if ( DEFINED ENV{TRAVIS} )
-  # We lie to Travis CI about the min CMake version we need. For what we use
-  # Travis for, the old version of CMake that it has is good enough.
-  cmake_minimum_required( VERSION 2.8 )
+if ( APPLE )
+  # OSX requires CMake >= 2.8.12, see YCM issue #1439
+  cmake_minimum_required( VERSION 2.8.12 )
 else()
-  if ( APPLE )
-    # OSX requires CMake >= 2.8.12, see YCM issue #1439
-    cmake_minimum_required( VERSION 2.8.12 )
-  else()
-    # CMake 2.8.11 is the latest available version on RHEL/CentOS 7
-    cmake_minimum_required( VERSION 2.8.11 )
-  endif()
+  # CMake 2.8.11 is the latest available version on RHEL/CentOS 7
+  cmake_minimum_required( VERSION 2.8.11 )
 endif()
 
 project( YouCompleteMe )

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -276,10 +276,15 @@ if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
   else()
     # For Macs, we do things differently; look further in this file.
     if ( NOT APPLE )
-      # Setting this to true makes sure that libraries we build will have our rpath
-      # set even without having to do "make install"
+      # Setting this to true makes sure that libraries we build will have our
+      # rpath set even without having to do "make install"
       set( CMAKE_BUILD_WITH_INSTALL_RPATH TRUE )
       set( CMAKE_INSTALL_RPATH "\$ORIGIN" )
+      # Add directories from all libraries outside the build tree to the rpath.
+      # This makes the dynamic linker able to find non system libraries that
+      # our libraries require, in particular the Python one (from pyenv for
+      # instance).
+      set( CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
     endif()
   endif()
 


### PR DESCRIPTION
### Problem

CMake is not able to find the Python libraries from `pyenv`. We can observe this on Travis. If we look at the build output of the Python 2.6 run on Linux, we have the following line during the CMake configuration:
```sh
-- Found PythonLibs: /usr/lib/libpython2.7.so (found suitable version "2.7.3", minimum required is "2.6")
```
which, in addition to be the wrong version, is the system library instead of the `pyenv` one. We confirm this by inspecting the `ycm_core.so` library from the build:
```sh
$ ldd ycm_core.so | grep python
libpython2.7.so.1.0 => /usr/lib/libpython2.7.so.1.0 (0x00007f0521fa1000)
```
Same issue with the Python 2.7 and 3.3 Linux runs although the library version is correct in these cases.
In the Travis configuration file, there is this comment:

> This is because stupid cmake 2.8.11 has a bug preventing it from finding the pyenv pythons (ostensibly; I haven't checked, but online reports say the issue is gone with cmake 3.4).

I tried with CMake 3.5.1 (3.5.2 is the last version) and it is still not working.

That's not all. In some situations, CMake find the wrong Python system libraries (see [this workaround on AppVeyor](https://github.com/Valloric/ycmd/blob/master/ci/appveyor/appveyor_install.bat#L36)) or cannot find them at all (see [this post on ycm-users](https://groups.google.com/forum/#!searchin/ycm-users/windows$20cmake/ycm-users/e6K-grbeUMw/0kzwtAaYCQAJ)).

### Solution

From this, it is clear that we cannot rely on CMake to find the Python libraries. We need to find them in the `build.py` script and pass the `PYTHON_LIBRARY` and `PYTHON_INCLUDE_DIR` parameters to CMake, like we already do for OS X.
This is implemented by creating a `FindPythonLibraries` function for each supported platform: Linux, OS X, and Windows. For OS X, we are keeping the logic from `CustomPythonCmakeArgs` except that we are dropping support for system Python 2.6. For Linux, we need to use the `ldconfig` tool to find the system Python library on some distributions (e.g. Ubuntu) because it is not installed in its standard location. For Windows, it is straightforward. In all cases, we assume that the Python running the script is the one that will be used to build the library.

This PR also fixes an important issue. When building the ycmd library with Clang support and linking it to a non-system Python libray, the dynamic linker will not be able to find the Python library:
```sh
$ ldd ycm_core.so | grep python
libpython3.4m.so.1.0 => not found
$ objdump -x ycm_core.so | grep RPATH
RPATH                $ORIGIN
```
This is solved by setting the `CMAKE_INSTALL_RPATH_USE_LINK_PATH` option to true (see [this wiki page](https://cmake.org/Wiki/CMake_RPATH_handling) for details on the option):
```
> ldd ycm_core.so | grep python
libpython3.4m.so.1.0 => /home/micbou/.pyenv/versions/3.4.4/lib/libpython3.4m.so.1.0 (0x00007f9fb6472000)
> objdump -x ycm_core.so | grep RPATH
RPATH                $ORIGIN:/home/micbou/.pyenv/versions/3.4.4/lib
```

Closes #196 (we don't care about the Python interpreter when building the ycmd library).
Fixes #479.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/481)
<!-- Reviewable:end -->
