### PR TITLE
[READY] Use HTTP status codes from requests module instead of http one

### DIFF
--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -24,7 +24,6 @@ from future.utils import iterkeys
 from future import standard_library
 standard_library.install_aliases()
 
-import http.client
 import logging
 import os
 import requests
@@ -269,7 +268,7 @@ class TernCompleter( Completer ):
     try:
       target = self._GetServerAddress() + '/ping'
       response = requests.get( target )
-      return response.status_code == http.client.OK
+      return response.status_code == requests.codes.ok
     except requests.ConnectionError:
       return False
 
@@ -321,7 +320,7 @@ class TernCompleter( Completer ):
     response = requests.post( self._GetServerAddress(),
                               json = full_request )
 
-    if response.status_code != http.client.OK:
+    if response.status_code != requests.codes.ok:
       raise RuntimeError( response.text )
 
     return response.json()

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -31,7 +31,6 @@ from ycmd import responses, utils, hmac_utils
 import logging
 import urllib.parse
 import requests
-import http.client
 import json
 import tempfile
 import base64
@@ -172,7 +171,7 @@ class RustCompleter( Completer ):
 
     response.raise_for_status()
 
-    if response.status_code == http.client.NO_CONTENT:
+    if response.status_code == requests.codes.no_content:
       return None
 
     return response.json()

--- a/ycmd/hmac_plugin.py
+++ b/ycmd/hmac_plugin.py
@@ -24,7 +24,7 @@ standard_library.install_aliases()
 from builtins import *  # noqa
 
 import logging
-import http.client
+import requests
 from urllib.parse import urlparse
 from base64 import b64decode, b64encode
 from bottle import request, abort
@@ -59,7 +59,7 @@ class HmacPlugin( object ):
     def wrapper( *args, **kwargs ):
       if not HostHeaderCorrect( request ):
         self._logger.info( 'Dropping request with bad Host header.' )
-        abort( http.client.UNAUTHORIZED,
+        abort( requests.codes.unauthorized,
                'Unauthorized, received bad Host header.' )
         return
 
@@ -67,7 +67,7 @@ class HmacPlugin( object ):
       if not RequestAuthenticated( request.method, request.path, body,
                                    self._hmac_secret ):
         self._logger.info( 'Dropping request with bad HMAC.' )
-        abort( http.client.UNAUTHORIZED, 'Unauthorized, received bad HMAC.' )
+        abort( requests.codes.unauthorized, 'Unauthorized, received bad HMAC.' )
         return
       body = callback( *args, **kwargs )
       SetHmacHeader( body, self._hmac_secret )

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -26,12 +26,11 @@ standard_library.install_aliases()
 from builtins import *  # noqa
 
 import json
-
+import requests
 from nose.tools import eq_
 from hamcrest import ( assert_that, contains, contains_inanyorder, empty,
                        has_item, has_items, has_entry, has_entries,
                        contains_string )
-import http.client
 
 from ycmd.completers.cpp.clang_completer import NO_COMPLETIONS_MESSAGE
 from ycmd.responses import UnknownExtraConf, NoExtraConfDetected
@@ -57,7 +56,7 @@ def RunTest( app, test ):
   test is a dictionary containing:
     'request': kwargs for BuildRequest
     'expect': {
-       'response': server response code (e.g. httplib.OK)
+       'response': server response code (e.g. requests.codes.ok)
        'data': matcher for the server response json
     }
     'extra_conf': [ optional list of path items to extra conf file ]
@@ -119,7 +118,7 @@ def GetCompletions_ForcedWithNoTrigger_test( app ):
       'force_semantic': True,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains(
           CompletionEntryMatcher( 'DO_SOMETHING_TO', 'void' ),
@@ -145,7 +144,7 @@ def GetCompletions_Fallback_NoSuggestions_test( app ):
       'force_semantic': False,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': empty(),
         'errors': has_item( NO_COMPLETIONS_ERROR ),
@@ -170,7 +169,7 @@ def GetCompletions_Fallback_NoSuggestions_MinimumCharaceters_test( app ):
       'force_semantic': False,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': empty(),
         'errors': has_item( NO_COMPLETIONS_ERROR ),
@@ -193,7 +192,7 @@ def GetCompletions_Fallback_Suggestions_test( app ):
       'force_semantic': False,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': has_item( CompletionEntryMatcher( 'a_parameter',
                                                          '[ID]' ) ),
