### PR TITLE
[READY] Also checking that rust_src_path exists

### DIFF
--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -60,8 +60,8 @@ BINARY_NOT_FOUND_MESSAGE = ( 'racerd binary not found. Did you build it? ' +
                              '"./build.py --racer-completer".' )
 ERROR_FROM_RACERD_MESSAGE = (
   'Received error from racerd while retrieving completions. You did not '
-  'set the rust_src_path option, which is probably causing this issue. '
-  'See YCM docs for details.'
+  'set the rust_src_path option (or you did, but the path doesn\'t exist), '
+  'which is probably causing this issue. See YCM docs for details.'
 )
 
 
@@ -237,7 +237,8 @@ class RustCompleter( Completer ):
     try:
       completions = self._FetchCompletions( request_data )
     except requests.HTTPError:
-      if not self._rust_source_path:
+      if not self._rust_source_path or not os.path.exists(
+          self._rust_source_path ):
         raise RuntimeError( ERROR_FROM_RACERD_MESSAGE )
       raise
 

--- a/ycmd/tests/rust/get_completions_test.py
+++ b/ycmd/tests/rust/get_completions_test.py
@@ -23,11 +23,14 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from hamcrest import assert_that, empty, has_entry, has_items, contains_string
+from hamcrest import assert_that, empty, has_entry, has_items
 from nose.tools import eq_
+from mock import patch
 
+from ycmd.completers.rust.rust_completer import ERROR_FROM_RACERD_MESSAGE
 from ycmd.tests.rust import IsolatedYcmd, PathToTestFile, SharedYcmd
-from ycmd.tests.test_utils import BuildRequest, CompletionEntryMatcher
+from ycmd.tests.test_utils import ( BuildRequest, CompletionEntryMatcher,
+                                    ErrorMatcher )
 from ycmd.utils import ReadFile
 import http.client
 
@@ -71,8 +74,29 @@ def GetCompletions_WhenStandardLibraryCompletionFails_MentionRustSrcPath_test(
                             completion_data,
                             expect_errors = True ).json
   assert_that( response,
-               has_entry( 'message',
-                          contains_string( 'rust_src_path' ) ) )
+               ErrorMatcher( RuntimeError, ERROR_FROM_RACERD_MESSAGE ) )
+
+
+# This test is isolated because it affects the GoTo tests, although it
+# shouldn't.
+@IsolatedYcmd
+@patch.dict( 'os.environ', { 'RUST_SRC_PATH': '/foobar' } )
+def GetCompletions_RustSrcPathSetButDoesntExist_test( app ):
+  filepath = PathToTestFile( 'std_completions.rs' )
+  contents = ReadFile( filepath )
+
+  completion_data = BuildRequest( filepath = filepath,
+                                  filetype = 'rust',
+                                  contents = contents,
+                                  force_semantic = True,
+                                  line_num = 5,
+                                  column_num = 11 )
+
+  response = app.post_json( '/completions',
+                            completion_data,
+                            expect_errors = True ).json
+  assert_that( response,
+               ErrorMatcher( RuntimeError, ERROR_FROM_RACERD_MESSAGE ) )
 
 
 @SharedYcmd


### PR DESCRIPTION
We were only checking that the path was set to something, not that there
was something there. This blows up in the user's face if they have
a common editor config across machines that gets synced but they forget
to actually place the required files in that location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/528)
<!-- Reviewable:end -->
