### PR TITLE
[READY] Uniformize debug informations

### DIFF
--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -333,34 +333,34 @@ class GoCompleter( Completer ):
         return ( 'Go completer debug information:\n'
                  '  Gocode running at: http://{0}\n'
                  '  Gocode process ID: {1}\n'
-                 '  Gocode binary: {2}\n'
+                 '  Gocode executable: {2}\n'
                  '  Gocode logfiles:\n'
                  '    {3}\n'
                  '    {4}\n'
-                 '  Godef binary: {5}'.format( self._gocode_address,
-                                               self._gocode_handle.pid,
-                                               self._gocode_binary_path,
-                                               self._gocode_stdout,
-                                               self._gocode_stderr,
-                                               self._godef_binary_path ) )
+                 '  Godef executable: {5}'.format( self._gocode_address,
+                                                   self._gocode_handle.pid,
+                                                   self._gocode_binary_path,
+                                                   self._gocode_stdout,
+                                                   self._gocode_stderr,
+                                                   self._godef_binary_path ) )
 
       if self._gocode_stdout and self._gocode_stderr:
         return ( 'Go completer debug information:\n'
                  '  Gocode no longer running\n'
-                 '  Gocode binary: {0}\n'
+                 '  Gocode executable: {0}\n'
                  '  Gocode logfiles:\n'
                  '    {1}\n'
                  '    {2}\n'
-                 '  Godef binary: {3}'.format( self._gocode_binary_path,
-                                               self._gocode_stdout,
-                                               self._gocode_stderr,
-                                               self._godef_binary_path ) )
+                 '  Godef executable: {3}'.format( self._gocode_binary_path,
+                                                   self._gocode_stdout,
+                                                   self._gocode_stderr,
+                                                   self._godef_binary_path ) )
 
       return ( 'Go completer debug information:\n'
                '  Gocode is not running\n'
-               '  Gocode binary: {0}\n'
-               '  Godef binary: {1}'.format( self._gocode_binary_path,
-                                             self._godef_binary_path ) )
+               '  Gocode executable: {0}\n'
+               '  Godef executable: {1}'.format( self._gocode_binary_path,
+                                                 self._godef_binary_path ) )
 
 
 def _ComputeOffset( contents, line, column ):

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -47,9 +47,9 @@ BINARY_NOT_FOUND_MESSAGE = ( 'The specified python interpreter {0} ' +
                              'was not found. Did you specify it correctly?' )
 LOG_FILENAME_FORMAT = os.path.join( utils.PathToCreatedTempDir(),
                                     u'jedihttp_{port}_{std}.log' )
-PATH_TO_JEDIHTTP = os.path.join( os.path.abspath( os.path.dirname( __file__ ) ),
-                                 '..', '..', '..',
-                                 'third_party', 'JediHTTP', 'jedihttp.py' )
+PATH_TO_JEDIHTTP = os.path.abspath(
+  os.path.join( os.path.dirname( __file__ ), '..', '..', '..',
+                'third_party', 'JediHTTP', 'jedihttp.py' ) )
 
 
 class JediCompleter( Completer ):
@@ -138,7 +138,9 @@ class JediCompleter( Completer ):
 
       if not self._keep_logfiles:
         utils.RemoveIfExists( self._logfile_stdout )
+        self._logfile_stdout = None
         utils.RemoveIfExists( self._logfile_stderr )
+        self._logfile_stderr = None
 
 
   def _StartServer( self ):
@@ -375,20 +377,38 @@ class JediCompleter( Completer ):
 
 
   def DebugInfo( self, request_data ):
-     with self._server_lock:
-       if self._ServerIsRunning():
-         return ( 'JediHTTP running at 127.0.0.1:{0}\n'
-                  '  python binary: {1}\n'
-                  '  stdout log: {2}\n'
-                  '  stderr log: {3}' ).format( self._jedihttp_port,
-                                                self._python_binary_path,
-                                                self._logfile_stdout,
-                                                self._logfile_stderr )
+    with self._server_lock:
+      if self._ServerIsRunning():
+        return ( 'Python completer debug information:\n'
+                 '  JediHTTP running at: http://127.0.0.1:{0}\n'
+                 '  JediHTTP process ID: {1}\n'
+                 '  JediHTTP executable: {2}\n'
+                 '  JediHTTP logfiles:\n'
+                 '    {3}\n'
+                 '    {4}\n'
+                 '  Python interpreter: {5}'.format(
+                   self._jedihttp_port,
+                   self._jedihttp_phandle.pid,
+                   PATH_TO_JEDIHTTP,
+                   self._logfile_stdout,
+                   self._logfile_stderr,
+                   self._python_binary_path ) )
 
