### PR TITLE
Search for completers binaries in system path

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -51,6 +51,18 @@ PATH_TO_OMNISHARP_BINARY = os.path.join(
   'OmniSharp', 'bin', 'Release', 'OmniSharp.exe' )
 
 
+def FindOmniSharpBinary():
+  """Find the path to the OmniSharp binary.
+
+  If a version is installed with YCM, use that.
+  Otherwise try to find one installed in the system.
+  If that fails, return None."""
+
+  if os.path.exists( PATH_TO_OMNISHARP_BINARY ):
+    return PATH_TO_OMNISHARP_BINARY
+
+  return utils.PathToFirstExistingExecutable( [ 'OmniSharp', 'OmniSharp.exe' ] )
+
 class CsharpCompleter( Completer ):
   """
   A Completer that uses the Omnisharp server as completion engine.
@@ -66,7 +78,7 @@ class CsharpCompleter( Completer ):
       'max_diagnostics_to_display' ]
     self._solution_state_lock = threading.Lock()
 
-    if not os.path.isfile( PATH_TO_OMNISHARP_BINARY ):
+    if not FindOmniSharpBinary():
       raise RuntimeError(
            SERVER_NOT_FOUND_MSG.format( PATH_TO_OMNISHARP_BINARY ) )
 
@@ -348,7 +360,7 @@ class CsharpSolutionCompleter( object ):
 
       self._ChooseOmnisharpPort()
 
-      command = [ PATH_TO_OMNISHARP_BINARY,
+      command = [ FindOmniSharpBinary(),
                   '-p',
                   str( self._omnisharp_port ),
                   '-s',

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -70,7 +70,8 @@ def FindBinary( binary, user_options ):
 
   If 'gocode_binary_path' or 'godef_binary_path'
   in the options is blank, use the version installed
-  with YCM, if it exists.
+  with YCM, if it exists. Otherwise try to find one
+  installed on the system.
 
   If the 'gocode_binary_path' or 'godef_binary_path' is
   specified, use it as an absolute path.
@@ -87,7 +88,7 @@ def FindBinary( binary, user_options ):
   binary_path = _FindPath()
   if os.path.isfile( binary_path ):
     return binary_path
-  return None
+  return utils.PathToFirstExistingExecutable( [ binary ] )
 
 
 def ShouldEnableGoCompleter( user_options ):

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -59,6 +59,18 @@ PATH_TO_NODE = utils.PathToFirstExistingExecutable( [ 'node' ] )
 SERVER_HOST = '127.0.0.1'
 
 
+def FindTernBinary():
+  """Find the path to the tern binary.
+
+  If a version is installed with YCM, use that.
+  Otherwise try to find one installed in the system.
+  If that fails, return None."""
+
+  if os.path.exists( PATH_TO_TERNJS_BINARY ):
+    return PATH_TO_TERNJS_BINARY
+
+  return utils.PathToFirstExistingExecutable( [ 'tern' ] )
+
 def ShouldEnableTernCompleter():
   """Returns whether or not the tern completer is 'installed'. That is whether
   or not the tern submodule has a 'node_modules' directory. This is pretty much
@@ -71,9 +83,7 @@ def ShouldEnableTernCompleter():
 
   _logger.info( 'Using node binary from: ' + PATH_TO_NODE )
 
-  installed = os.path.exists( PATH_TO_TERNJS_BINARY )
-
-  if not installed:
+  if not FindTernBinary():
     _logger.info( 'Not using Tern completer: not installed at ' +
                   PATH_TO_TERNJS_BINARY )
     return False
@@ -372,7 +382,7 @@ class TernCompleter( Completer ):
         extra_args = []
 
       command = [ PATH_TO_NODE,
-                  PATH_TO_TERNJS_BINARY,
+                  FindTernBinary(),
                   '--port',
                   str( self._server_port ),
                   '--host',


### PR DESCRIPTION
The Rust and Typescript completers are already searching the system path if a binary is not installed alongside YCM.
This commit adds the same behavior to the C#, Go and Javascript completers.

This means one can build ycmd without bundling the specific completer engines, but being able to use them when installing them on the system.
I want to do this for an ArchLinux AUR package, so that a user only gets a YCM "core" installation and can install completer engines on a per-need basis. I imagine this would be favorable for other distribution's packaging as well.

I tested this for Go and Javascript (the existing completers for Rust and Typescript work like this already), but I did not test C#.
I am also unsure if any changes have to be made to work well on non-GNU/Linux systems.

Python completion is not adapted, because JediHTTP does currently not provide a facility to be installed on its own: vheon/JediHTTP#17.

For the C family this also seems to be inapplicable, since support for clang has to be built into the ycmd library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/535)
<!-- Reviewable:end -->
