### PR TITLE
[READY] Make completer interface uniform throughout completers

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -247,8 +247,8 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
   def DefinedSubcommands( self ):
     subcommands = sorted( self.GetSubcommandsMap().keys() )
     try:
-      # We don't want expose this sub-command because is not really needed for
-      # the user but is useful in tests for tearing down the server
+      # We don't want expose this subcommand because it is not really needed
+      # for the user but it is useful in tests for tearing down the server
       subcommands.remove( 'StopServer' )
     except ValueError:
       pass

--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -245,7 +245,14 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
 
 
   def DefinedSubcommands( self ):
-    return sorted( self.GetSubcommandsMap().keys() )
+    subcommands = sorted( self.GetSubcommandsMap().keys() )
+    try:
+      # We don't want expose this sub-command because is not really needed for
+      # the user but is useful in tests for tearing down the server
+      subcommands.remove( 'StopServer' )
+    except ValueError:
+      pass
+    return subcommands
 
 
   def GetSubcommandsMap( self ):

--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -147,8 +147,8 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
   custom cleanup logic on server shutdown.
 
   If your completer uses an external server process, then it can be useful to
-  implement the ServerIsReady member function to handle the /ready request. This
-  is very useful for the test suite."""
+  implement the ServerIsHealthy member function to handle the /healthy request.
+  This is very useful for the test suite."""
 
   def __init__( self, user_options ):
     self.user_options = user_options
@@ -372,7 +372,11 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
 
 
   def ServerIsReady( self ):
