### PR TITLE
[READY] Pass ycmd logging level to JediHTTP

### DIFF
--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -162,6 +162,7 @@ class JediCompleter( Completer ):
         command = [ self._python_binary_path,
                     PATH_TO_JEDIHTTP,
                     '--port', str( self._jedihttp_port ),
+                    '--log', self._GetLoggingLevel(),
                     '--hmac-file-secret', hmac_file.name ]
 
       self._logfile_stdout = LOG_FILENAME_FORMAT.format(
@@ -178,6 +179,13 @@ class JediCompleter( Completer ):
 
   def _GenerateHmacSecret( self ):
     return os.urandom( HMAC_SECRET_LENGTH )
+
+
+  def _GetLoggingLevel( self ):
+    # Tests are run with the NOTSET logging level but JediHTTP only accepts the
+    # predefined levels above (DEBUG, INFO, WARNING, etc.).
+    log_level = max( self._logger.getEffectiveLevel(), logging.DEBUG )
+    return logging.getLevelName( log_level ).lower()
 
 
   def _GetResponse( self, handler, request_data = {} ):


### PR DESCRIPTION
Now that [`JediHTTP` has an option to set its logging level](https://github.com/vheon/JediHTTP/pull/15), we can pass `ycmd` logging level to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/513)
<!-- Reviewable:end -->
