### PR TITLE
[READY] Update flake8 requirement for tests and fix issue reported by the new version

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-flake8>=2.5.2
+flake8>=2.6.0
 mock>=1.3.0
 nose>=1.3.7
 PyHamcrest>=1.8.5

--- a/ycmd/tests/go/__init__.py
+++ b/ycmd/tests/go/__init__.py
@@ -25,6 +25,7 @@ from builtins import *  # noqa
 
 import functools
 import os
+import time
 
 from ycmd import handlers
 from ycmd.tests.test_utils import BuildRequest, ClearCompletionsCache, SetUpApp


### PR DESCRIPTION
flake8 2.6.0 adds a new [check](https://gitlab.com/pycqa/flake8/blob/master/docs/warnings.rst):
> F405: `name` may be undefined, or defined from star imports: `module`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/526)
<!-- Reviewable:end -->
