### PR TITLE
[READY] Use status code from requests instead of http.client in Rust test

### DIFF
--- a/ycmd/tests/rust/get_completions_test.py
+++ b/ycmd/tests/rust/get_completions_test.py
@@ -32,7 +32,7 @@ from ycmd.tests.rust import IsolatedYcmd, PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import ( BuildRequest, CompletionEntryMatcher,
                                     ErrorMatcher )
 from ycmd.utils import ReadFile
-import http.client
+import requests
 
 
 @SharedYcmd
@@ -113,5 +113,5 @@ def GetCompletions_NoCompletionsFound_test( app ):
 
   response = app.post_json( '/completions', completion_data )
 
-  eq_( response.status_code, http.client.OK )
+  eq_( response.status_code, requests.codes.ok )
   assert_that( response.json, has_entry( 'completions', empty() ) )


### PR DESCRIPTION
See PR #523.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/531)
<!-- Reviewable:end -->