-       if self._logfile_stdout and self._logfile_stderr:
-         return ( 'JediHTTP is no longer running\n'
-                  '  stdout log: {0}\n'
-                  '  stderr log: {1}' ).format( self._logfile_stdout,
-                                                self._logfile_stderr )
+      if self._logfile_stdout and self._logfile_stderr:
+        return ( 'Python completer debug information:\n'
+                 '  JediHTTP no longer running\n'
+                 '  JediHTTP executable: {0}\n'
+                 '  JediHTTP logfiles:\n'
+                 '    {1}\n'
+                 '    {2}\n'
+                 '  Python interpreter: {3}'.format(
+                   PATH_TO_JEDIHTTP,
+                   self._logfile_stdout,
+                   self._logfile_stderr,
+                   self._python_binary_path ) )
 
-       return 'JediHTTP is not running'
+      return ( 'Python completer debug information:\n'
+               '  JediHTTP is not running\n'
+               '  JediHTTP executable: {0}\n'
+               '  Python interpreter: {1}'.format( PATH_TO_JEDIHTTP,
+                                                   self._python_binary_path ) )

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -543,17 +543,23 @@ class TypeScriptCompleter( Completer ):
   def DebugInfo( self, request_data ):
     with self._server_lock:
       if self._ServerIsRunning():
-        return ( 'Typescript completer debug informations:\n'
+        return ( 'TypeScript completer debug information:\n'
+                 '  TSServer running\n'
                  '  TSServer process ID: {0}\n'
-                 '  TSServer logfile: {1}' ).format( self._tsserver_handle.pid,
-                                                     self._logfile )
+                 '  TSServer executable: {1}\n'
+                 '  TSServer logfile: {2}'.format( self._tsserver_handle.pid,
+                                                   self._binary_path,
+                                                   self._logfile ) )
       if self._logfile:
-        return ( 'Typescript completer debug informations:\n'
-                 '  TSServer is not running\n'
-                 '  TSServer logfile: {0}' ).format( self._logfile )
+        return ( 'TypeScript completer debug information:\n'
+                 '  TSServer no longer running\n'
+                 '  TSServer executable: {0}\n'
+                 '  TSServer logfile: {1}'.format( self._binary_path,
+                                                   self._logfile ) )
 
-      return ( 'Typescript completer debug informations:\n'
-                '  TSServer is not running' )
+      return ( 'TypeScript completer debug information:\n'
+               '  TSServer is not running\n'
+               '  TSServer executable: {0}'.format( self._binary_path ) )
 
 
 def _LogFileName():

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -211,7 +211,7 @@ def DebugInfo():
   request_data = RequestWrap( request.json )
   try:
     output.append(
-        _GetCompleterForRequestData( request_data ).DebugInfo( request_data) )
+        _GetCompleterForRequestData( request_data ).DebugInfo( request_data ) )
   except Exception:
     _logger.debug( 'Exception in debug info request: '
                    + traceback.format_exc() )