-    """Called by the /ready handler to check if the underlying completion
+    return self.ServerIsHealthy()
+
+
+  def ServerIsHealthy( self ):
+    """Called by the /healthy handler to check if the underlying completion
     server is started and ready to receive requests. Returns bool."""
     return True
 

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -134,10 +134,6 @@ class CsharpCompleter( Completer ):
 
   def GetSubcommandsMap( self ):
     return {
-      'StartServer'                      : ( lambda self, request_data, args:
-         self._SolutionSubcommand( request_data,
-                                   method = '_StartServer',
-                                   no_request_data = True ) ),
       'StopServer'                       : ( lambda self, request_data, args:
          self._SolutionSubcommand( request_data,
                                    method = '_StopServer',
@@ -418,9 +414,9 @@ class CsharpSolutionCompleter( object ):
     self._omnisharp_phandle = None
     if ( not self._keep_logfiles ):
       if self._filename_stdout:
-        os.unlink( self._filename_stdout )
+        utils.RemoveIfExists( self._filename_stdout )
       if self._filename_stderr:
-        os.unlink( self._filename_stderr )
+        utils.RemoveIfExists( self._filename_stderr )
 
 
   def _RestartServer( self ):

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -162,14 +162,6 @@ class GoCompleter( Completer ):
     return [ _ConvertCompletionData( x ) for x in resultdata[ 1 ] ]
 
 
-  def DefinedSubcommands( self ):
-    # We don't want to expose this sub-command because it is not really needed
-    # for the user but it is useful in tests for tearing down the server.
-    subcommands = super( GoCompleter, self ).DefinedSubcommands()
-    subcommands.remove( 'StopServer' )
-    return subcommands
-
-
   def GetSubcommandsMap( self ):
     return {
       'StopServer'     : ( lambda self, request_data, args:

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -262,7 +262,7 @@ class TernCompleter( Completer ):
     self._StopServer()
 
 
-  def ServerIsReady( self, request_data = {} ):
+  def ServerIsHealthy( self, request_data = {} ):
     if not self._ServerIsRunning():
       return False
 

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -396,8 +396,8 @@ class TernCompleter( Completer ):
 
         # We need to open a pipe to stdin or the Tern server is killed.
         # See https://github.com/ternjs/tern/issues/740#issuecomment-203979749
-        # For unknown reasons, this is only needed on Windows and for Python 3.4+
-        # on other platforms.
+        # For unknown reasons, this is only needed on Windows and for Python
+        # 3.4+ on other platforms.
         with utils.OpenForStdHandle( self._server_stdout ) as stdout:
           with utils.OpenForStdHandle( self._server_stderr ) as stderr:
             self._server_handle = utils.SafePopen( command,

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -118,7 +118,7 @@ class TernCompleter( Completer ):
     self._server_keep_logfiles = user_options[ 'server_keep_logfiles' ]
 
     # Used to ensure that starting/stopping of the server is synchronised
-    self._server_state_mutex = threading.Lock()
+    self._server_state_mutex = threading.RLock()
 
     self._do_tern_project_check = False
 
@@ -126,7 +126,7 @@ class TernCompleter( Completer ):
       self._server_stdout = None
       self._server_stderr = None
       self._Reset()
-      self._StartServerNoLock()
+      self._StartServer()
 
 
   def _WarnIfMissingTernProject( self ):
@@ -208,8 +208,8 @@ class TernCompleter( Completer ):
 
   def GetSubcommandsMap( self ):
     return {
-      'StartServer':    ( lambda self, request_data, args:
-                                         self._StartServer() ),
+      'RestartServer':  ( lambda self, request_data, args:
+                                         self._RestartServer() ),
       'StopServer':     ( lambda self, request_data, args:
                                          self._StopServer() ),
       'GoToDefinition': ( lambda self, request_data, args:
@@ -274,18 +274,17 @@ class TernCompleter( Completer ):
 
 
   def _Reset( self ):
-    """Callers must hold self._server_state_mutex"""
+    with self._server_state_mutex:
+      if not self._server_keep_logfiles:
+        if self._server_stdout:
+          utils.RemoveIfExists( self._server_stdout )
+        if self._server_stderr:
+          utils.RemoveIfExists( self._server_stderr )
 
-    if not self._server_keep_logfiles:
-      if self._server_stdout:
-        utils.RemoveIfExists( self._server_stdout )
-      if self._server_stderr:
-        utils.RemoveIfExists( self._server_stderr )
-
-    self._server_handle = None
-    self._server_port   = 0
-    self._server_stdout = None
-    self._server_stderr = None
+      self._server_handle = None
+      self._server_port   = 0
+      self._server_stdout = None
+      self._server_stderr = None
 
 
   def _PostRequest( self, request, request_data ):
@@ -356,103 +355,94 @@ class TernCompleter( Completer ):
     return self._PostRequest( { 'query': full_query }, request_data )
 
 
+  # TODO: this function is way too long. Consider refactoring it.
   def _StartServer( self ):
-    if not self._ServerIsRunning():
-      with self._server_state_mutex:
-        self._StartServerNoLock()
+    with self._server_state_mutex:
+      if self._ServerIsRunning():
+        return
+
+      _logger.info( 'Starting Tern.js server...' )
+
+      self._server_port = utils.GetUnusedLocalhostPort()
+
+      if _logger.isEnabledFor( logging.DEBUG ):
+        extra_args = [ '--verbose' ]
+      else:
+        extra_args = []
+
+      command = [ PATH_TO_NODE,
+                  PATH_TO_TERNJS_BINARY,
+                  '--port',
+                  str( self._server_port ),
+                  '--host',
+                  SERVER_HOST,
+                  '--persistent',
+                  '--no-port-file' ] + extra_args
+
+      _logger.debug( 'Starting tern with the following command: '
+                    + ' '.join( command ) )
+
+      try:
+        logfile_format = os.path.join( utils.PathToCreatedTempDir(),
+                                      u'tern_{port}_{std}.log' )
+
+        self._server_stdout = logfile_format.format(
+            port = self._server_port,
+            std = 'stdout' )
+
+        self._server_stderr = logfile_format.format(
+            port = self._server_port,
+            std = 'stderr' )
+
+        # We need to open a pipe to stdin or the Tern server is killed.
+        # See https://github.com/ternjs/tern/issues/740#issuecomment-203979749
+        # For unknown reasons, this is only needed on Windows and for Python 3.4+
+        # on other platforms.
+        with utils.OpenForStdHandle( self._server_stdout ) as stdout:
+          with utils.OpenForStdHandle( self._server_stderr ) as stderr:
+            self._server_handle = utils.SafePopen( command,
+                                                  stdin = PIPE,
+                                                  stdout = stdout,
+                                                  stderr = stderr )
+      except Exception:
+        _logger.warning( 'Unable to start Tern.js server: '
+                        + traceback.format_exc() )
+        self._Reset()
+
+      if self._server_port > 0 and self._ServerIsRunning():
+        _logger.info( 'Tern.js Server started with pid: ' +
+                      str( self._server_handle.pid ) +
+                      ' listening on port ' +
+                      str( self._server_port ) )
+        _logger.info( 'Tern.js Server log files are: ' +
+                      self._server_stdout +
+                      ' and ' +
+                      self._server_stderr )
+
+        self._do_tern_project_check = True
+      else:
+        _logger.warning( 'Tern.js server did not start successfully' )
 
 
-  def _StartServerNoLock( self ):
-    """Start the server, under the lock.
-
-    Callers must hold self._server_state_mutex"""
-
-    if self._ServerIsRunning():
-      return
-
-    _logger.info( 'Starting Tern.js server...' )
-
-    self._server_port = utils.GetUnusedLocalhostPort()
-
-    if _logger.isEnabledFor( logging.DEBUG ):
-      extra_args = [ '--verbose' ]
-    else:
-      extra_args = []
-
-    command = [ PATH_TO_NODE,
-                PATH_TO_TERNJS_BINARY,
-                '--port',
-                str( self._server_port ),
-                '--host',
-                SERVER_HOST,
-                '--persistent',
-                '--no-port-file' ] + extra_args
-
-    _logger.debug( 'Starting tern with the following command: '
-                   + ' '.join( command ) )
-
-    try:
-      logfile_format = os.path.join( utils.PathToCreatedTempDir(),
-                                     u'tern_{port}_{std}.log' )
-
-      self._server_stdout = logfile_format.format(
-          port = self._server_port,
-          std = 'stdout' )
-
-      self._server_stderr = logfile_format.format(
-          port = self._server_port,
-          std = 'stderr' )
-
-      # We need to open a pipe to stdin or the Tern server is killed.
-      # See https://github.com/ternjs/tern/issues/740#issuecomment-203979749
-      # For unknown reasons, this is only needed on Windows and for Python 3.4+
-      # on other platforms.
-      with utils.OpenForStdHandle( self._server_stdout ) as stdout:
-        with utils.OpenForStdHandle( self._server_stderr ) as stderr:
-          self._server_handle = utils.SafePopen( command,
-                                                 stdin = PIPE,
-                                                 stdout = stdout,
-                                                 stderr = stderr )
-    except Exception:
-      _logger.warning( 'Unable to start Tern.js server: '
-                       + traceback.format_exc() )
-      self._Reset()
-
-    if self._server_port > 0 and self._ServerIsRunning():
-      _logger.info( 'Tern.js Server started with pid: ' +
-                    str( self._server_handle.pid ) +
-                    ' listening on port ' +
-                    str( self._server_port ) )
-      _logger.info( 'Tern.js Server log files are: ' +
-                    self._server_stdout +
-                    ' and ' +
-                    self._server_stderr )
-
-      self._do_tern_project_check = True
-    else:
-      _logger.warning( 'Tern.js server did not start successfully' )
+  def _RestartServer( self ):
+    with self._server_state_mutex:
+      self._StopServer()
+      self._StartServer()
 
 
   def _StopServer( self ):
     with self._server_state_mutex:
-      self._StopServerNoLock()
+      if self._ServerIsRunning():
+        _logger.info( 'Stopping Tern.js server with PID '
+                      + str( self._server_handle.pid )
+                      + '...' )
 
+        self._server_handle.terminate()
+        self._server_handle.wait()
 
-  def _StopServerNoLock( self ):
-    """Stop the server, under the lock.
+        _logger.info( 'Tern.js server terminated.' )
 
