### PR TITLE
[READY] Always open a pipe to stdin when starting Tern

### DIFF
--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -404,12 +404,14 @@ class TernCompleter( Completer ):
           port = self._server_port,
           std = 'stderr' )
 
-      # On Windows, we need to open a pipe to stdin to prevent Tern crashing
-      # with following error: "Implement me. Unknown stdin file type!"
+      # We need to open a pipe to stdin or the Tern server is killed.
+      # See https://github.com/ternjs/tern/issues/740#issuecomment-203979749
+      # For unknown reasons, this is only needed on Windows and for Python 3.4+
+      # on other platforms.
       with utils.OpenForStdHandle( self._server_stdout ) as stdout:
         with utils.OpenForStdHandle( self._server_stderr ) as stderr:
           self._server_handle = utils.SafePopen( command,
-                                                 stdin_windows = PIPE,
+                                                 stdin = PIPE,
                                                  stdout = stdout,
                                                  stderr = stderr )
     except Exception:


### PR DESCRIPTION
Since PR #450 seems stale (no answer from the author) and this is a rather important issue, I am opening a PR that supersedes it.

@puremourning suggested to use the `--ignore-stdin` option but it is not available in the last version of Tern (0.18.0) and it would require users to update their Tern version. In addition, the solution proposed here is already used by some plugin. See [this comment](https://github.com/ternjs/tern/issues/740#issuecomment-203979749).

Fixes Valloric/YouCompleteMe#2152
Closes #450

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/483)
<!-- Reviewable:end -->
