### PR TITLE
Pipe Omnisharp server output to ycmd logs

### DIFF
--- a/ycmd/tests/cs/initialization_test.py
+++ b/ycmd/tests/cs/initialization_test.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2016 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+import time
+import threading
+from nose.tools import ok_
+
+from ycmd.tests.cs import ( IsolatedYcmd, PathToTestFile, StopOmniSharpServer,
+                            WrapOmniSharpServer )
+
+
+@IsolatedYcmd
+def Initialization_StopServer_NoErrorIfNotStarted_test( app ):
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
+  StopOmniSharpServer( app, filepath )
+  # Success = no raise
+
+
+@IsolatedYcmd
+def Initialization_StopServer_LoggingThreadsStops_test( app ):
+  preexisting_threads = threading.enumerate()
+
+  def has_existing_log_threads( desired_result ):
+    log_thread_name = 'Omnisharp_Log_'
+    for _ in range(0, 10):
+      threads = threading.enumerate()
+      new_threads = [ thread for thread in threads
+                      if not any( [ thread.ident == t.ident
+                                    for t in preexisting_threads ] ) ]
+      has_log_threads = any( [ log_thread_name in thread.name
+                           for thread in new_threads ] )
+      if has_log_threads == desired_result:
+        return desired_result
+      time.sleep( .1 )
+    return not desired_result
+
+  filepath = PathToTestFile( 'testy', 'GetDocTestCase.cs' )
+  # This starts Omnisharp server
+  with WrapOmniSharpServer( app, filepath ):
+    ok_( has_existing_log_threads( True ),
+        "Omnisharp logging threads didn't start" )
+  StopOmniSharpServer( app, filepath )
+
+  ok_( not has_existing_log_threads( False ),
+       "Omnisharp logging threads didn't die" )

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -23,19 +23,13 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-
-from nose.tools import eq_, ok_
+from nose.tools import eq_
 from webtest import AppError
 from hamcrest import assert_that, has_entries, contains
 import pprint
-import re
-import os.path
 
-from ycmd.tests.cs import ( IsolatedYcmd, PathToTestFile, SharedYcmd,
-                            StopOmniSharpServer, WaitUntilOmniSharpServerReady,
-                            WrapOmniSharpServer )
+from ycmd.tests.cs import ( PathToTestFile, SharedYcmd, WrapOmniSharpServer )
 from ycmd.tests.test_utils import ( BuildRequest,
-                                    UserOption,
                                     LocationMatcher,
                                     ChunkMatcher )
 from ycmd.utils import ReadFile
@@ -497,62 +491,3 @@ def Subcommands_FixIt_Unicode_test( app ):
                                         LocationMatcher( filepath, 30, 44 ) ) )
     } ) )
   } ), filepath = [ 'testy', 'Unicode.cs' ] )
