### PR TITLE
[READY] Switch back to GCC on Linux Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,12 +46,11 @@ addons:
      # The Travis apt source whitelist can be found here:
      #   https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
      - ubuntu-toolchain-r-test  # for new libstdc++
-     - llvm-toolchain-precise-3.7  # for clang
      - george-edison55-precise-backports # for a more recent version of cmake (3.2.3)
     packages:
      - cmake-data
      - cmake
-     - clang-3.7
+     - g++-6
      - ninja-build
      # Everything below is a Python build dep (though it depends on Python
      # version). We need them because pyenv builds Python.

--- a/ci/travis/travis_install.linux.sh
+++ b/ci/travis/travis_install.linux.sh
@@ -1,19 +1,12 @@
 # Linux-specific installation
 
 # We can't use sudo, so we have to approximate the behaviour of the following:
-# $ sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.7 100
+# $ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
 
 mkdir ${HOME}/bin
 
-ln -s /usr/bin/clang++-3.7 ${HOME}/bin/clang++
-ln -s /usr/bin/clang-3.7 ${HOME}/bin/clang
-
-ln -s /usr/bin/clang++-3.7 ${HOME}/bin/c++
-ln -s /usr/bin/clang-3.7 ${HOME}/bin/cc
-
-# These shouldn't be necessary, but just in case.
-ln -s /usr/bin/clang++-3.7 ${HOME}/bin/g++
-ln -s /usr/bin/clang-3.7 ${HOME}/bin/gcc
+ln -s /usr/bin/g++-6 ${HOME}/bin/c++
+ln -s /usr/bin/gcc-6 ${HOME}/bin/cc
 
 export PATH=${HOME}/bin:${PATH}
 


### PR DESCRIPTION
Since [LLVM APT repository is not available anymore](http://lists.llvm.org/pipermail/llvm-dev/2016-May/100303.html) and we were using it to install Clang and build ycmd with it, we go back to GCC to make the tests pass again on Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/514)
<!-- Reviewable:end -->