-    Callers must hold self._server_state_mutex"""
-    if self._ServerIsRunning():
-      _logger.info( 'Stopping Tern.js server with PID '
-                    + str( self._server_handle.pid )
-                    + '...' )
-
-      self._server_handle.terminate()
-      self._server_handle.wait()
-
-      _logger.info( 'Tern.js server terminated.' )
-
-      self._Reset()
+        self._Reset()
 
 
   def _ServerIsRunning( self ):

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -232,28 +232,29 @@ class TernCompleter( Completer ):
 
 
   def DebugInfo( self, request_data ):
-    if self._server_handle is None:
-      # server is not running because we haven't tried to start it.
-      return ' * Tern server is not running'
+    with self._server_state_mutex:
+      if self._server_handle is None:
+        # server is not running because we haven't tried to start it.
+        return ' * Tern server is not running'
 
-    if not self._ServerIsRunning():
-      # The handle is set, but the process isn't running. This means either it
-      # crashed or we failed to start it.
-      return ( ' * Tern server is not running (crashed)'
-               + '\n * Server stdout: '
-               + self._server_stdout
-               + '\n * Server stderr: '
-               + self._server_stderr )
+      if not self._ServerIsRunning():
+        # The handle is set, but the process isn't running. This means either it
+        # crashed or we failed to start it.
+        return ( ' * Tern server is not running (crashed)'
+                + '\n * Server stdout: '
+                + self._server_stdout
+                + '\n * Server stderr: '
+                + self._server_stderr )
 
-    # Server is up and running.
-    return ( ' * Tern server is running on port: '
-             + str( self._server_port )
-             + ' with PID: '
-             + str( self._server_handle.pid )
-             + '\n * Server stdout: '
-             + self._server_stdout
-             + '\n * Server stderr: '
-             + self._server_stderr )
+      # Server is up and running.
+      return ( ' * Tern server is running on port: '
+              + str( self._server_port )
+              + ' with PID: '
+              + str( self._server_handle.pid )
+              + '\n * Server stdout: '
+              + self._server_stdout
+              + '\n * Server stderr: '
+              + self._server_stderr )
 
 
   def Shutdown( self ):

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -95,7 +95,7 @@ class JediCompleter( Completer ):
       self._StopServer()
 
 
-  def ServerIsReady( self ):
+  def ServerIsHealthy( self ):
     """
     Check if JediHTTP is alive AND ready to serve requests.
     """
@@ -112,7 +112,7 @@ class JediCompleter( Completer ):
   def _ServerIsRunning( self ):
     """
     Check if JediHTTP is alive. That doesn't necessarily mean it's ready to
