### PR TITLE
[READY] Check if Rust sources path exists at completer initialization

### DIFF
--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -55,14 +55,16 @@ RACERD_BINARY_DEBUG = p.join( DIR_OF_THIRD_PARTY, 'racerd', 'target',
 RACERD_HMAC_HEADER = 'x-racerd-hmac'
 HMAC_SECRET_LENGTH = 16
 
-BINARY_NOT_FOUND_MESSAGE = ( 'racerd binary not found. Did you build it? ' +
-                             'You can do so by running ' +
-                             '"./build.py --racer-completer".' )
+BINARY_NOT_FOUND_MESSAGE = (
+  'racerd binary not found. Did you build it? '
+  'You can do so by running "./build.py --racer-completer".' )
+NON_EXISTING_RUST_SOURCES_PATH_MESSAGE = (
+  'Rust sources path does not exist. Check the value of the rust_src_path '
+  'option or the RUST_SRC_PATH environment variable.' )
 ERROR_FROM_RACERD_MESSAGE = (
   'Received error from racerd while retrieving completions. You did not '
-  'set the rust_src_path option (or you did, but the path doesn\'t exist), '
-  'which is probably causing this issue. See YCM docs for details.'
-)
+  'set the rust_src_path option, which is probably causing this issue. '
+  'See YCM docs for details.' )
 
 
 def FindRacerdBinary( user_options ):
@@ -110,6 +112,9 @@ class RustCompleter( Completer ):
     if not self._rust_source_path:
       _logger.warning( 'No path provided for the rustc source. Please set the '
                        'rust_src_path option' )
+    elif not p.isdir( self._rust_source_path ):
+      _logger.error( NON_EXISTING_RUST_SOURCES_PATH_MESSAGE )
+      raise RuntimeError( NON_EXISTING_RUST_SOURCES_PATH_MESSAGE )
 
     if not self._racerd:
       _logger.error( BINARY_NOT_FOUND_MESSAGE )
@@ -237,8 +242,7 @@ class RustCompleter( Completer ):
     try:
       completions = self._FetchCompletions( request_data )
     except requests.HTTPError:
-      if not self._rust_source_path or not os.path.exists(
-          self._rust_source_path ):
+      if not self._rust_source_path:
         raise RuntimeError( ERROR_FROM_RACERD_MESSAGE )
       raise
 

--- a/ycmd/tests/rust/__init__.py
+++ b/ycmd/tests/rust/__init__.py
@@ -105,12 +105,11 @@ def IsolatedYcmd( test ):
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
     old_server_state = handlers._server_state
+    app = SetUpApp()
 
     try:
-      app = SetUpApp()
-      WaitUntilRacerdServerReady( app )
       test( app, *args, **kwargs )
-      StopRacerdServer( app )
     finally:
+      StopRacerdServer( app )
       handlers._server_state = old_server_state
   return Wrapper

--- a/ycmd/tests/rust/get_completions_test.py
+++ b/ycmd/tests/rust/get_completions_test.py
@@ -28,7 +28,8 @@ from nose.tools import eq_
 from mock import patch
 
 from ycmd.completers.rust.rust_completer import ERROR_FROM_RACERD_MESSAGE
-from ycmd.tests.rust import IsolatedYcmd, PathToTestFile, SharedYcmd
+from ycmd.tests.rust import ( IsolatedYcmd, PathToTestFile, SharedYcmd,
+                              WaitUntilRacerdServerReady )
 from ycmd.tests.test_utils import ( BuildRequest, CompletionEntryMatcher,
                                     ErrorMatcher )
 from ycmd.utils import ReadFile
@@ -60,6 +61,8 @@ def GetCompletions_Basic_test( app ):
 @IsolatedYcmd
 def GetCompletions_WhenStandardLibraryCompletionFails_MentionRustSrcPath_test(
   app ):
+  WaitUntilRacerdServerReady( app )
+
   filepath = PathToTestFile( 'std_completions.rs' )
   contents = ReadFile( filepath )
 
