### PR TITLE
[READY] Unbreak vagrant config for non-parallels

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,8 +20,8 @@ Vagrant.configure(2) do |config|
     v.cpus = 2
   end
 
-  config.vm.provider "parallels" do |v|
-    config.vm.box = 'parallels/ubuntu-14.04'
+  config.vm.provider "parallels" do |v, override|
+    override.vm.box = 'parallels/ubuntu-14.04'
 
     v.memory = 3072
     v.cpus = 4


### PR DESCRIPTION
The current config has a bug. It wants to set a custom box for the
parallels VM provider but instead it overwrites the global config,
breaking the virtualbox provider (since that one can't use the parallels
box) on box creation.

The correct way to do a per-provider box is with an override param.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/511)
<!-- Reviewable:end -->
