### PR TITLE
[READY] Fix failing unicode test

### DIFF
--- a/ycmd/tests/filename_completer_test.py
+++ b/ycmd/tests/filename_completer_test.py
@@ -26,6 +26,7 @@ standard_library.install_aliases()
 from builtins import *  # noqa
 
 import os
+from hamcrest import assert_that, contains_inanyorder
 from nose.tools import eq_
 from ycmd.completers.general.filename_completer import FilenameCompleter
 from ycmd.request_wrap import RequestWrap
@@ -329,8 +330,10 @@ class FilenameCompleter_test( object ):
                    1 + # 0-based offset of ∂
                    1 ) # Make it 1-based
     eq_( True, self._ShouldUseNowForLine( contents, column_num = column_num ) )
-    eq_( [ ( 'inner_dir', '[Dir]' ), ( '∂†∫', '[Dir]' ) ],
-         self._CompletionResultsForLine( contents, column_num = column_num ) )
+    assert_that( self._CompletionResultsForLine( contents,
+                                                 column_num = column_num ),
+                 contains_inanyorder( ( 'inner_dir', '[Dir]' ),
+                                      ( '∂†∫', '[Dir]' )  ) )
 
 
 def WorkingDir_Use_File_Path_test():


### PR DESCRIPTION
This test seems to pass on some machines but not on others and the
reason is different unicode sort order. The actual order doesn't matter
for the test so we specify that it doesn't matter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/527)
<!-- Reviewable:end -->
