### PR TITLE
[READY] Return a proper response when the request is too big.

### DIFF
--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -25,7 +25,6 @@ from builtins import *  # noqa
 
 import atexit
 import bottle
-import http.client
 import json
 import logging
 import traceback
@@ -221,12 +220,14 @@ def DebugInfo():
 
 
 # The type of the param is Bottle.HTTPError
-@app.error( http.client.INTERNAL_SERVER_ERROR )
 def ErrorHandler( httperror ):
   body = _JsonResponse( BuildExceptionResponse( httperror.exception,
                                                 httperror.traceback ) )
   hmac_plugin.SetHmacHeader( body, _hmac_secret )
   return body
+
+# For every error Bottle encounters it will use this as the default handler
+app.default_error_handler = ErrorHandler
 
 
 def _JsonResponse( data ):

--- a/ycmd/tests/misc_handlers_test.py
+++ b/ycmd/tests/misc_handlers_test.py
@@ -56,7 +56,6 @@ def MiscHandlers_EventNotification_ReturnJsonOnBigFileError_test( app ):
   app.post_json( '/event_notification', event_data, expect_errors = True ).json
 
 
-
 @SharedYcmd
 def MiscHandlers_FilterAndSortCandidates_Basic_test( app ):
   candidate1 = { 'prop1': 'aoo', 'prop2': 'bar' }

--- a/ycmd/tests/misc_handlers_test.py
+++ b/ycmd/tests/misc_handlers_test.py
@@ -47,6 +47,17 @@ def MiscHandlers_EventNotification_AlwaysJsonResponse_test( app ):
 
 
 @SharedYcmd
+def MiscHandlers_EventNotification_ReturnJsonOnBigFileError_test( app ):
+  # We generate a content greater than Bottle.MEMFILE_MAX, which is set to 1Mb.
+  contents = "foo " * 500000
+  event_data = BuildRequest( contents = contents,
+                             event_name = 'FileReadyToParse' )
+
+  app.post_json( '/event_notification', event_data, expect_errors = True ).json
+
+
+
+@SharedYcmd
 def MiscHandlers_FilterAndSortCandidates_Basic_test( app ):
   candidate1 = { 'prop1': 'aoo', 'prop2': 'bar' }
   candidate2 = { 'prop1': 'bfo', 'prop2': 'zoo' }


### PR DESCRIPTION
We have a hard limit on the size of the request that ycmd can handle that is set to 1Mb. This is dictated by Bottle and there is no way around it.

#### Why is this a problem:

When a client makes a request greater than 1Mb Bottle returns an error that is not generated by us and thus it is not a json response, but an html one, and it doesn't contain the HMAC header which causes  errors like #476. 

For now I've pushed only the failing test. Once I see it fail on Travis I will push the fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/482)
<!-- Reviewable:end -->
