### PR TITLE
[READY] Always enable spell checking for better FixIts

### DIFF
--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -185,6 +185,25 @@ def RemoveUnusedFlags_Depfiles_test():
                contains( *expected ) )
 
 
+def EnableTypoCorrection_Empty_test():
+  eq_( flags._EnableTypoCorrection( [] ), [ '-fspell-checking' ] )
+
+
+def EnableTypoCorrection_Trivial_test():
+  eq_( flags._EnableTypoCorrection( [ '-x', 'c++' ] ),
+                                    [ '-x', 'c++', '-fspell-checking' ] )
+
+
+def EnableTypoCorrection_Reciprocal_test():
+  eq_( flags._EnableTypoCorrection( [ '-fno-spell-checking' ] ),
+                                    [ '-fno-spell-checking' ] )
+
+
+def EnableTypoCorrection_ReciprocalOthers_test():
+  eq_( flags._EnableTypoCorrection( [ '-x', 'c++', '-fno-spell-checking' ] ),
+                                    [ '-x', 'c++', '-fno-spell-checking' ] )
+
+
 def RemoveUnusedFlags_RemoveFilenameWithoutPrecedingInclude_test():
   def tester( flag ):
     expected = [ 'clang', flag, '/foo/bar', '-isystem/zoo/goo' ]

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -727,12 +727,32 @@ def FixIt_Check_cpp11_Note( results ):
   } ) )
 
 
+def FixIt_Check_cpp11_SpellCheck( results ):
+  assert_that( results, has_entries( {
+    'fixits': contains(
+      # Change to SpellingIsNotMyStrongPoint
+      has_entries( {
+        'text': contains_string( "did you mean 'SpellingIsNotMyStrongPoint'" ),
+        'chunks': contains(
+          ChunkMatcher( 'SpellingIsNotMyStrongPoint',
+                        LineColMatcher( 72, 9 ),
+                        LineColMatcher( 72, 35 ) )
+        ),
+        'location': LineColMatcher( 72, 9 ),
+      } ) )
+  } ) )
+
+
 def Subcommands_FixIt_all_test():
   cfile = 'FixIt_Clang_cpp11.cpp'
   mfile = 'FixIt_Clang_objc.m'
   ufile = 'unicode.cc'
 
   tests = [
+    # L
+    # i   C
+    # n   o
+    # e   l   Lang     File,  Checker
     [ 16, 0,  'cpp11', cfile, FixIt_Check_cpp11_Ins ],
     [ 16, 1,  'cpp11', cfile, FixIt_Check_cpp11_Ins ],
     [ 16, 10, 'cpp11', cfile, FixIt_Check_cpp11_Ins ],
@@ -762,6 +782,9 @@ def Subcommands_FixIt_all_test():
 
     # FixIt attached to a "child" diagnostic (i.e. a Note)
     [ 60, 1,  'cpp11', cfile, FixIt_Check_cpp11_Note ],
+
+    # FixIt due to forced spell checking
+    [ 72, 9,  'cpp11', cfile, FixIt_Check_cpp11_SpellCheck ],
   ]
 
   for test in tests:

--- a/ycmd/tests/clang/testdata/FixIt_Clang_cpp11.cpp
+++ b/ycmd/tests/clang/testdata/FixIt_Clang_cpp11.cpp
@@ -63,3 +63,11 @@ void z() {
 
   }
 }
+
+namespace Typo {
+    struct SpellingIsNotMyStrongPoint;
+}
+
+void typo() {
+  Typo::SpellingIsNotMyStringPiont *p;
+}


### PR DESCRIPTION
Fixes #546 

We enable spell-checking to get better FixIt suggestions. The only time we don't is if the user's flags explicitly request it is disabled.

The change is in `PrepareFlagsForClang` because that is run both when getting the flags from the `FlagsForFile` function and when supplying them in the request. However, rather than having to update every test which does this to also expect `-fspell-checking` in the result, we use the same approach as `FlagsForFile` to allow the test system to disable adding it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/548)
<!-- Reviewable:end -->
