### PR TITLE
[READY] Remove architecture option in scripts

### DIFF
--- a/build.py
+++ b/build.py
@@ -270,8 +270,7 @@ def GetGenerator( args ):
     else:
       generator = 'Visual Studio 11'
 
-    if ( not args.arch and platform.architecture()[ 0 ] == '64bit'
-         or args.arch == 64 ):
+    if platform.architecture()[ 0 ] == '64bit':
       generator = generator + ' Win64'
     return generator
 
@@ -299,9 +298,6 @@ def ParseArguments():
   parser.add_argument( '--msvc', type = int, choices = [ 11, 12, 14 ],
                        default = 14, help = 'Choose the Microsoft Visual '
                        'Studio version (default: %(default)s).' )
-  parser.add_argument( '--arch', type = int, choices = [ 32, 64 ],
-                       help = 'Force architecture to 32 or 64 bits on '
-                       'Windows (default: python interpreter architecture).' ),
   parser.add_argument( '--tern-completer',
                        action = 'store_true',
                        help   = 'Enable tern javascript completer' ),

--- a/run_tests.py
+++ b/run_tests.py
@@ -120,9 +120,6 @@ def ParseArguments():
   parser.add_argument( '--msvc', type = int, choices = [ 11, 12, 14 ],
                        help = 'Choose the Microsoft Visual '
                        'Studio version. (default: 14).' )
-  parser.add_argument( '--arch', type = int, choices = [ 32, 64 ],
-                       help = 'Force architecture to 32 or 64 bits on '
-                       'Windows (default: python interpreter architecture).' )
   parser.add_argument( '--coverage', action = 'store_true',
                        help = 'Enable coverage report (requires coverage pkg)' )
   parser.add_argument( '--no-flake8', action = 'store_true',
@@ -178,9 +175,6 @@ def BuildYcmdLibs( args ):
 
     if args.msvc:
       build_cmd.extend( [ '--msvc', str( args.msvc ) ] )
-
-    if args.arch:
-      build_cmd.extend( [ '--arch', str( args.arch ) ] )
 
     subprocess.check_call( build_cmd )
 


### PR DESCRIPTION
With the changes from PR #481, the `--arch` option cannot be used anymore to specify the architecture on Windows because the architecture of the Python library is now the same as the Python interpreter running the `build.py` script and this architecture must match the one used to compile ycmd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/484)
<!-- Reviewable:end -->
