### PR TITLE
[RFC] Move member variable to function local in LetterNode

### DIFF
--- a/cpp/ycm/LetterNode.cpp
+++ b/cpp/ycm/LetterNode.cpp
@@ -18,6 +18,7 @@
 #include "LetterNode.h"
 #include "standard.h"
 
+#include <vector>
 
 namespace YouCompleteMe {
 
@@ -30,22 +31,22 @@ LetterNode::LetterNode( char letter, int index )
 LetterNode::LetterNode( const std::string &text )
   : is_uppercase_( false ),
     index_( -1 ) {
-  letternode_per_text_index_.resize( text.size() );
+  std::vector< LetterNode * > letternode_per_text_index( text.size() );
 
   for ( uint i = 0; i < text.size(); ++i ) {
     char letter = text[ i ];
     LetterNode *node = new LetterNode( letter, i );
     letters_[ letter ].push_back( node );
-    letternode_per_text_index_[ i ] = boost::shared_ptr< LetterNode >( node );
+    letternode_per_text_index[ i ] = node;
   }
 
-  for ( int i = static_cast< int >( letternode_per_text_index_.size() ) - 1;
+  for ( int i = static_cast< int >( letternode_per_text_index.size() ) - 1;
         i >= 0; --i ) {
-    LetterNode *node_to_add = letternode_per_text_index_[ i ].get();
+    LetterNode *node_to_add = letternode_per_text_index[ i ];
 
     for ( int j = i - 1; j >= 0; --j ) {
-      letternode_per_text_index_[ j ]->PrependNodeForLetter( text[ i ],
-                                                             node_to_add );
+      letternode_per_text_index[ j ]->PrependNodeForLetter( text[ i ],
+                                                            node_to_add );
     }
   }
 }

--- a/cpp/ycm/LetterNode.h
+++ b/cpp/ycm/LetterNode.h
@@ -22,9 +22,7 @@
 #include "LetterNodeListMap.h"
 
 #include <boost/utility.hpp>
-#include <boost/shared_ptr.hpp>
 
-#include <vector>
 #include <list>
 #include <string>
 
@@ -59,7 +57,6 @@ public:
 private:
 
   LetterNodeListMap letters_;
-  std::vector< boost::shared_ptr< LetterNode > > letternode_per_text_index_;
   bool is_uppercase_;
   int index_;
 };


### PR DESCRIPTION
While I was refreshing my knowledge of the `cpp` code for #475 I noticed that
`letternode_per_text_index` is actually only used during one of the two
constructor (the one for the root node) as a utility data structure, so it doesn't make much sense
to keep it around longer than necessary. Since #475 is proposed I don't know if we really want to merge this, but I wanted to see what do you think, hence the `RFC` mark ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/498)
<!-- Reviewable:end -->
