### PR TITLE
[READY] Overhaul Go completer

### DIFF
--- a/ycmd/tests/go/__init__.py
+++ b/ycmd/tests/go/__init__.py
@@ -26,6 +26,7 @@ from builtins import *  # noqa
 import functools
 import os
 
+from ycmd import handlers
 from ycmd.tests.test_utils import BuildRequest, ClearCompletionsCache, SetUpApp
 
 shared_app = None
@@ -43,6 +44,20 @@ def StopGoCodeServer( app ):
                                filetype = 'go' ) )
 
 
+def WaitUntilGoCodeServerReady( app ):
+  retries = 100
+
+  while retries > 0:
+    result = app.get( '/ready', { 'subserver': 'go' } ).json
+    if result:
+      return
+
+    time.sleep( 0.2 )
+    retries = retries - 1
+
+  raise RuntimeError( 'Timeout waiting for GoCode' )
+
+
 def setUpPackage():
   """Initializes the ycmd server as a WebTest application that will be shared
   by all tests using the SharedYcmd decorator in this package. Additional
@@ -51,6 +66,7 @@ def setUpPackage():
   global shared_app
 
   shared_app = SetUpApp()
+  WaitUntilGoCodeServerReady( shared_app )
 
 
 def tearDownPackage():
@@ -70,4 +86,23 @@ def SharedYcmd( test ):
   def Wrapper( *args, **kwargs ):
     ClearCompletionsCache()
     return test( shared_app, *args, **kwargs )
+  return Wrapper
+
+
+def IsolatedYcmd( test ):
+  """Defines a decorator to be attached to tests of this package. This decorator
+  passes a unique ycmd application as a parameter. It should be used on tests
+  that change the server state in a irreversible way (ex: a semantic subserver
+  is stopped or restarted) or expect a clean state (ex: no semantic subserver
+  started, no .ycm_extra_conf.py loaded, etc).
+
+  Do NOT attach it to test generators but directly to the yielded tests."""
+  @functools.wraps( test )
+  def Wrapper( *args, **kwargs ):
+    old_server_state = handlers._server_state
+
+    try:
+      test( SetUpApp(), *args, **kwargs )
+    finally:
+      handlers._server_state = old_server_state
   return Wrapper

--- a/ycmd/tests/go/debug_info_test.py
+++ b/ycmd/tests/go/debug_info_test.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2016 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from hamcrest import assert_that, matches_regexp
+
+from ycmd.tests.go import IsolatedYcmd, SharedYcmd, StopGoCodeServer
+from ycmd.tests.test_utils import BuildRequest, UserOption
+
+
+@SharedYcmd
+def DebugInfo_ServerIsRunning_test( app ):
+  subcommands_data = BuildRequest( completer_target = 'go' )
+  assert_that(
+    app.post_json( '/debug_info', subcommands_data ).json,
+    matches_regexp( 'Go completer debug information:\n'
+                    '  Gocode running at: http://127.0.0.1:\d+\n'
+                    '  Gocode process ID: \d+\n'
+                    '  Gocode binary: .+\n'
+                    '  Gocode logfiles:\n'
+                    '    .+\n'
+                    '    .+\n'
+                    '  Godef binary: .+' ) )
+
+
+@IsolatedYcmd
+def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
+  with UserOption( 'server_keep_logfiles', True ):
+    StopGoCodeServer( app )
+    subcommands_data = BuildRequest( completer_target = 'go' )
+    assert_that(
+      app.post_json( '/debug_info', subcommands_data ).json,
+      matches_regexp( 'Go completer debug information:\n'
+                      '  Gocode no longer running\n'
+                      '  Gocode binary: .+\n'
+                      '  Gocode logfiles:\n'
+                      '    .+\n'
+                      '    .+\n'
+                      '  Godef binary: .+' ) )
+
+
+@IsolatedYcmd
+def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
+  with UserOption( 'server_keep_logfiles', False ):
+    StopGoCodeServer( app )
+    subcommands_data = BuildRequest( completer_target = 'go' )
+    assert_that(
+      app.post_json( '/debug_info', subcommands_data ).json,
+      matches_regexp( 'Go completer debug information:\n'
+                      '  Gocode is not running\n'
+                      '  Gocode binary: .+\n'
+                      '  Godef binary: .+' ) )

--- a/ycmd/tests/go/go_completer_test.py
+++ b/ycmd/tests/go/go_completer_test.py
@@ -25,12 +25,17 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
+from hamcrest import assert_that, calling, raises
+from mock import patch
+from nose.tools import eq_
+import functools
 import os
-from nose.tools import eq_, raises
-from ycmd.completers.go.go_completer import GoCompleter, GO_BINARIES, FindBinary
+
+from ycmd.completers.go.go_completer import ( _ComputeOffset, GoCompleter,
+                                              GO_BINARIES, FindBinary )
 from ycmd.request_wrap import RequestWrap
 from ycmd import user_options_store
-from ycmd.utils import ReadFile
+from ycmd.utils import ReadFile, ToBytes
 
 TEST_DIR = os.path.dirname( os.path.abspath( __file__ ) )
 DATA_DIR = os.path.join( TEST_DIR, 'testdata' )
@@ -51,133 +56,132 @@ REQUEST_DATA = {
 }
 
 
-class GoCompleter_test( object ):
-  def setUp( self ):
+def BuildRequest( line_num, column_num ):
+  request = REQUEST_DATA.copy()
+  request[ 'line_num' ] = line_num
+  request[ 'column_num' ] = column_num
+  request[ 'file_data' ][ PATH_TO_TEST_FILE ][ 'contents' ] = ReadFile(
+    PATH_TO_TEST_FILE )
+  return RequestWrap( request )
+
+
+def SetUpGoCompleter( test ):
+  @functools.wraps( test )
+  def Wrapper( *args, **kwargs ):
     user_options = user_options_store.DefaultOptions()
     user_options[ 'gocode_binary_path' ] = DUMMY_BINARY
-    self._completer = GoCompleter( user_options )
+    with patch( 'ycmd.utils.SafePopen' ):
+      completer = GoCompleter( user_options )
+      return test( completer, *args, **kwargs )
+  return Wrapper
 
 
-  def _BuildRequest( self, line_num, column_num ):
-    request = REQUEST_DATA.copy()
-    request[ 'column_num' ] = column_num
-    request[ 'line_num' ] = line_num
-    request[ 'file_data' ][ PATH_TO_TEST_FILE ][ 'contents' ] = ReadFile(
-      PATH_TO_TEST_FILE )
-    return RequestWrap( request )
+def FindGoCodeBinary_test():
+  user_options = user_options_store.DefaultOptions()
+
+  eq_( GO_BINARIES.get( "gocode" ), FindBinary( "gocode", user_options ) )
+
+  user_options[ 'gocode_binary_path' ] = DUMMY_BINARY
+  eq_( DUMMY_BINARY, FindBinary( "gocode", user_options ) )
+
+  user_options[ 'gocode_binary_path' ] = DATA_DIR
+  eq_( None, FindBinary( "gocode", user_options ) )
 
 
-  def FindGoCodeBinary_test( self ):
-    user_options = user_options_store.DefaultOptions()
-
-    eq_( GO_BINARIES.get( "gocode" ), FindBinary( "gocode", user_options ) )
-
-    user_options[ 'gocode_binary_path' ] = DUMMY_BINARY
-    eq_( DUMMY_BINARY, FindBinary( "gocode", user_options ) )
-
-    user_options[ 'gocode_binary_path' ] = DATA_DIR
-    eq_( None, FindBinary( "gocode", user_options ) )
+def ComputeOffset_OutOfBoundsOffset_test():
+  assert_that(
+    calling( _ComputeOffset ).with_args( 'test', 2, 1 ),
+    raises( RuntimeError, 'Go completer could not compute byte offset '
+                          'corresponding to line 2 and column 1.' ) )
 
 
-  # Test line-col to offset in the file before any unicode occurrences.
-  def ComputeCandidatesInnerOffsetBeforeUnicode_test( self ):
-    mock = MockPopen( returncode = 0,
-                      stdout = ReadFile( PATH_TO_POS121_RES ),
-                      stderr = '' )
-    self._completer._popener = mock
-    # Col 8 corresponds to cursor at log.Pr^int("Line 7 ...
-    self._completer.ComputeCandidatesInner( self._BuildRequest( 7, 8 ) )
-    eq_( mock.cmd, [
-      DUMMY_BINARY, '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '119' ] )
+# Test line-col to offset in the file before any unicode occurrences.
+@SetUpGoCompleter
+@patch( 'ycmd.completers.go.go_completer.GoCompleter._ExecuteCommand',
+        return_value = ReadFile( PATH_TO_POS215_RES ) )
+def ComputeCandidatesInner_BeforeUnicode_test( completer, execute_command ):
+  # Col 8 corresponds to cursor at log.Pr^int("Line 7 ...
+  completer.ComputeCandidatesInner( BuildRequest( 7, 8 ) )
+  execute_command.assert_called_once_with(
+    [ DUMMY_BINARY, '-addr', completer._gocode_address,
+      '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '119' ],
+    contents = ToBytes( ReadFile( PATH_TO_TEST_FILE ) ) )
 
 
-  # Test line-col to offset in the file after a unicode occurrences.
-  def ComputeCandidatesInnerAfterUnicode_test( self ):
-    mock = MockPopen( returncode = 0,
-                      stdout = ReadFile( PATH_TO_POS215_RES ),
-                      stderr = '' )
-    self._completer._popener = mock
-    # Col 9 corresponds to cursor at log.Pri^nt("Line 7 ...
-    self._completer.ComputeCandidatesInner(self._BuildRequest(9, 9))
-    eq_( mock.cmd, [
-      DUMMY_BINARY, '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '212' ] )
+# Test line-col to offset in the file after a unicode occurrences.
+@SetUpGoCompleter
+@patch( 'ycmd.completers.go.go_completer.GoCompleter._ExecuteCommand',
+        return_value = ReadFile( PATH_TO_POS215_RES ) )
+def ComputeCandidatesInner_AfterUnicode_test( completer, execute_command ):
+  # Col 9 corresponds to cursor at log.Pri^nt("Line 7 ...
+  completer.ComputeCandidatesInner( BuildRequest( 9, 9 ) )
+  execute_command.assert_called_once_with(
+    [ DUMMY_BINARY, '-addr', completer._gocode_address,
+      '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '212' ],
+    contents = ToBytes( ReadFile( PATH_TO_TEST_FILE ) ) )
 
 
-  # Test end to end parsing of completed results.
-  def ComputeCandidatesInner_test( self ):
-    mock = MockPopen( returncode = 0,
-                      stdout = ReadFile( PATH_TO_POS292_RES ),
-                      stderr = '' )
-    self._completer._popener = mock
-    # Col 40 corresponds to cursor at ..., log.Prefi^x ...
-    result = self._completer.ComputeCandidatesInner(
-      self._BuildRequest( 10, 40 ) )
-    eq_( mock.cmd, [
-      DUMMY_BINARY, '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '287' ] )
-    eq_( result, [ {
-        'menu_text': u'Prefix',
-        'insertion_text': u'Prefix',
-        'extra_menu_info': u'func() string',
-        'detailed_info': u'Prefix func() string func',
-        'kind': u'func'
-    } ] )
+# Test end to end parsing of completed results.
+@SetUpGoCompleter
+@patch( 'ycmd.completers.go.go_completer.GoCompleter._ExecuteCommand',
+        return_value = ReadFile( PATH_TO_POS292_RES ) )
+def ComputeCandidatesInner_test( completer, execute_command ):
+  # Col 40 corresponds to cursor at ..., log.Prefi^x ...
+  result = completer.ComputeCandidatesInner( BuildRequest( 10, 40 ) )
+  execute_command.assert_called_once_with(
+    [ DUMMY_BINARY, '-addr', completer._gocode_address,
+      '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '287' ],
+    contents = ToBytes( ReadFile( PATH_TO_TEST_FILE ) ) )
+  eq_( result, [ {
+      'menu_text': u'Prefix',
+      'insertion_text': u'Prefix',
+      'extra_menu_info': u'func() string',
+      'detailed_info': u'Prefix func() string func',
+      'kind': u'func'
+  } ] )
 
 
-  # Test gocode failure.
-  @raises( RuntimeError )
-  def ComputeCandidatesInnerGoCodeFailure_test( self ):
-    mock = MockPopen( returncode = 1, stdout = '', stderr = '' )
-    self._completer._popener = mock
-    self._completer.ComputeCandidatesInner( self._BuildRequest( 1, 1 ) )
-
-  # Test JSON parsing failure.
-  @raises( RuntimeError )
-  def ComputeCandidatesInnerParseFailure_test( self ):
-    mock = MockPopen( returncode = 0,
-                      stdout = "{this isn't parseable",
-                      stderr = '' )
-    self._completer._popener = mock
-    self._completer.ComputeCandidatesInner( self._BuildRequest( 1, 1 ) )
-
-  # Test empty results error (different than no results).
-  @raises( RuntimeError )
-  def ComputeCandidatesInnerNoResultsFailure_test( self ):
-    mock = MockPopen( returncode = 0, stdout = '[]', stderr = '' )
-    self._completer._popener = mock
-    self._completer.ComputeCandidatesInner( self._BuildRequest( 1, 1 ) )
-
-  # Test empty results error (different than no results).
-  @raises( RuntimeError )
-  def ComputeCandidatesGoCodePanic_test( self ):
-    mock = MockPopen( returncode = 0,
-                      stdout = ReadFile( PATH_TO_PANIC_OUTPUT_RES ),
-                      stderr = '' )
-    self._completer._popener = mock
-    self._completer.ComputeCandidatesInner( self._BuildRequest( 1, 1 ) )
+# Test Gocode failure.
+@SetUpGoCompleter
+@patch( 'ycmd.completers.go.go_completer.GoCompleter._ExecuteCommand',
+        return_value = '' )
+def ComputeCandidatesInner_GoCodeFailure_test( completer, *args ):
+  assert_that(
+    calling( completer.ComputeCandidatesInner ).with_args(
+      BuildRequest( 1, 1 ) ),
+    raises( RuntimeError, 'Gocode returned invalid JSON response.' ) )
 
 
-class MockSubprocess( object ):
-  def __init__( self, returncode, stdout, stderr ):
-    self.returncode = returncode
-    self.stdout = stdout
-    self.stderr = stderr
+# Test JSON parsing failure.
+@SetUpGoCompleter
+@patch( 'ycmd.completers.go.go_completer.GoCompleter._ExecuteCommand',
+        return_value = "{this isn't parseable" )
+def ComputeCandidatesInner_ParseFailure_test( completer, *args ):
+  assert_that(
+    calling( completer.ComputeCandidatesInner ).with_args(
+      BuildRequest( 1, 1 ) ),
+    raises( RuntimeError, 'Gocode returned invalid JSON response.' ) )
 
 
-  def communicate( self, stdin ):
-    self.stdin = stdin
-    return ( self.stdout, self.stderr )
+# Test empty results error.
+@SetUpGoCompleter
+@patch( 'ycmd.completers.go.go_completer.GoCompleter._ExecuteCommand',
+        return_value = '[]' )
+def ComputeCandidatesInner_NoResultsFailure_test( completer, *args ):
+  assert_that(
+    calling( completer.ComputeCandidatesInner ).with_args(
+      BuildRequest( 1, 1 ) ),
+    raises( RuntimeError, 'No completions found.' ) )
 
 
-
-class MockPopen( object ):
-  def __init__( self, returncode = None, stdout = None, stderr = None ):
-    self._returncode = returncode
-    self._stdout = stdout
-    self._stderr = stderr
-    # cmd will be populated when a subprocess is created.
-    self.cmd = None
-
-
-  def __call__( self, cmd, stdout = None, stderr = None, stdin = None ):
-    self.cmd = cmd
-    return MockSubprocess( self._returncode, self._stdout, self._stderr )
+# Test panic error.
+@SetUpGoCompleter
+@patch( 'ycmd.completers.go.go_completer.GoCompleter._ExecuteCommand',
+        return_value = ReadFile( PATH_TO_PANIC_OUTPUT_RES ) )
+def ComputeCandidatesInner_GoCodePanic_test( completer, *args ):
+  assert_that(
+    calling( completer.ComputeCandidatesInner ).with_args(
+      BuildRequest( 1, 1 ) ),
+    raises( RuntimeError,
+            'Gocode panicked trying to find completions, '
+            'you likely have a syntax error.' ) )

--- a/ycmd/tests/go/subcommands_test.py
+++ b/ycmd/tests/go/subcommands_test.py
@@ -23,60 +23,126 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
+from hamcrest import assert_that, has_entries
 from nose.tools import eq_
+from pprint import pformat
+import http.client
 
 from ycmd.tests.go import PathToTestFile, SharedYcmd
-from ycmd.tests.test_utils import BuildRequest
+from ycmd.tests.test_utils import BuildRequest, ErrorMatcher
 from ycmd.utils import ReadFile
 
 
 @SharedYcmd
-def RunGoToTest( app, params ):
-  filepath = PathToTestFile( 'goto.go' )
-  contents = ReadFile( filepath )
+def Subcommands_DefinedSubcommands_test( app ):
+  subcommands_data = BuildRequest( completer_target = 'go' )
 
-  command = params[ 'command' ]
-  goto_data = BuildRequest( completer_target = 'filetype_default',
-                            command_arguments = [ command ],
-                            line_num = 8,
-                            column_num = 8,
-                            contents = contents,
-                            filetype = 'go',
-                            filepath = filepath )
-
-  results = app.post_json( '/run_completer_command',
-                           goto_data )
-
-  eq_( {
-    'line_num': 3, 'column_num': 6, 'filepath': filepath
-  }, results.json )
-
-  filepath = PathToTestFile( 'win.go' )
-  contents = ReadFile( filepath )
-
-  command = params[ 'command' ]
-  goto_data = BuildRequest( completer_target = 'filetype_default',
-                            command_arguments = [ command ],
-                            line_num = 4,
-                            column_num = 7,
-                            contents = contents,
-                            filetype = 'go',
-                            filepath = filepath )
-
-  results = app.post_json( '/run_completer_command',
-                           goto_data )
-
-  eq_( {
-    'line_num': 2, 'column_num': 6, 'filepath': filepath
-  }, results.json )
+  eq_( sorted( [ 'RestartServer',
+                 'GoTo',
+                 'GoToDefinition',
+                 'GoToDeclaration' ] ),
+       app.post_json( '/defined_subcommands',
+                      subcommands_data ).json )
 
 
-def Subcommands_GoTo_all_test():
-  tests = [
-    { 'command': 'GoTo' },
-    { 'command': 'GoToDefinition' },
-    { 'command': 'GoToDeclaration' }
-  ]
+def RunTest( app, test ):
+  contents = ReadFile( test[ 'request' ][ 'filepath' ] )
 
-  for test in tests:
-    yield RunGoToTest, test
+  def CombineRequest( request, data ):
+    kw = request
+    request.update( data )
+    return BuildRequest( **kw )
+
+  # We ignore errors here and check the response code ourself.
+  # This is to allow testing of requests returning errors.
+  response = app.post_json(
+    '/run_completer_command',
+    CombineRequest( test[ 'request' ], {
+      'completer_target': 'filetype_default',
+      'contents': contents,
+      'filetype': 'go',
+      'command_arguments': ( [ test[ 'request' ][ 'command' ] ]
+                             + test[ 'request' ].get( 'arguments', [] ) )
+    } ),
+    expect_errors = True
+  )
+
+  print( 'completer response: {0}'.format( pformat( response.json ) ) )
+
+  eq_( response.status_code, test[ 'expect' ][ 'response' ] )
+
+  assert_that( response.json, test[ 'expect' ][ 'data' ] )
+
+
+@SharedYcmd
+def Subcommands_GoTo_Basic( app, goto_command ):
+  RunTest( app, {
+    'description': goto_command + ' works within file',
+    'request': {
+      'command': goto_command,
+      'line_num': 8,
+      'column_num': 8,
+      'filepath': PathToTestFile( 'goto.go' ),
+    },
+    'expect': {
+      'response': http.client.OK,
+      'data': has_entries( {
+        'filepath': PathToTestFile( 'goto.go' ),
+        'line_num': 3,
+        'column_num': 6,
+      } )
+    }
+  } )
+
+
+def Subcommands_GoTo_Basic_test():
+  for command in [ 'GoTo', 'GoToDefinition', 'GoToDeclaration' ]:
+    yield Subcommands_GoTo_Basic, command
+
+
+@SharedYcmd
+def Subcommands_GoTo_Keyword( app, goto_command ):
+  RunTest( app, {
+    'description': goto_command + ' can\'t jump on keyword',
+    'request': {
+      'command': goto_command,
+      'line_num': 3,
+      'column_num': 3,
+      'filepath': PathToTestFile( 'goto.go' ),
+    },
+    'expect': {
+      'response': http.client.INTERNAL_SERVER_ERROR,
+      'data': ErrorMatcher( RuntimeError, 'Can\'t find a definition.' )
+    }
+  } )
+
+
+def Subcommands_GoTo_Keyword_test():
+  for command in [ 'GoTo', 'GoToDefinition', 'GoToDeclaration' ]:
+    yield Subcommands_GoTo_Keyword, command
+
+
+@SharedYcmd
+def Subcommands_GoTo_WindowsNewlines( app, goto_command ):
+  RunTest( app, {
+    'description': goto_command + ' works with Windows newlines',
+    'request': {
+      'command': goto_command,
+      'line_num': 4,
+      'column_num': 7,
+      'filepath': PathToTestFile( 'win.go' ),
+    },
+    'expect': {
+      'response': http.client.OK,
+      'data': has_entries( {
+        'filepath': PathToTestFile( 'win.go' ),
+        'line_num': 2,
+        'column_num': 6,
+      } )
+    }
+  } )
+
+
+def Subcommands_GoTo_WindowsNewlines_test():
+  for command in [ 'GoTo', 'GoToDefinition', 'GoToDeclaration' ]:
+    yield Subcommands_GoTo_WindowsNewlines, command


### PR DESCRIPTION
This PR includes the changes mentioned in PR #282 for the Go completer and other small changes (listed in the commit message). The main change is the way we start the `gocode` daemon: instead of letting the client automatically start the daemon, we directly start it by running the `gocode` executable in server mode (using the `-s` parameter). This allows us to:
 - get its PID;
 - log stdout and stderr into files;
 - enable `gocode` debug mode;
 - set the port listened by `gocode`;
 - terminate the process;
 - implement the `_ServerIs*` methods;
 - etc.

The second important change is the implementation of the `DebugInfo` method to show debug informations about the Go completer. The way informations are displayed will be adapted to other completers. Here's the output obtained in Vim when editing a Go file before and after the changes:

Before:
```
Printing YouCompleteMe debug information...
-- Server has Clang support compiled in: True
-- Clang version: clang version 3.8.0 (branches/release_38)
--
-- Server running at: http://127.0.0.1:59642
-- Server process ID: 4884
-- Server logfiles:
--   c:\users\micbou\appdata\local\temp\ycm_temp\server_59642_stdout.log
--   c:\users\micbou\appdata\local\temp\ycm_temp\server_59642_stderr.log
```
*How can I write a good issue report in these conditions?*

After:
```
Printing YouCompleteMe debug information...
-- Server has Clang support compiled in: True
-- Clang version: clang version 3.8.0 (branches/release_38)
-- Go completer debug information:
--   Gocode running at: http://127.0.0.1:59667
--   Gocode process ID: 8720
--   Gocode binary: C:\Users\micbou\VIM~1\bundle\YOUCOM~2\THIRD_~1\ycmd\third_pa
rty\gocode\gocode.exe
--   Gocode logfiles:
--     C:\Users\micbou\AppData\Local\Temp\ycm_temp\gocode_59667_stdout.log
--     C:\Users\micbou\AppData\Local\Temp\ycm_temp\gocode_59667_stderr.log
--   Godef binary: C:\Users\micbou\VIM~1\bundle\YOUCOM~2\THIRD_~1\ycmd\third_par
ty\godef\godef.exe
-- Server running at: http://127.0.0.1:59663
-- Server process ID: 2788
-- Server logfiles:
--   c:\users\micbou\appdata\local\temp\ycm_temp\server_59663_stdout.log
--   c:\users\micbou\appdata\local\temp\ycm_temp\server_59663_stderr.log
```
*Please help, I am overwhelmed by all this information.*

Finally, the last important change (copied from the Python completer) is replacing the `StartServer` subcommand with the `RestartServer` one (reasoning is that if you can restart the server, you can start it too) and hiding the `StopServer` subcommand from the user (if users need to stop the server then something is wrong with the completer).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/505)
<!-- Reviewable:end -->
