### PR TITLE
[READY] Build Python as a shared library on Vagrant

### DIFF
--- a/vagrant_bootstrap.sh
+++ b/vagrant_bootstrap.sh
@@ -13,6 +13,9 @@ export DEBIAN_FRONTEND=noninteractive
 # For pyenv Python building
 export CFLAGS='-O2'
 
+# In order to work with ycmd, python *must* be built as a shared library. This
+# is set via the PYTHON_CONFIGURE_OPTS option.
+export PYTHON_CONFIGURE_OPTS='--enable-shared'
 
 #######################
 # APT-GET INSTALL


### PR DESCRIPTION
With the new `build.py` script, CMake now picks the `pyenv` Python library instead of the system one on our Vagrant configuration. This library needs to be built as a shared library. This is done by adding the `--enable-shared` flag to the `PYTHON_CONFIGURE_OPTS` like [we are doing on Travis](https://github.com/Valloric/ycmd/blob/master/ci/travis/travis_install.linux.sh#L22).

I can't test it myself (I can't make Vagrant work on Windows) so if someone could test it, that would be great. PR is marked as RFC for this reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/504)
<!-- Reviewable:end -->
