### PR TITLE
[READY] Use equality instead of identity when checking the status response in Rust completer

### DIFF
--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -172,7 +172,7 @@ class RustCompleter( Completer ):
 
     response.raise_for_status()
 
-    if response.status_code is http.client.NO_CONTENT:
+    if response.status_code == http.client.NO_CONTENT:
       return None
 
     return response.json()


### PR DESCRIPTION
`http.client.NO_CONTENT` is an enumeration member while `response.status_code` is an int so we need to use an equality instead of an identity.

Added a test for when racerd returns a no content response.

On a side note, I think we should use [`requests.codes` instead of `http.client`](http://docs.python-requests.org/en/master/user/quickstart/?highlight=status_code#response-status-codes) in these situations. This would prevent this kind of issue (`requests.codes.no_content` is an int) and we would not have to import the `http.client` module. If you agree, I'll send a PR replacing all `http.client` occurences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/521)
<!-- Reviewable:end -->