@@ -218,7 +217,7 @@ def GetCompletions_Fallback_Exception_test( app ):
       'force_semantic': False,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains(
           CompletionEntryMatcher( 'a_parameter', '[ID]' ),
@@ -244,7 +243,7 @@ def GetCompletions_Forced_NoFallback_test( app ):
       'force_semantic': True,
     },
     'expect': {
-      'response': http.client.INTERNAL_SERVER_ERROR,
+      'response': requests.codes.internal_server_error,
       'data': NO_COMPLETIONS_ERROR,
     },
   } )
@@ -269,7 +268,7 @@ def GetCompletions_FilteredNoResults_Fallback_test( app ):
       'force_semantic': False,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains_inanyorder(
           # do_ is an identifier because it is already in the file when we
@@ -364,7 +363,7 @@ def GetCompletions_UnknownExtraConfException_test( app ):
                             completion_data,
                             expect_errors = True )
 
-  eq_( response.status_code, http.client.INTERNAL_SERVER_ERROR )
+  eq_( response.status_code, requests.codes.internal_server_error )
   assert_that( response.json,
                has_entry( 'exception',
                           has_entry( 'TYPE', UnknownExtraConf.__name__ ) ) )
@@ -377,7 +376,7 @@ def GetCompletions_UnknownExtraConfException_test( app ):
                             completion_data,
                             expect_errors = True )
 
-  eq_( response.status_code, http.client.INTERNAL_SERVER_ERROR )
+  eq_( response.status_code, requests.codes.internal_server_error )
   assert_that( response.json,
                has_entry( 'exception',
                           has_entry( 'TYPE',
@@ -423,7 +422,7 @@ def GetCompletions_ExceptionWhenNoFlagsFromExtraConf_test( app ):
   response = app.post_json( '/completions',
                             completion_data,
                             expect_errors = True )
-  eq_( response.status_code, http.client.INTERNAL_SERVER_ERROR )
+  eq_( response.status_code, requests.codes.internal_server_error )
 
   assert_that( response.json,
                has_entry( 'exception',
@@ -522,7 +521,7 @@ def GetCompletions_UnicodeInLine_test( app ):
       'extra_conf_data': { '&filetype': 'cpp' },
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completion_start_column': 8,
         'completions': contains_inanyorder(
@@ -554,7 +553,7 @@ def GetCompletions_UnicodeInLineFilter_test( app ):
       'extra_conf_data': { '&filetype': 'cpp' },
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completion_start_column': 8,
         'completions': contains_inanyorder(

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -30,7 +30,7 @@ from hamcrest import ( assert_that, calling, contains, equal_to,
 from nose.tools import eq_
 from pprint import pprint
 from webtest import AppError
-import http.client
+import requests
 import os.path
 
 from ycmd.completers.cpp.clang_completer import NO_DOCUMENTATION_MESSAGE
@@ -841,7 +841,7 @@ def Subcommands_GetDoc_Undocumented_test( app ):
                             event_data,
                             expect_errors = True )
 
-  eq_( response.status_code, http.client.INTERNAL_SERVER_ERROR )
+  eq_( response.status_code, requests.codes.internal_server_error )
 
   assert_that( response.json,
                ErrorMatcher( ValueError, NO_DOCUMENTATION_MESSAGE ) )
@@ -865,7 +865,7 @@ def Subcommands_GetDoc_NoCursor_test( app ):
                             event_data,
                             expect_errors = True )
 
-  eq_( response.status_code, http.client.INTERNAL_SERVER_ERROR )
+  eq_( response.status_code, requests.codes.internal_server_error )
 
   assert_that( response.json,
                ErrorMatcher( ValueError, NO_DOCUMENTATION_MESSAGE ) )
@@ -1016,7 +1016,7 @@ def Subcommands_GetDocQuick_Undocumented_test( app ):
                             event_data,
                             expect_errors = True )
 
-  eq_( response.status_code, http.client.INTERNAL_SERVER_ERROR )
+  eq_( response.status_code, requests.codes.internal_server_error )
 
   assert_that( response.json,
                ErrorMatcher( ValueError, NO_DOCUMENTATION_MESSAGE ) )
@@ -1049,7 +1049,7 @@ def Subcommands_GetDocQuick_NoCursor_test( app ):
                             event_data,
                             expect_errors = True )
 
-  eq_( response.status_code, http.client.INTERNAL_SERVER_ERROR )
+  eq_( response.status_code, requests.codes.internal_server_error )
 
   assert_that( response.json,
                ErrorMatcher( ValueError, NO_DOCUMENTATION_MESSAGE ) )

--- a/ycmd/tests/diagnostics_test.py
+++ b/ycmd/tests/diagnostics_test.py
@@ -26,7 +26,7 @@ from builtins import *  # noqa
 from hamcrest import assert_that
 from mock import patch
 from nose.tools import eq_
-import http.client
+import requests
 
 from ycmd.responses import NoDiagnosticSupport, BuildDisplayMessageResponse
 from ycmd.tests import SharedYcmd
@@ -45,7 +45,7 @@ def Diagnostics_DoesntWork_test( app ):
                               diag_data,
                               expect_errors = True )
 
-    eq_( response.status_code, http.client.INTERNAL_SERVER_ERROR )
+    eq_( response.status_code, requests.codes.internal_server_error )
     assert_that( response.json, ErrorMatcher( NoDiagnosticSupport ) )
 
 

--- a/ycmd/tests/go/subcommands_test.py
+++ b/ycmd/tests/go/subcommands_test.py
@@ -26,7 +26,7 @@ from builtins import *  # noqa
 from hamcrest import assert_that, has_entries
 from nose.tools import eq_
 from pprint import pformat
-import http.client
+import requests
 
 from ycmd.tests.go import PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import BuildRequest, ErrorMatcher
@@ -85,7 +85,7 @@ def Subcommands_GoTo_Basic( app, goto_command ):
       'filepath': PathToTestFile( 'goto.go' ),
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'filepath': PathToTestFile( 'goto.go' ),
         'line_num': 3,
@@ -111,7 +111,7 @@ def Subcommands_GoTo_Keyword( app, goto_command ):
       'filepath': PathToTestFile( 'goto.go' ),
     },
     'expect': {
-      'response': http.client.INTERNAL_SERVER_ERROR,
+      'response': requests.codes.internal_server_error,
       'data': ErrorMatcher( RuntimeError, 'Can\'t find a definition.' )
     }
   } )