-    serve requests; that's checked by ServerIsReady.
+    serve requests; that's checked by ServerIsHealthy.
     """
     with self._server_lock:
       return ( bool( self._jedihttp_port ) and

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -387,8 +387,8 @@ class JediCompleter( Completer ):
 
        if self._logfile_stdout and self._logfile_stderr:
          return ( 'JediHTTP is no longer running\n'
-                  '  stdout log: {1}\n'
-                  '  stderr log: {2}' ).format( self._logfile_stdout,
+                  '  stdout log: {0}\n'
+                  '  stderr log: {1}' ).format( self._logfile_stdout,
                                                 self._logfile_stderr )
 
        return 'JediHTTP is not running'

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -91,7 +91,7 @@ class JediCompleter( Completer ):
 
 
   def Shutdown( self ):
-    if self.ServerIsRunning():
+    if self._ServerIsRunning():
       self._StopServer()
 
 
@@ -99,7 +99,7 @@ class JediCompleter( Completer ):
     """
     Check if JediHTTP is alive AND ready to serve requests.
     """
-    if not self.ServerIsRunning():
+    if not self._ServerIsRunning():
       self._logger.debug( 'JediHTTP not running.' )
       return False
     try:
@@ -109,7 +109,7 @@ class JediCompleter( Completer ):
       return False
 
 
-  def ServerIsRunning( self ):
+  def _ServerIsRunning( self ):
     """
     Check if JediHTTP is alive. That doesn't necessarily mean it's ready to
     serve requests; that's checked by ServerIsReady.
@@ -376,7 +376,7 @@ class JediCompleter( Completer ):
 
   def DebugInfo( self, request_data ):
      with self._server_lock:
-       if self.ServerIsRunning():
+       if self._ServerIsRunning():
          return ( 'JediHTTP running at 127.0.0.1:{0}\n'
                   '  python binary: {1}\n'
                   '  stdout log: {2}\n'

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -265,14 +265,6 @@ class JediCompleter( Completer ):
                               request_data )[ 'completions' ]
 
 