@@ -82,6 +85,8 @@ def GetCompletions_WhenStandardLibraryCompletionFails_MentionRustSrcPath_test(
 @IsolatedYcmd
 @patch.dict( 'os.environ', { 'RUST_SRC_PATH': '/foobar' } )
 def GetCompletions_RustSrcPathSetButDoesntExist_test( app ):
+  WaitUntilRacerdServerReady( app )
+
   filepath = PathToTestFile( 'std_completions.rs' )
   contents = ReadFile( filepath )
 

--- a/ycmd/tests/rust/get_completions_test.py
+++ b/ycmd/tests/rust/get_completions_test.py
@@ -27,11 +27,12 @@ from hamcrest import assert_that, empty, has_entry, has_items
 from nose.tools import eq_
 from mock import patch
 
-from ycmd.completers.rust.rust_completer import ERROR_FROM_RACERD_MESSAGE
+from ycmd.completers.rust.rust_completer import (
+  ERROR_FROM_RACERD_MESSAGE, NON_EXISTING_RUST_SOURCES_PATH_MESSAGE )
 from ycmd.tests.rust import ( IsolatedYcmd, PathToTestFile, SharedYcmd,
                               WaitUntilRacerdServerReady )
 from ycmd.tests.test_utils import ( BuildRequest, CompletionEntryMatcher,
-                                    ErrorMatcher )
+                                    ErrorMatcher, UserOption )
 from ycmd.utils import ReadFile
 import http.client
 
@@ -80,28 +81,26 @@ def GetCompletions_WhenStandardLibraryCompletionFails_MentionRustSrcPath_test(
                ErrorMatcher( RuntimeError, ERROR_FROM_RACERD_MESSAGE ) )
 
 
-# This test is isolated because it affects the GoTo tests, although it
-# shouldn't.
 @IsolatedYcmd
-@patch.dict( 'os.environ', { 'RUST_SRC_PATH': '/foobar' } )
-def GetCompletions_RustSrcPathSetButDoesntExist_test( app ):
-  WaitUntilRacerdServerReady( app )
+def GetCompletions_NonExistingRustSrcPathFromUserOption_test( app ):
+  with UserOption( 'rust_src_path', '/non/existing/rust/src/path' ):
+    response = app.get( '/ready',
+                        { 'subserver': 'rust' },
+                        expect_errors = True ).json
+    assert_that( response,
+                 ErrorMatcher( RuntimeError,
+                               NON_EXISTING_RUST_SOURCES_PATH_MESSAGE ) )
 
-  filepath = PathToTestFile( 'std_completions.rs' )
-  contents = ReadFile( filepath )
 
-  completion_data = BuildRequest( filepath = filepath,
-                                  filetype = 'rust',
-                                  contents = contents,
-                                  force_semantic = True,
-                                  line_num = 5,
-                                  column_num = 11 )
-
-  response = app.post_json( '/completions',
-                            completion_data,
-                            expect_errors = True ).json
+@IsolatedYcmd
+@patch.dict( 'os.environ', { 'RUST_SRC_PATH': '/non/existing/rust/src/path' } )
+def GetCompletions_NonExistingRustSrcPathFromEnvironmentVariable_test( app ):
+  response = app.get( '/ready',
+                      { 'subserver': 'rust' },
+                      expect_errors = True ).json
   assert_that( response,
-               ErrorMatcher( RuntimeError, ERROR_FROM_RACERD_MESSAGE ) )
+               ErrorMatcher( RuntimeError,
+                             NON_EXISTING_RUST_SOURCES_PATH_MESSAGE ) )
 
 
 @SharedYcmd


### PR DESCRIPTION
This PR is a proof that the changes introduced in PR #528 are not working as expected. By waiting for the racerd server to be ready at the start of the tests instead of waiting in the `IsolatedYcmd` decorator, the `GetCompletions_RustSrcPathSetButDoesntExist` test does not pass the CI runs. The reason is that when calling the `WaitUntilRacerdServerReady` function, the Rust completer is initialized and thus patching the `RUST_SRC_PATH` environment variable has no effect (the `_GetRustSrcPath` method is already called). In other words, the `GetCompletions_RustSrcPathSetButDoesntExist` test in its current state is identical to the `GetCompletions_WhenStandardLibraryCompletionFails_MentionRustSrcPath` one.

When patching `RUST_SRC_PATH` before waiting for racerd, the server will not return an HTTP error but an empty list of completions. I can confirm this by setting the `RUST_SRC_PATH` variable before running Vim, editing the [`std_completions.rs` file from the test](https://github.com/Valloric/ycmd/blob/master/ycmd/tests/rust/testdata/std_completions.rs) and trying to complete the line 5. No error message appears in the status line.

From this, I am suggesting to either revert commit e75ff91fbbeb58cf488bb189815b86def6d995b5 or check for the existence of the Rust sources path when initializing the Rust completer (we could even check if some file exists). I can make these changes in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/530)
<!-- Reviewable:end -->