@@ -133,7 +133,7 @@ def Subcommands_GoTo_WindowsNewlines( app, goto_command ):
       'filepath': PathToTestFile( 'win.go' ),
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'filepath': PathToTestFile( 'win.go' ),
         'line_num': 2,

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -27,7 +27,7 @@ from hamcrest import assert_that, empty
 from mock import patch
 from nose.tools import eq_
 from pprint import pformat
-import http.client
+import requests
 import os
 
 from ycmd.tests.test_utils import BuildRequest, ErrorMatcher
@@ -47,7 +47,7 @@ def EventNotification_OnFileReadyToParse_ProjectFile_cwd_test( app ):
                               filetype = 'javascript' ),
                             expect_errors = True)
 
-  eq_( response.status_code, http.client.OK )
+  eq_( response.status_code, requests.codes.ok )
   assert_that( response.json, empty() )
 
 
@@ -63,7 +63,7 @@ def EventNotification_OnFileReadyToParse_ProjectFile_parentdir_test( app ):
                               filetype = 'javascript' ),
                             expect_errors = True)
 
-  eq_( response.status_code, http.client.OK )
+  eq_( response.status_code, requests.codes.ok )
   assert_that( response.json, empty() )
 
 
@@ -86,7 +86,7 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
 
   print( 'event response: {0}'.format( pformat( response.json ) ) )
 