-
-
-@IsolatedYcmd
-def Subcommands_StopServer_NoErrorIfNotStarted_test( app ):
-  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
-  StopOmniSharpServer( app, filepath )
-  # Success = no raise
-
-
-@IsolatedYcmd
-def StopServer_KeepLogFiles( app, keeping_log_files ):
-  with UserOption( 'server_keep_logfiles', keeping_log_files ):
-    filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
-    contents = ReadFile( filepath )
-    event_data = BuildRequest( filepath = filepath,
-                               filetype = 'cs',
-                               contents = contents,
-                               event_name = 'FileReadyToParse' )
-
-    app.post_json( '/event_notification', event_data )
-    WaitUntilOmniSharpServerReady( app, filepath )
-
-    event_data = BuildRequest( filetype = 'cs', filepath = filepath )
-
-    debuginfo = app.post_json( '/debug_info', event_data ).json
-
-    log_files_match = re.search( "^OmniSharp logfiles:\n(.*)\n(.*)",
-                                 debuginfo,
-                                 re.MULTILINE )
-    stdout_logfiles_location = log_files_match.group( 1 )
-    stderr_logfiles_location = log_files_match.group( 2 )
-
-    try:
-      ok_( os.path.exists(stdout_logfiles_location ),
-           "Logfile should exist at {0}".format( stdout_logfiles_location ) )
-      ok_( os.path.exists( stderr_logfiles_location ),
-           "Logfile should exist at {0}".format( stderr_logfiles_location ) )
-    finally:
-      StopOmniSharpServer( app, filepath )
-
-    if keeping_log_files:
-      ok_( os.path.exists( stdout_logfiles_location ),
-           "Logfile should still exist at "
-           "{0}".format( stdout_logfiles_location ) )
-      ok_( os.path.exists( stderr_logfiles_location ),
-           "Logfile should still exist at "
-           "{0}".format( stderr_logfiles_location ) )
-    else:
-      ok_( not os.path.exists( stdout_logfiles_location ),
-           "Logfile should no longer exist at "
-           "{0}".format( stdout_logfiles_location ) )
-      ok_( not os.path.exists( stderr_logfiles_location ),
-           "Logfile should no longer exist at "
-           "{0}".format( stderr_logfiles_location ) )
-
-
-def Subcommands_StopServer_KeepLogFiles_test():
-  yield StopServer_KeepLogFiles, True
-  yield StopServer_KeepLogFiles, False

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -25,7 +25,7 @@ from builtins import *  # noqa
 
 from nose.tools import eq_
 from webtest import AppError
-from hamcrest import assert_that, has_entries, contains
+from hamcrest import assert_that, has_entries, contains, contains_string
 import pprint
 
 from ycmd.tests.cs import ( PathToTestFile, SharedYcmd, WrapOmniSharpServer )
@@ -491,3 +491,19 @@ def Subcommands_FixIt_Unicode_test( app ):
                                         LocationMatcher( filepath, 30, 44 ) ) )
     } ) )
   } ), filepath = [ 'testy', 'Unicode.cs' ] )
+
+
+@SharedYcmd
+def Subcommands_DebugInfo_HasOmnisharpLogText_test( app ):
+  filepath = PathToTestFile( 'testy', 'GetDocTestCase.cs' )
+  with WrapOmniSharpServer( app, filepath ):
+    contents = ReadFile( filepath )
+
+    debuginfo_data = BuildRequest( contents = contents,
+                                   filetype = 'cs',
+                                   filepath = filepath )
+
+    debuginfo = app.post_json( '/debug_info', debuginfo_data ).json
+
+    assert_that( debuginfo,
+                 contains_string( 'Omnisharp logs: included in ycmd logs' ) )

--- a/ycmd/tests/misc_handlers_test.py
+++ b/ycmd/tests/misc_handlers_test.py
@@ -71,3 +71,31 @@ def MiscHandlers_FilterAndSortCandidates_Basic_test( app ):
   response_data = app.post_json( '/filter_and_sort_candidates', data ).json
 
   assert_that( response_data, contains( candidate2, candidate3 ) )
+
+
+@SharedYcmd
+def MiscHandlers_IsReady_Basic_test( app ):
+  response_data = app.get( '/ready' ).json
+
+  ok_( response_data  )
+
+
+@SharedYcmd
+def MiscHandlers_IsReady_Subservers_test( app ):
+  response_data = app.get( '/ready', { 'include_subservers': True } ).json
+
+  ok_( response_data  )
+
+
+@SharedYcmd
+def MiscHandlers_IsHealthy_Basic_test( app ):
+  response_data = app.get( '/healthy' ).json
+
+  ok_( response_data  )
+
+
+@SharedYcmd
+def MiscHandlers_IsHealthy_Subservers_test( app ):
+  response_data = app.get( '/healthy', { 'include_subservers': True } ).json
+
+  ok_( response_data  )


### PR DESCRIPTION
Pipe the stdout and stderr of the Omnisharp server to the ycmd logs,
instead of to separate files. This makes tailing the logs easier, and
more importantly, allows seeing the Omnisharp server output in CI
logging output.

This is a change I implemented as part of https://github.com/Valloric/ycmd/pull/213 and was crucial to that implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/507)
<!-- Reviewable:end -->