--- a/ycmd/tests/clang/debug_info_test.py
+++ b/ycmd/tests/clang/debug_info_test.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2016 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from hamcrest import assert_that, contains_string, matches_regexp
+
+from ycmd.tests.clang import IsolatedYcmd, PathToTestFile, SharedYcmd
+from ycmd.tests.test_utils import BuildRequest
+
+
+@SharedYcmd
+def DebugInfo_ExtraConfLoaded_test( app ):
+  app.post_json( '/load_extra_conf_file',
+                 { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
+  request_data = BuildRequest( filepath = PathToTestFile( 'basic.cpp' ),
+                               filetype = 'cpp' )
+  assert_that(
+    app.post_json( '/debug_info', request_data ).json,
+    matches_regexp( 'C-family completer debug information:\n'
+                    '  Configuration file found and loaded\n'
+                    '  Configuration path: .+\n'
+                    '  Flags: .+' ) )
+
+
+@SharedYcmd
+def DebugInfo_NoExtraConfFound_test( app ):
+  request_data = BuildRequest( filetype = 'cpp' )
+  # First time, an exception is raised when no .ycm_extra_conf.py file is found.
+  assert_that(
+    app.post_json( '/debug_info', request_data ).json,
+    contains_string( 'C-family completer debug information:\n'
+                     '  No configuration file found' ) )
+  # Second time, None is returned as the .ycm_extra_conf.py path.
+  assert_that(
+    app.post_json( '/debug_info', request_data ).json,
+    contains_string( 'C-family completer debug information:\n'
+                     '  No configuration file found' ) )
+
+
+@IsolatedYcmd
+def DebugInfo_ExtraConfFoundButNotLoaded_test( app ):
+  request_data = BuildRequest( filepath = PathToTestFile( 'basic.cpp' ),
+                               filetype = 'cpp' )
+  assert_that(
+    app.post_json( '/debug_info', request_data ).json,
+    matches_regexp(
+      'C-family completer debug information:\n'
+      '  Configuration file found but not loaded\n'
+      '  Configuration path: .+' ) )

--- a/ycmd/tests/cs/debug_info_test.py
+++ b/ycmd/tests/cs/debug_info_test.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2016 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from hamcrest import assert_that, matches_regexp
+
+from ycmd.tests.cs import IsolatedYcmd, PathToTestFile, SharedYcmd
+from ycmd.tests.test_utils import ( BuildRequest, StopCompleterServer,
+                                    UserOption, WaitUntilCompleterServerReady )
+from ycmd.utils import ReadFile
+
+
+@SharedYcmd
+def DebugInfo_ServerIsRunning_test( app ):
+  filepath = PathToTestFile( 'testy', 'Program.cs' )
+  contents = ReadFile( filepath )
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'cs',
+                             contents = contents,
+                             event_name = 'FileReadyToParse' )
+
+  app.post_json( '/event_notification', event_data )
+  WaitUntilCompleterServerReady( app, 'cs' )
+
+  request_data = BuildRequest( filepath = filepath,
+                               filetype = 'cs' )
+  assert_that(
+    app.post_json( '/debug_info', request_data ).json,
+    matches_regexp( 'C# completer debug information:\n'
+                    '  OmniSharp running at: http://localhost:\d+\n'
+                    '  OmniSharp process ID: \d+\n'
+                    '  OmniSharp executable: .+\n'
+                    '  OmniSharp logfiles:\n'
+                    '    .+\n'
+                    '    .+\n'
+                    '  OmniSharp solution: .+' ) )
+
+
+@SharedYcmd
+def DebugInfo_ServerIsNotRunning_NoSolution_test( app ):
+  request_data = BuildRequest( filetype = 'cs' )
+  assert_that(
+    app.post_json( '/debug_info', request_data ).json,
+    matches_regexp( 'C# completer debug information:\n'
+                    '  OmniSharp not running\n'
+                    '  OmniSharp executable: .+\n'
+                    '  OmniSharp solution: not found' ) )
+
+
+@IsolatedYcmd
+def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
+  with UserOption( 'server_keep_logfiles', True ):
+    filepath = PathToTestFile( 'testy', 'Program.cs' )
+    contents = ReadFile( filepath )
+    event_data = BuildRequest( filepath = filepath,
+                               filetype = 'cs',
+                               contents = contents,
+                               event_name = 'FileReadyToParse' )
+
+    app.post_json( '/event_notification', event_data )
+    WaitUntilCompleterServerReady( app, 'cs' )
+
+    StopCompleterServer( app, 'cs', filepath )
+    request_data = BuildRequest( filepath = filepath,
+                                 filetype = 'cs' )
+    assert_that(
+      app.post_json( '/debug_info', request_data ).json,
+      matches_regexp( 'C# completer debug information:\n'
+                      '  OmniSharp no longer running\n'
+                      '  OmniSharp executable: .+\n'
+                      '  OmniSharp logfiles:\n'
+                      '    .+\n'
+                      '    .+\n'
+                      '  OmniSharp solution: .+' ) )
+
+
+@IsolatedYcmd
+def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
+  with UserOption( 'server_keep_logfiles', False ):
+    filepath = PathToTestFile( 'testy', 'Program.cs' )
+    contents = ReadFile( filepath )
+    event_data = BuildRequest( filepath = filepath,
+                               filetype = 'cs',
+                               contents = contents,
+                               event_name = 'FileReadyToParse' )
+
+    app.post_json( '/event_notification', event_data )
+    WaitUntilCompleterServerReady( app, 'cs' )
+
+    StopCompleterServer( app, 'cs', filepath )
+    request_data = BuildRequest( filepath = filepath,
+                                 filetype = 'cs' )
+    assert_that(
+      app.post_json( '/debug_info', request_data ).json,
+      matches_regexp( 'C# completer debug information:\n'
+                      '  OmniSharp is not running\n'
+                      '  OmniSharp executable: .+\n'
+                      '  OmniSharp solution: .+' ) )

--- a/ycmd/tests/go/__init__.py
+++ b/ycmd/tests/go/__init__.py
@@ -25,10 +25,11 @@ from builtins import *  # noqa
 
 import functools
 import os
-import time
 
 from ycmd import handlers
-from ycmd.tests.test_utils import BuildRequest, ClearCompletionsCache, SetUpApp
+from ycmd.tests.test_utils import ( ClearCompletionsCache, SetUpApp,
+                                    StopCompleterServer,
+                                    WaitUntilCompleterServerReady )
 
 shared_app = None
 
@@ -36,27 +37,6 @@ shared_app = None
 def PathToTestFile( *args ):
   dir_of_current_script = os.path.dirname( os.path.abspath( __file__ ) )
   return os.path.join( dir_of_current_script, 'testdata', *args )
-
-
-def StopGoCodeServer( app ):
-  app.post_json( '/run_completer_command',
-                 BuildRequest( completer_target = 'filetype_default',
-                               command_arguments = [ 'StopServer' ],
-                               filetype = 'go' ) )
-
-
-def WaitUntilGoCodeServerReady( app ):
-  retries = 100
-
-  while retries > 0:
-    result = app.get( '/ready', { 'subserver': 'go' } ).json
-    if result:
-      return
-
-    time.sleep( 0.2 )
-    retries = retries - 1
-
-  raise RuntimeError( 'Timeout waiting for GoCode' )
 
 
 def setUpPackage():
@@ -67,13 +47,13 @@ def setUpPackage():
   global shared_app
 
   shared_app = SetUpApp()
-  WaitUntilGoCodeServerReady( shared_app )
+  WaitUntilCompleterServerReady( shared_app, 'go' )
 
 
 def tearDownPackage():
   global shared_app
 
-  StopGoCodeServer( shared_app )
+  StopCompleterServer( shared_app, 'go' )
 
 
 def SharedYcmd( test ):
@@ -101,9 +81,10 @@ def IsolatedYcmd( test ):
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
     old_server_state = handlers._server_state
-
+    app = SetUpApp()
     try:
-      test( SetUpApp(), *args, **kwargs )
+      test( app, *args, **kwargs )
     finally:
+      StopCompleterServer( app, 'go' )
       handlers._server_state = old_server_state
   return Wrapper

--- a/ycmd/tests/javascript/__init__.py
+++ b/ycmd/tests/javascript/__init__.py
@@ -25,10 +25,11 @@ from builtins import *  # noqa
 
 import functools
 import os
-import time
 
 from ycmd import handlers
-from ycmd.tests.test_utils import BuildRequest, ClearCompletionsCache, SetUpApp
+from ycmd.tests.test_utils import ( ClearCompletionsCache, SetUpApp,
+                                    StopCompleterServer,
+                                    WaitUntilCompleterServerReady )
 
 shared_app = None
 shared_current_dir = None
@@ -37,27 +38,6 @@ shared_current_dir = None
 def PathToTestFile( *args ):
   dir_of_current_script = os.path.dirname( os.path.abspath( __file__ ) )
   return os.path.join( dir_of_current_script, 'testdata', *args )
-
-
-def WaitUntilTernServerReady( app ):
-  retries = 100
-  while retries > 0:
-    result = app.get( '/ready', { 'subserver': 'javascript' } ).json
-    if result:
-      return
-
-    time.sleep( 0.2 )
-    retries = retries - 1
-
-  raise RuntimeError( 'Timeout waiting for Tern.js server to be ready' )
-
-
-def StopTernServer( app ):
-  app.post_json( '/run_completer_command',
-                 BuildRequest( completer_target = 'filetype_default',
-                               command_arguments = [ 'StopServer' ],
-                               filetype = 'javascript' ),
-                 expect_errors = True )
 
 
 def setUpPackage():
@@ -70,7 +50,7 @@ def setUpPackage():
   shared_app = SetUpApp()
   shared_current_dir = os.getcwd()
   os.chdir( PathToTestFile() )
-  WaitUntilTernServerReady( shared_app )
+  WaitUntilCompleterServerReady( shared_app, 'javascript' )
 
 
 def tearDownPackage():
@@ -78,7 +58,7 @@ def tearDownPackage():
   executed once after running all the tests in the package."""
   global shared_app, shared_current_dir
 
-  StopTernServer( shared_app )
+  StopCompleterServer( shared_app, 'javascript' )
   os.chdir( shared_current_dir )
 
 
@@ -108,14 +88,12 @@ def IsolatedYcmd( test ):
   def Wrapper( *args, **kwargs ):
     old_server_state = handlers._server_state
     old_current_dir = os.getcwd()
-
+    app = SetUpApp()
+    os.chdir( PathToTestFile() )
     try:
-      os.chdir( PathToTestFile() )
-      app = SetUpApp()
-      WaitUntilTernServerReady( app )
       test( app, *args, **kwargs )
-      StopTernServer( app )
     finally:
+      StopCompleterServer( app, 'javascript' )
       os.chdir( old_current_dir )
       handlers._server_state = old_server_state
   return Wrapper

--- a/ycmd/tests/javascript/debug_info_test.py
+++ b/ycmd/tests/javascript/debug_info_test.py
@@ -25,49 +25,46 @@ from builtins import *  # noqa
 
 from hamcrest import assert_that, matches_regexp
 
-from ycmd.tests.go import IsolatedYcmd, SharedYcmd
+from ycmd.tests.javascript import IsolatedYcmd, SharedYcmd
 from ycmd.tests.test_utils import BuildRequest, StopCompleterServer, UserOption
 
 
 @SharedYcmd
 def DebugInfo_ServerIsRunning_test( app ):
-  request_data = BuildRequest( filetype = 'go' )
+  request_data = BuildRequest( filetype = 'javascript' )
   assert_that(
     app.post_json( '/debug_info', request_data ).json,
-    matches_regexp( 'Go completer debug information:\n'
-                    '  Gocode running at: http://127.0.0.1:\d+\n'
-                    '  Gocode process ID: \d+\n'
-                    '  Gocode executable: .+\n'
-                    '  Gocode logfiles:\n'
+    matches_regexp( 'JavaScript completer debug information:\n'
+                    '  Tern running at: http://127.0.0.1:\d+\n'
+                    '  Tern process ID: \d+\n'
+                    '  Tern executable: .+\n'
+                    '  Tern logfiles:\n'
                     '    .+\n'
-                    '    .+\n'
-                    '  Godef executable: .+' ) )
+                    '    .+' ) )
 
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
   with UserOption( 'server_keep_logfiles', True ):
-    StopCompleterServer( app, 'go' )
-    request_data = BuildRequest( filetype = 'go' )
+    StopCompleterServer( app, 'javascript' )
+    request_data = BuildRequest( filetype = 'javascript' )
     assert_that(
       app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Go completer debug information:\n'
-                      '  Gocode no longer running\n'
-                      '  Gocode executable: .+\n'
-                      '  Gocode logfiles:\n'
+      matches_regexp( 'JavaScript completer debug information:\n'
+                      '  Tern no longer running\n'
+                      '  Tern executable: .+\n'
+                      '  Tern logfiles:\n'
                       '    .+\n'
-                      '    .+\n'
-                      '  Godef executable: .+' ) )
+                      '    .+' ) )
 
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
   with UserOption( 'server_keep_logfiles', False ):
-    StopCompleterServer( app, 'go' )
-    request_data = BuildRequest( filetype = 'go' )
+    StopCompleterServer( app, 'javascript' )
+    request_data = BuildRequest( filetype = 'javascript' )
     assert_that(
       app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Go completer debug information:\n'
-                      '  Gocode is not running\n'
-                      '  Gocode executable: .+\n'
-                      '  Godef executable: .+' ) )
+      matches_regexp( 'JavaScript completer debug information:\n'
+                      '  Tern is not running\n'
+                      '  Tern executable: .+' ) )

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -30,14 +30,16 @@ from pprint import pformat
 import requests
 import os
 
-from ycmd.tests.test_utils import BuildRequest, ErrorMatcher
-from ycmd.tests.javascript import ( IsolatedYcmd, PathToTestFile,
-                                    WaitUntilTernServerReady )
+from ycmd.tests.test_utils import ( BuildRequest, ErrorMatcher,
+                                    WaitUntilCompleterServerReady )
+from ycmd.tests.javascript import IsolatedYcmd, PathToTestFile
 from ycmd.utils import ReadFile
 
 
 @IsolatedYcmd
 def EventNotification_OnFileReadyToParse_ProjectFile_cwd_test( app ):
+  WaitUntilCompleterServerReady( app, 'javascript' )
+
   contents = ReadFile( PathToTestFile( 'simple_test.js' ) )
 
   response = app.post_json( '/event_notification',
@@ -53,6 +55,8 @@ def EventNotification_OnFileReadyToParse_ProjectFile_cwd_test( app ):
 
 @IsolatedYcmd
 def EventNotification_OnFileReadyToParse_ProjectFile_parentdir_test( app ):
+  WaitUntilCompleterServerReady( app, 'javascript' )
+
   os.chdir( PathToTestFile( 'lamelib' ) )
   contents = ReadFile( PathToTestFile( 'simple_test.js' ) )
 
@@ -71,6 +75,8 @@ def EventNotification_OnFileReadyToParse_ProjectFile_parentdir_test( app ):
 @patch( 'ycmd.completers.javascript.tern_completer.GlobalConfigExists',
         return_value = False )
 def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
+  WaitUntilCompleterServerReady( app, 'javascript' )
+
   # We raise an error if we can't detect a .tern-project file.
   # We only do this on the first OnFileReadyToParse event after a
   # server startup.
@@ -121,7 +127,7 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
                                contents = contents,
                                completer_target = 'filetype_default' ) )
 
-  WaitUntilTernServerReady( app )
+  WaitUntilCompleterServerReady( app, 'javascript' )
 
   response = app.post_json( '/event_notification',
                             BuildRequest( event_name = 'FileReadyToParse',
@@ -149,6 +155,8 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
 @patch( 'ycmd.completers.javascript.tern_completer.GlobalConfigExists',
         return_value = True )
 def EventNotification_OnFileReadyToParse_UseGlobalConfig_test( app, *args ):
+  WaitUntilCompleterServerReady( app, 'javascript' )
+
   os.chdir( PathToTestFile( '..' ) )
   contents = ReadFile( PathToTestFile( 'simple_test.js' ) )
 

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -33,7 +33,8 @@ from ycmd.tests.javascript import IsolatedYcmd, PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import ( BuildRequest,
                                     ChunkMatcher,
                                     ErrorMatcher,
-                                    LocationMatcher )
+                                    LocationMatcher,
+                                    WaitUntilCompleterServerReady )
 from ycmd.utils import ReadFile
 
 
@@ -371,6 +372,8 @@ def Subcommands_RefactorRename_MultipleFiles_test( app ):
 # an extra file into tern's project memory)
 @IsolatedYcmd
 def Subcommands_RefactorRename_MultipleFiles_OnFileReadyToParse_test( app ):
+  WaitUntilCompleterServerReady( app, 'javascript' )
+
   file1 = PathToTestFile( 'file1.js' )
   file2 = PathToTestFile( 'file2.js' )
   file3 = PathToTestFile( 'file3.js' )

--- a/ycmd/tests/python/debug_info_test.py
+++ b/ycmd/tests/python/debug_info_test.py
@@ -25,49 +25,49 @@ from builtins import *  # noqa
 
 from hamcrest import assert_that, matches_regexp
 
-from ycmd.tests.go import IsolatedYcmd, SharedYcmd
+from ycmd.tests.python import IsolatedYcmd, SharedYcmd
 from ycmd.tests.test_utils import BuildRequest, StopCompleterServer, UserOption
 
 
 @SharedYcmd
 def DebugInfo_ServerIsRunning_test( app ):
-  request_data = BuildRequest( filetype = 'go' )
+  request_data = BuildRequest( filetype = 'python' )
   assert_that(
     app.post_json( '/debug_info', request_data ).json,
-    matches_regexp( 'Go completer debug information:\n'
-                    '  Gocode running at: http://127.0.0.1:\d+\n'
-                    '  Gocode process ID: \d+\n'
-                    '  Gocode executable: .+\n'
-                    '  Gocode logfiles:\n'
+    matches_regexp( 'Python completer debug information:\n'
+                    '  JediHTTP running at: http://127.0.0.1:\d+\n'
+                    '  JediHTTP process ID: \d+\n'
+                    '  JediHTTP executable: .+\n'
+                    '  JediHTTP logfiles:\n'
                     '    .+\n'
                     '    .+\n'
-                    '  Godef executable: .+' ) )
+                    '  Python interpreter: .+' ) )
 
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
   with UserOption( 'server_keep_logfiles', True ):
-    StopCompleterServer( app, 'go' )
-    request_data = BuildRequest( filetype = 'go' )
+    StopCompleterServer( app, 'python' )
+    request_data = BuildRequest( filetype = 'python' )
     assert_that(
       app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Go completer debug information:\n'
-                      '  Gocode no longer running\n'
-                      '  Gocode executable: .+\n'
-                      '  Gocode logfiles:\n'
+      matches_regexp( 'Python completer debug information:\n'
+                      '  JediHTTP no longer running\n'
+                      '  JediHTTP executable: .+\n'
+                      '  JediHTTP logfiles:\n'
                       '    .+\n'
                       '    .+\n'
-                      '  Godef executable: .+' ) )
+                      '  Python interpreter: .+' ) )
 
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
   with UserOption( 'server_keep_logfiles', False ):
-    StopCompleterServer( app, 'go' )
-    request_data = BuildRequest( filetype = 'go' )
+    StopCompleterServer( app, 'python' )
+    request_data = BuildRequest( filetype = 'python' )
     assert_that(
       app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Go completer debug information:\n'
-                      '  Gocode is not running\n'
-                      '  Gocode executable: .+\n'
-                      '  Godef executable: .+' ) )
+      matches_regexp( 'Python completer debug information:\n'
+                      '  JediHTTP is not running\n'
+                      '  JediHTTP executable: .+\n'
+                      '  Python interpreter: .+' ) )

--- a/ycmd/tests/rust/debug_info_test.py
+++ b/ycmd/tests/rust/debug_info_test.py
@@ -25,49 +25,49 @@ from builtins import *  # noqa
 
 from hamcrest import assert_that, matches_regexp
 
-from ycmd.tests.go import IsolatedYcmd, SharedYcmd
+from ycmd.tests.rust import IsolatedYcmd, SharedYcmd
 from ycmd.tests.test_utils import BuildRequest, StopCompleterServer, UserOption
 
 
 @SharedYcmd
 def DebugInfo_ServerIsRunning_test( app ):
-  request_data = BuildRequest( filetype = 'go' )
+  request_data = BuildRequest( filetype = 'rust' )
   assert_that(
     app.post_json( '/debug_info', request_data ).json,
-    matches_regexp( 'Go completer debug information:\n'
-                    '  Gocode running at: http://127.0.0.1:\d+\n'
-                    '  Gocode process ID: \d+\n'
-                    '  Gocode executable: .+\n'
-                    '  Gocode logfiles:\n'
+    matches_regexp( 'Rust completer debug information:\n'
+                    '  Racerd running at: http://127.0.0.1:\d+\n'
+                    '  Racerd process ID: \d+\n'
+                    '  Racerd executable: .+\n'
+                    '  Racerd logfiles:\n'
                     '    .+\n'
                     '    .+\n'
-                    '  Godef executable: .+' ) )
+                    '  Rust sources: .+' ) )
 
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
   with UserOption( 'server_keep_logfiles', True ):
-    StopCompleterServer( app, 'go' )
-    request_data = BuildRequest( filetype = 'go' )
+    StopCompleterServer( app, 'rust' )
+    request_data = BuildRequest( filetype = 'rust' )
     assert_that(
       app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Go completer debug information:\n'
-                      '  Gocode no longer running\n'
-                      '  Gocode executable: .+\n'
-                      '  Gocode logfiles:\n'
+      matches_regexp( 'Rust completer debug information:\n'
+                      '  Racerd no longer running\n'
+                      '  Racerd executable: .+\n'
+                      '  Racerd logfiles:\n'
                       '    .+\n'
                       '    .+\n'
-                      '  Godef executable: .+' ) )
+                      '  Rust sources: .+' ) )
 
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
   with UserOption( 'server_keep_logfiles', False ):
-    StopCompleterServer( app, 'go' )
-    request_data = BuildRequest( filetype = 'go' )
+    StopCompleterServer( app, 'rust' )
+    request_data = BuildRequest( filetype = 'rust' )
     assert_that(
       app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Go completer debug information:\n'
-                      '  Gocode is not running\n'
-                      '  Gocode executable: .+\n'
-                      '  Godef executable: .+' ) )
+      matches_regexp( 'Rust completer debug information:\n'
+                      '  Racerd is not running\n'
+                      '  Racerd executable: .+\n'
+                      '  Rust sources: .+' ) )

--- a/ycmd/tests/rust/get_completions_test.py
+++ b/ycmd/tests/rust/get_completions_test.py
@@ -29,10 +29,10 @@ from mock import patch
 
 from ycmd.completers.rust.rust_completer import (
   ERROR_FROM_RACERD_MESSAGE, NON_EXISTING_RUST_SOURCES_PATH_MESSAGE )
-from ycmd.tests.rust import ( IsolatedYcmd, PathToTestFile, SharedYcmd,
-                              WaitUntilRacerdServerReady )
+from ycmd.tests.rust import IsolatedYcmd, PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import ( BuildRequest, CompletionEntryMatcher,
-                                    ErrorMatcher, UserOption )
+                                    ErrorMatcher, UserOption,
+                                    WaitUntilCompleterServerReady )
 from ycmd.utils import ReadFile
 import requests
 
@@ -62,7 +62,7 @@ def GetCompletions_Basic_test( app ):
 @IsolatedYcmd
 def GetCompletions_WhenStandardLibraryCompletionFails_MentionRustSrcPath_test(
   app ):
-  WaitUntilRacerdServerReady( app )
+  WaitUntilCompleterServerReady( app, 'rust' )
 
   filepath = PathToTestFile( 'std_completions.rs' )
   contents = ReadFile( filepath )

--- a/ycmd/tests/typescript/debug_info_test.py
+++ b/ycmd/tests/typescript/debug_info_test.py
@@ -25,49 +25,42 @@ from builtins import *  # noqa
 
 from hamcrest import assert_that, matches_regexp
 
-from ycmd.tests.go import IsolatedYcmd, SharedYcmd
-from ycmd.tests.test_utils import BuildRequest, StopCompleterServer, UserOption
+from ycmd.tests.typescript import IsolatedYcmd, SharedYcmd, StopCompleterServer
+from ycmd.tests.test_utils import BuildRequest, UserOption
 
 
 @SharedYcmd
 def DebugInfo_ServerIsRunning_test( app ):
-  request_data = BuildRequest( filetype = 'go' )
+  request_data = BuildRequest( filetype = 'typescript' )
   assert_that(
     app.post_json( '/debug_info', request_data ).json,
-    matches_regexp( 'Go completer debug information:\n'
-                    '  Gocode running at: http://127.0.0.1:\d+\n'
-                    '  Gocode process ID: \d+\n'
-                    '  Gocode executable: .+\n'
-                    '  Gocode logfiles:\n'
-                    '    .+\n'
-                    '    .+\n'
-                    '  Godef executable: .+' ) )
+    matches_regexp( 'TypeScript completer debug information:\n'
+                    '  TSServer running\n'
+                    '  TSServer process ID: \d+\n'
+                    '  TSServer executable: .+\n'
+                    '  TSServer logfile: .+' ) )
 
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
   with UserOption( 'server_keep_logfiles', True ):
-    StopCompleterServer( app, 'go' )
-    request_data = BuildRequest( filetype = 'go' )
+    StopCompleterServer( app, filetype = 'typescript' )
+    request_data = BuildRequest( filetype = 'typescript' )
     assert_that(
       app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Go completer debug information:\n'
-                      '  Gocode no longer running\n'
-                      '  Gocode executable: .+\n'
-                      '  Gocode logfiles:\n'
-                      '    .+\n'
-                      '    .+\n'
-                      '  Godef executable: .+' ) )
+      matches_regexp( 'TypeScript completer debug information:\n'
+                      '  TSServer no longer running\n'
+                      '  TSServer executable: .+\n'
+                      '  TSServer logfile: .+' ) )
 
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
   with UserOption( 'server_keep_logfiles', False ):
-    StopCompleterServer( app, 'go' )
-    request_data = BuildRequest( filetype = 'go' )
+    StopCompleterServer( app, filetype = 'typescript' )
+    request_data = BuildRequest( filetype = 'typescript' )
     assert_that(
       app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Go completer debug information:\n'
-                      '  Gocode is not running\n'
-                      '  Gocode executable: .+\n'
-                      '  Godef executable: .+' ) )
+      matches_regexp( 'TypeScript completer debug information:\n'
+                      '  TSServer is not running\n'
+                      '  TSServer executable: .+' ) )


### PR DESCRIPTION
This PR makes the string returned by the `DebugInfo` method more consistent throughout completers. It also adds more informations:
 - status of the `.ycm_extra_conf.py` file for the C-family completer;
 - subserver PID when relevant (needed for the tests in PR #282);
 - executable(s) used by the completer;
 - current solution for the C♯ completer;
 - Rust sources path for the Rust completer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/533)
<!-- Reviewable:end -->