-  def DefinedSubcommands( self ):
-    # We don't want expose this sub-command because is not really needed for
-    # the user but is useful in tests for tearing down the server
-    subcommands = super( JediCompleter, self ).DefinedSubcommands()
-    subcommands.remove( 'StopServer' )
-    return subcommands
-
-
   def GetSubcommandsMap( self ):
     return {
       'GoToDefinition' : ( lambda self, request_data, args:

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -335,12 +335,12 @@ class RustCompleter( Completer ):
 
       if not self._keep_logfiles:
         # Remove stdout log
-        if self._server_stdout and p.exists( self._server_stdout ):
+        if self._server_stdout:
           utils.RemoveIfExists( self._server_stdout )
           self._server_stdout = None
 
         # Remove stderr log
-        if self._server_stderr and p.exists( self._server_stderr ):
+        if self._server_stderr:
           utils.RemoveIfExists( self._server_stderr )
           self._server_stderr = None
 

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -336,12 +336,12 @@ class RustCompleter( Completer ):
       if not self._keep_logfiles:
         # Remove stdout log
         if self._server_stdout and p.exists( self._server_stdout ):
-          os.unlink( self._server_stdout )
+          utils.RemoveIfExists( self._server_stdout )
           self._server_stdout = None
 
         # Remove stderr log
         if self._server_stderr and p.exists( self._server_stderr ):
-          os.unlink( self._server_stderr )
+          utils.RemoveIfExists( self._server_stderr )
           self._server_stderr = None
 
 

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -292,12 +292,12 @@ class RustCompleter( Completer ):
                                                   env = env )
 
       self._racerd_host = 'http://127.0.0.1:{0}'.format( port )
-      if not self.ServerIsRunning():
+      if not self._ServerIsRunning():
         raise RuntimeError( 'Failed to start racerd!' )
       _logger.info( 'Racerd started on: ' + self._racerd_host )
 
 
-  def ServerIsRunning( self ):
+  def _ServerIsRunning( self ):
     """
     Check if racerd is alive. That doesn't necessarily mean it's ready to serve
     requests; that's checked by ServerIsReady.
@@ -311,7 +311,7 @@ class RustCompleter( Completer ):
     """
     Check if racerd is alive AND ready to serve requests.
     """
-    if not self.ServerIsRunning():
+    if not self._ServerIsRunning():
       _logger.debug( 'Racerd not running.' )
       return False
     try:
@@ -349,7 +349,7 @@ class RustCompleter( Completer ):
     _logger.debug( 'RustCompleter restarting racerd' )
 
     with self._server_state_lock:
-      if self.ServerIsRunning():
+      if self._ServerIsRunning():
         self._StopServer()
       self._StartServer()
 
@@ -393,7 +393,7 @@ class RustCompleter( Completer ):
 
   def DebugInfo( self, request_data ):
     with self._server_state_lock:
-      if self.ServerIsRunning():
+      if self._ServerIsRunning():
         return ( 'racerd\n'
                  '  listening at: {0}\n'
                  '  racerd path: {1}\n'

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -300,14 +300,14 @@ class RustCompleter( Completer ):
   def _ServerIsRunning( self ):
     """
     Check if racerd is alive. That doesn't necessarily mean it's ready to serve
-    requests; that's checked by ServerIsReady.
+    requests; that's checked by ServerIsHealthy.
     """
     with self._server_state_lock:
       return ( bool( self._racerd_host ) and
                ProcessIsRunning( self._racerd_phandle ) )
 
 
-  def ServerIsReady( self ):
+  def ServerIsHealthy( self ):
     """
     Check if racerd is alive AND ready to serve requests.
     """

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -301,6 +301,10 @@ class TypeScriptCompleter( Completer ):
       return utils.ProcessIsRunning( self._tsserver_handle )
 
 
+  def ServerIsHealthy( self ):
+    return self._ServerIsRunning()
+
+
   def SupportedFiletypes( self ):
     return [ 'typescript' ]
 

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -293,6 +293,11 @@ class TypeScriptCompleter( Completer ):
     utils.RemoveIfExists( tmpfile.name )
 
 
+  def ServerIsRunning( self ):
+    with self._server_lock:
+      return utils.ProcessIsRunning( self._tsserver_handle )
+
+
   def SupportedFiletypes( self ):
     return [ 'typescript' ]
 

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -542,7 +542,19 @@ class TypeScriptCompleter( Completer ):
 
 
   def DebugInfo( self, request_data ):
-    return ( 'TSServer logfile:\n  {0}' ).format( self._logfile )
+    with self._server_lock:
+      if self._ServerIsRunning():
+        return ( 'Typescript completer debug informations:\n'
+                 '  TSServer process ID: {0}\n'
+                 '  TSServer logfile: {1}' ).format( self._tsserver_handle.pid,
+                                                     self._logfile )
+      if self._logfile:
+        return ( 'Typescript completer debug informations:\n'
+                 '  TSServer is not running\n'
+                 '  TSServer logfile: {0}' ).format( self._logfile )
+
+      return ( 'Typescript completer debug informations:\n'
+                '  TSServer is not running' )
 
 
 def _LogFileName():

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -30,10 +30,8 @@ import os
 import re
 import subprocess
 import itertools
+import threading
 
-from threading import Thread
-from threading import Event
-from threading import Lock
 from tempfile import NamedTemporaryFile
 
 from ycmd import responses
@@ -56,7 +54,7 @@ class DeferredResponse( object ):
   """
 
   def __init__( self, timeout = RESPONSE_TIMEOUT_SECONDS ):
-    self._event = Event()
+    self._event = threading.Event()
     self._message = None
     self._timeout = timeout
 
@@ -91,9 +89,11 @@ class TypeScriptCompleter( Completer ):
   def __init__( self, user_options ):
     super( TypeScriptCompleter, self ).__init__( user_options )
 
+    self._tsserver_handle = None
+
     # Used to prevent threads from concurrently writing to
     # the tsserver process' stdin
-    self._writelock = Lock()
+    self._write_lock = threading.Lock()
 
     binarypath = utils.PathToFirstExistingExecutable( [ 'tsserver' ] )
     if not binarypath:
@@ -118,14 +118,20 @@ class TypeScriptCompleter( Completer ):
     self._sequenceid = itertools.count()
 
     # Used to prevent threads from concurrently accessing the sequence counter
-    self._sequenceid_lock = Lock()
+    self._sequenceid_lock = threading.Lock()
 
-    # We need to redirect the error stream to the output one on Windows.
-    self._tsserver_handle = utils.SafePopen( binarypath,
-                                             stdin = subprocess.PIPE,
-                                             stdout = subprocess.PIPE,
-                                             stderr = subprocess.STDOUT,
-                                             env = self._environ )
+    # TODO: if we follow the path of tern_completer we can extract a
+    # `ShouldEnableTypescriptCompleter` and use it in hook.py
+    self._binary_path = utils.PathToFirstExistingExecutable( [ 'tsserver' ] )
+    if not self._binary_path:
+      _logger.error( BINARY_NOT_FOUND_MESSAGE )
+      raise RuntimeError( BINARY_NOT_FOUND_MESSAGE )
+
+    self._server_lock = threading.RLock()
+
+    # We first start the server and then the response-reading queue, so it will
+    # certainly find a responding TSServer.
+    self._StartServer()
 
     # Used to map sequence id's to their corresponding DeferredResponse
     # objects. The reader loop uses this to hand out responses.
@@ -133,14 +139,36 @@ class TypeScriptCompleter( Completer ):
 
     # Used to prevent threads from concurrently reading and writing to
     # the pending response dictionary
-    self._pendinglock = Lock()
+    self._pending_lock = threading.Lock()
 
     # Start a thread to read response from TSServer.
-    self._thread = Thread( target = self._ReaderLoop, args = () )
+    self._thread = threading.Thread( target = self._ReaderLoop, args = () )
     self._thread.daemon = True
     self._thread.start()
 
     _logger.info( 'Enabling typescript completion' )
+
+
+  def _StartServer( self ):
+    with self._server_lock:
+      self._logfile = _LogFileName()
+      tsserver_log = '-file {path} -level {level}'.format( path = self._logfile,
+                                                           level = _LogLevel() )
+      # TSServer gets the configuration for the log file through the
+      # environment variable 'TSS_LOG'. This seems to be undocumented but
+      # looking at the source code it seems like this is the way:
+      # https://github.com/Microsoft/TypeScript/blob/8a93b489454fdcbdf544edef05f73a913449be1d/src/server/server.ts#L136
+      environ = os.environ.copy()
+      utils.SetEnviron( environ, 'TSS_LOG', tsserver_log )
+
+      _logger.info( 'TSServer log file: {0}'.format( self._logfile ) )
+
+      # We need to redirect the error stream to the output one on Windows.
+      self._tsserver_handle = utils.SafePopen( self._binary_path,
+                                               stdin = subprocess.PIPE,
+                                               stdout = subprocess.PIPE,
+                                               stderr = subprocess.STDOUT,
+                                               env = environ )
 
 
   def _ReaderLoop( self ):
@@ -164,7 +192,7 @@ class TypeScriptCompleter( Completer ):
           continue
 
         seq = message[ 'request_seq' ]
-        with self._pendinglock:
+        with self._pending_lock:
           if seq in self._pending:
             self._pending[ seq ].resolve( message )
             del self._pending[ seq ]
@@ -224,7 +252,7 @@ class TypeScriptCompleter( Completer ):
     """
 
     request = json.dumps( self._BuildRequest( command, arguments ) ) + '\n'
-    with self._writelock:
+    with self._write_lock:
       self._tsserver_handle.stdin.write( utils.ToBytes( request ) )
       self._tsserver_handle.stdin.flush()
 
@@ -238,10 +266,10 @@ class TypeScriptCompleter( Completer ):
     request = self._BuildRequest( command, arguments )
     json_request = json.dumps( request ) + '\n'
     deferred = DeferredResponse()
-    with self._pendinglock:
+    with self._pending_lock:
       seq = request[ 'seq' ]
       self._pending[ seq ] = deferred
-    with self._writelock:
+    with self._write_lock:
       self._tsserver_handle.stdin.write( utils.ToBytes( json_request ) )
       self._tsserver_handle.stdin.flush()
     return deferred.result()
@@ -262,7 +290,7 @@ class TypeScriptCompleter( Completer ):
       'file':    filename,
       'tmpfile': tmpfile.name
     } )
-    os.unlink( tmpfile.name )
+    utils.RemoveIfExists( tmpfile.name )
 
 
   def SupportedFiletypes( self ):
@@ -301,6 +329,10 @@ class TypeScriptCompleter( Completer ):
 
   def GetSubcommandsMap( self ):
     return {
+      'RestartServer'  : ( lambda self, request_data, args:
+                           self._RestartServer( request_data ) ),
+      'StopServer'     : ( lambda self, request_data, args:
+                           self._StopServer() ),
       'GoToDefinition' : ( lambda self, request_data, args:
                            self._GoToDefinition( request_data ) ),
       'GoToReferences' : ( lambda self, request_data, args:
@@ -471,11 +503,31 @@ class TypeScriptCompleter( Completer ):
     ] )
 
 
+  def _RestartServer( self, request_data ):
+    with self._server_lock:
+      self._StopServer()
+      self._StartServer()
+      # This is needed because after we restart the TSServer it would lose all
+      # the information about the files we were working on. This means that the
+      # newly started TSServer will know nothing about the buffer we're working
+      # on after restarting the server. So if we restart the server and right
+      # after that ask for completion in the buffer, the server will timeout.
+      # So we notify the server that we're working on the current buffer.
+      self.OnBufferVisit( request_data )
+
+
+  def _StopServer( self ):
+    with self._server_lock:
+      self._SendCommand( 'exit' )
+      self._tsserver_handle.wait()
+
+      if not self.user_options[ 'server_keep_logfiles' ]:
+        utils.RemoveIfExists( self._logfile )
+        self._logfile = None
+
+
   def Shutdown( self ):
-    self._SendCommand( 'exit' )
-    if not self.user_options[ 'server_keep_logfiles' ]:
-      os.unlink( self._logfile )
-      self._logfile = None
+    self._StopServer()
 
 
   def DebugInfo( self, request_data ):

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -151,6 +151,9 @@ class TypeScriptCompleter( Completer ):
 
   def _StartServer( self ):
     with self._server_lock:
+      if self._ServerIsRunning():
+        return
+
       self._logfile = _LogFileName()
       tsserver_log = '-file {path} -level {level}'.format( path = self._logfile,
                                                            level = _LogLevel() )
@@ -293,7 +296,7 @@ class TypeScriptCompleter( Completer ):
     utils.RemoveIfExists( tmpfile.name )
 
 
-  def ServerIsRunning( self ):
+  def _ServerIsRunning( self ):
     with self._server_lock:
       return utils.ProcessIsRunning( self._tsserver_handle )
 
@@ -523,6 +526,9 @@ class TypeScriptCompleter( Completer ):
 
   def _StopServer( self ):
     with self._server_lock:
+      if not self._ServerIsRunning():
+        return
+
       self._SendCommand( 'exit' )
       self._tsserver_handle.wait()
 

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -95,11 +95,13 @@ class TypeScriptCompleter( Completer ):
     # the tsserver process' stdin
     self._write_lock = threading.Lock()
 
-    binarypath = utils.PathToFirstExistingExecutable( [ 'tsserver' ] )
-    if not binarypath:
+    # TODO: if we follow the path of tern_completer we can extract a
+    # `ShouldEnableTypescriptCompleter` and use it in hook.py
+    self._binary_path = utils.PathToFirstExistingExecutable( [ 'tsserver' ] )
+    if not self._binary_path:
       _logger.error( BINARY_NOT_FOUND_MESSAGE )
       raise RuntimeError( BINARY_NOT_FOUND_MESSAGE )
-    _logger.info( 'Found TSServer at {0}'.format( binarypath ) )
+    _logger.info( 'Found TSServer at {0}'.format( self._binary_path ) )
 
     self._logfile = _LogFileName()
     tsserver_log = '-file {path} -level {level}'.format( path = self._logfile,
@@ -119,13 +121,6 @@ class TypeScriptCompleter( Completer ):
 
     # Used to prevent threads from concurrently accessing the sequence counter
     self._sequenceid_lock = threading.Lock()
-
-    # TODO: if we follow the path of tern_completer we can extract a
-    # `ShouldEnableTypescriptCompleter` and use it in hook.py
-    self._binary_path = utils.PathToFirstExistingExecutable( [ 'tsserver' ] )
-    if not self._binary_path:
-      _logger.error( BINARY_NOT_FOUND_MESSAGE )
-      raise RuntimeError( BINARY_NOT_FOUND_MESSAGE )
 
     self._server_lock = threading.RLock()
 

--- a/ycmd/tests/completer_test.py
+++ b/ycmd/tests/completer_test.py
@@ -26,6 +26,7 @@ from builtins import *  # noqa
 
 from ycmd.tests.test_utils import DummyCompleter, ExpectedFailure
 from ycmd.user_options_store import DefaultOptions
+from mock import patch
 from nose.tools import eq_
 from hamcrest import contains_string
 
@@ -66,3 +67,10 @@ def FilterAndSortCandidates_Unicode_test():
   _FilterAndSortCandidates_Match( [ { 'insertion_text': 'ø' } ],
                                   'ø',
                                   [ { 'insertion_text': 'ø' } ] )
+
+
+@patch( 'ycmd.tests.test_utils.DummyCompleter.GetSubcommandsMap',
+        return_value = { 'Foo': '', 'StopServer': '' } )
+def DefinedSubcommands_RemoveStopServerSubcommand_test( subcommands_map ):
+  completer = DummyCompleter( DefaultOptions() )
+  eq_( completer.DefinedSubcommands(), [ 'Foo' ] )

--- a/ycmd/tests/cs/__init__.py
+++ b/ycmd/tests/cs/__init__.py
@@ -43,7 +43,7 @@ def PathToTestFile( *args ):
 def StartOmniSharpServer( app, filepath ):
   app.post_json( '/run_completer_command',
                  BuildRequest( completer_target = 'filetype_default',
-                               command_arguments = [ "StartServer" ],
+                               command_arguments = [ "RestartServer" ],
                                filepath = filepath,
                                filetype = 'cs' ) )
 

--- a/ycmd/tests/go/subcommands_test.py
+++ b/ycmd/tests/go/subcommands_test.py
@@ -36,7 +36,6 @@ from ycmd.utils import ReadFile
 @SharedYcmd
 def Subcommands_DefinedSubcommands_test( app ):
   subcommands_data = BuildRequest( completer_target = 'go' )
-
   eq_( sorted( [ 'RestartServer',
                  'GoTo',
                  'GoToDefinition',

--- a/ycmd/tests/javascript/__init__.py
+++ b/ycmd/tests/javascript/__init__.py
@@ -40,15 +40,6 @@ def PathToTestFile( *args ):
 
 
 def WaitUntilTernServerReady( app ):
-  app.post_json( '/run_completer_command', BuildRequest(
-    command_arguments = [ 'StartServer' ],
-    completer_target = 'filetype_default',
-    filetype = 'javascript',
-    filepath = '/foo.js',
-    contents = '',
-    line_num = '1'
-  ) )
-
   retries = 100
   while retries > 0:
     result = app.get( '/ready', { 'subserver': 'javascript' } ).json

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -116,12 +116,7 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
   # Restart the server and check that it raises it again
 
   app.post_json( '/run_completer_command',
-                 BuildRequest( command_arguments = [ 'StopServer' ],
-                               filetype = 'javascript',
-                               contents = contents,
-                               completer_target = 'filetype_default' ) )
-  app.post_json( '/run_completer_command',
-                 BuildRequest( command_arguments = [ 'StartServer' ],
+                 BuildRequest( command_arguments = [ 'RestartServer' ],
                                filetype = 'javascript',
                                contents = contents,
                                completer_target = 'filetype_default' ) )

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -45,10 +45,9 @@ def Subcommands_DefinedSubcommands_test( app ):
                  'GoTo',
                  'GetDoc',
                  'GetType',
-                 'StartServer',
-                 'StopServer',
                  'GoToReferences',
-                 'RefactorRename' ] ),
+                 'RefactorRename',
+                 'RestartServer' ] ),
        app.post_json( '/defined_subcommands',
                       subcommands_data ).json )
 

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -104,3 +104,34 @@ def GetCompletions_MaxDetailedCompletion_test( app ):
       } )
     }
   } )
+
+
+@SharedYcmd
+def GetCompletions_AfterRestart_test( app ):
+  filepath = PathToTestFile( 'test.ts' )
+
+  app.post_json( '/run_completer_command',
+                BuildRequest( completer_target = 'filetype_default',
+                              command_arguments = [ 'RestartServer' ],
+                              filetype = 'typescript',
+                              filepath = filepath ) )
+
+  completion_data = BuildRequest( filepath = filepath,
+                                  filetype = 'typescript',
+                                  contents = ReadFile( filepath ),
+                                  force_semantic = True,
+                                  line_num = 17,
+                                  column_num = 6 )
+
+  response = app.post_json( '/completions', completion_data )
+  assert_that( response.json, has_entries( {
+        'completions': contains_inanyorder(
+          CompletionEntryMatcher( 'methodA', extra_params = {
+            'menu_text': 'methodA (method) Foo.methodA(): void' } ),
+          CompletionEntryMatcher( 'methodB', extra_params = {
+            'menu_text': 'methodB (method) Foo.methodB(): void' } ),
+          CompletionEntryMatcher( 'methodC', extra_params = {
+            'menu_text': ( 'methodC (method) Foo.methodC(a: '
+                           '{ foo: string; bar: number; }): void' ) } ),
+        )
+      } ) )


### PR DESCRIPTION
This should cover the first point from https://github.com/Valloric/ycmd/pull/282#issuecomment-220062574

What I did was:
- Remove `StartServer` from completers
- Add `RestartServer` to completers
- Make `StopServer` unavailable to the end user but usable for testing porpuse

This change didn't involve the `Go` completer because I knew that @micbou was working on it.

I'm still not fully convinced about the C# completer, so I'm marking this as WIP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/506)
<!-- Reviewable:end -->