-  eq_( response.status_code, http.client.INTERNAL_SERVER_ERROR )
+  eq_( response.status_code, requests.codes.internal_server_error )
 
   assert_that(
     response.json,
@@ -110,7 +110,7 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
 
   print( 'event response: {0}'.format( pformat( response.json ) ) )
 
-  eq_( response.status_code, http.client.OK )
+  eq_( response.status_code, requests.codes.ok )
   assert_that( response.json, empty() )
 
   # Restart the server and check that it raises it again
@@ -136,7 +136,7 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
 
   print( 'event response: {0}'.format( pformat( response.json ) ) )
 
-  eq_( response.status_code, http.client.INTERNAL_SERVER_ERROR )
+  eq_( response.status_code, requests.codes.internal_server_error )
 
   assert_that(
     response.json,
@@ -165,4 +165,4 @@ def EventNotification_OnFileReadyToParse_UseGlobalConfig_test( app, *args ):
 
   print( 'event response: {0}'.format( pformat( response.json ) ) )
 
-  eq_( response.status_code, http.client.OK )
+  eq_( response.status_code, requests.codes.ok )

--- a/ycmd/tests/javascript/get_completions_test.py
+++ b/ycmd/tests/javascript/get_completions_test.py
@@ -27,7 +27,7 @@ from hamcrest import ( assert_that, contains, contains_inanyorder, empty,
                        has_entries )
 from nose.tools import eq_
 from pprint import pformat
-import http.client
+import requests
 
 from ycmd.tests.javascript import PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import BuildRequest, CompletionEntryMatcher
@@ -101,7 +101,7 @@ def GetCompletions_NoQuery_test( app ):
       'column_num': 43,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains_inanyorder(
           CompletionEntryMatcher( 'a_simple_function',
@@ -135,7 +135,7 @@ def GetCompletions_Query_test( app ):
       'column_num': 45,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains(
           CompletionEntryMatcher( 'basic_type', 'number' ),
@@ -159,7 +159,7 @@ def GetCompletions_Require_NoQuery_test( app ):
       'column_num': 15,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains_inanyorder(
           CompletionEntryMatcher( 'mine_bitcoin',
@@ -195,7 +195,7 @@ def GetCompletions_Require_Query_test( app ):
       'column_num': 17,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains(
           CompletionEntryMatcher( 'mine_bitcoin',
@@ -219,7 +219,7 @@ def GetCompletions_Require_Query_LCS_test( app ):
       'column_num': 17,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains(
           CompletionEntryMatcher( 'get_number', 'number' ),
@@ -254,7 +254,7 @@ def GetCompletions_DirtyNamedBuffers_test( app ):
       },
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains_inanyorder(
           CompletionEntryMatcher( 'big_endian_node', 'number' ),
@@ -286,7 +286,7 @@ def GetCompletions_ReturnsDocsInCompletions_test( app ):
       'column_num': 15,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains_inanyorder(
           CompletionEntryMatcher(
@@ -422,7 +422,7 @@ def GetCompletions_Unicode_AfterLine_test( app ):
       'column_num': 16,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains_inanyorder(
           CompletionEntryMatcher( 'charAt', 'fn(i: number) -> string' ),
@@ -446,7 +446,7 @@ def GetCompletions_Unicode_InLine_test( app ):
       'column_num': 18,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains_inanyorder(
           CompletionEntryMatcher( 'charAt', 'fn(i: number) -> string' ),
@@ -470,7 +470,7 @@ def GetCompletions_Unicode_InFile_test( app ):
       'column_num': 16,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains_inanyorder(
           CompletionEntryMatcher( 'charAt', 'fn(i: number) -> string' ),

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -27,7 +27,7 @@ from builtins import *  # noqa
 from hamcrest import assert_that, contains, contains_inanyorder, has_entries
 from nose.tools import eq_
 from pprint import pformat
-import http.client
+import requests
 
 from ycmd.tests.javascript import IsolatedYcmd, PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import ( BuildRequest,
@@ -105,7 +105,7 @@ def Subcommands_GoToDefinition_test( app ):
       'filepath': PathToTestFile( 'simple_test.js' ),
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'filepath': PathToTestFile( 'simple_test.js' ),
         'line_num': 1,
@@ -126,7 +126,7 @@ def Subcommands_GoToDefinition_Unicode_test( app ):
       'filepath': PathToTestFile( 'unicode.js' ),
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'filepath': PathToTestFile( 'unicode.js' ),
         'line_num': 6,
@@ -147,7 +147,7 @@ def Subcommands_GoTo_test( app ):
       'filepath': PathToTestFile( 'simple_test.js' ),
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'filepath': PathToTestFile( 'simple_test.js' ),
         'line_num': 1,
@@ -168,7 +168,7 @@ def Subcommands_GetDoc_test( app ):
       'filepath': PathToTestFile( 'coollib', 'cool_object.js' ),
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'detailed_info': (
           'Name: mine_bitcoin\n'
@@ -192,7 +192,7 @@ def Subcommands_GetType_test( app ):
       'filepath': PathToTestFile( 'coollib', 'cool_object.js' ),
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'message': 'number'
       } )
@@ -211,7 +211,7 @@ def Subcommands_GoToReferences_test( app ):
       'filepath': PathToTestFile( 'coollib', 'cool_object.js' ),
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': contains_inanyorder(
         has_entries( {
           'filepath': PathToTestFile( 'coollib', 'cool_object.js' ),
@@ -239,7 +239,7 @@ def Subcommands_GoToReferences_Unicode_test( app ):
       'filepath': PathToTestFile( 'unicode.js' ),
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': contains_inanyorder(
         has_entries( {
           'filepath': PathToTestFile( 'unicode.js' ),
@@ -272,7 +272,7 @@ def Subcommands_GetDocWithNoItendifier_test( app ):
       'column_num': 1,
     },
     'expect': {
-      'response': http.client.INTERNAL_SERVER_ERROR,
+      'response': requests.codes.internal_server_error,
       'data': ErrorMatcher( RuntimeError, 'TernError: No type found '
                                           'at the given position.' ),
     }
@@ -292,7 +292,7 @@ def Subcommands_RefactorRename_Simple_test( app ):
       'column_num': 32,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries ( {
         'fixits': contains( has_entries( {
           'chunks': contains(
@@ -340,7 +340,7 @@ def Subcommands_RefactorRename_MultipleFiles_test( app ):
       'column_num': 14,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries ( {
         'fixits': contains( has_entries( {
           'chunks': contains(
@@ -401,7 +401,7 @@ def Subcommands_RefactorRename_MultipleFiles_OnFileReadyToParse_test( app ):
       'column_num': 14,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'fixits': contains( has_entries( {
           'chunks': contains(
@@ -444,7 +444,7 @@ def Subcommands_RefactorRename_Missing_New_Name_test( app ):
       'filepath': PathToTestFile( 'coollib', 'cool_object.js' ),
     },
     'expect': {
-      'response': http.client.INTERNAL_SERVER_ERROR,
+      'response': requests.codes.internal_server_error,
       'data': ErrorMatcher( ValueError,
                             'Please specify a new name to rename it to.\n'
                             'Usage: RefactorRename <new name>' ),
@@ -465,7 +465,7 @@ def Subcommands_RefactorRename_Unicode_test( app ):
       'column_num': 3,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries ( {
         'fixits': contains( has_entries( {
           'chunks': contains(

--- a/ycmd/tests/python/get_completions_test.py
+++ b/ycmd/tests/python/get_completions_test.py
@@ -28,11 +28,12 @@ from builtins import *  # noqa
 from nose.tools import eq_
 from hamcrest import ( assert_that, has_item, has_items, has_entry,
                        has_entries, contains, empty, contains_string )
+import requests
+
 from ycmd.utils import ReadFile
 from ycmd.tests.python import PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import ( BuildRequest, CompletionEntryMatcher,
                                     CompletionLocationMatcher )
-import http.client
 
 
 @SharedYcmd
@@ -127,7 +128,7 @@ def GetCompletions_NoSuggestions_Fallback_test( app ):
       'force_semantic': False,
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains(
           CompletionEntryMatcher( 'a_parameter', '[ID]' ),
@@ -150,7 +151,7 @@ def GetCompletions_Unicode_InLine_test( app ):
       'column_num': 14
     },
     'expect': {
-      'response': http.client.OK,
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains(
           CompletionEntryMatcher( 'center', 'function: builtins.str.center' )


### PR DESCRIPTION
See [the requests documentation](http://docs.python-requests.org/en/master/user/quickstart/?highlight=status_code#response-status-codes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/523)
<!-- Reviewable:end -->
