### PR TITLE
[READY] Improve newline TypeScript fix on Windows

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -194,10 +194,9 @@ class TypeScriptCompleter( Completer ):
     # as one character (\n) towards the content length. However, newlines are
     # two characters on Windows (\r\n), so we need to take care of that. See
     # issue https://github.com/Microsoft/TypeScript/issues/3403
-    # TODO: remove this when the issue is fixed.
-    if utils.OnWindows():
-      contentlength += 1
     content = self._tsserver_handle.stdout.readline( contentlength )
+    if utils.OnWindows() and content.endswith( b'\r' ):
+      content += self._tsserver_handle.stdout.read( 1 )
     return json.loads( utils.ToUnicode( content ) )
 
 

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -194,7 +194,7 @@ class TypeScriptCompleter( Completer ):
     # as one character (\n) towards the content length. However, newlines are
     # two characters on Windows (\r\n), so we need to take care of that. See
     # issue https://github.com/Microsoft/TypeScript/issues/3403
-    content = self._tsserver_handle.stdout.readline( contentlength )
+    content = self._tsserver_handle.stdout.read( contentlength )
     if utils.OnWindows() and content.endswith( b'\r' ):
       content += self._tsserver_handle.stdout.read( 1 )
     return json.loads( utils.ToUnicode( content ) )


### PR DESCRIPTION
This change was suggested by @puremourning in PR https://github.com/puremourning/ycmd-1/pull/1.

With this change, we have nothing to do if issue https://github.com/Microsoft/TypeScript/issues/3403 is fixed and we will still support TSServer versions without the fix.

Also, according to this comment in the code:
> The response message is a JSON object which comes back on one line. Since this might change in the future, we use the 'Content-Length' header.

we should use `read` instead of `readline`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/503)
<!-- Reviewable:end -->
