### PR TITLE
[READY] Return True as JSON in /load_extra_conf_file and /ignore_extra_conf_file handlers

### DIFF
--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -188,12 +188,16 @@ def LoadExtraConfFile():
   request_data = RequestWrap( request.json, validate = False )
   extra_conf_store.Load( request_data[ 'filepath' ], force = True )
 
+  return _JsonResponse( True )
+
 
 @app.post( '/ignore_extra_conf_file' )
 def IgnoreExtraConfFile():
   _logger.info( 'Received extra conf ignore request' )
   request_data = RequestWrap( request.json, validate = False )
   extra_conf_store.Disable( request_data[ 'filepath' ] )
+
+  return _JsonResponse( True )
 
 
 @app.post( '/debug_info' )


### PR DESCRIPTION
See #536 for the rationale.

We choose to return `True` instead of an empty dictionary because it allows clients to use the response like this:
```python
response = ...
if response:
  # do something
```
while it would be awkward with an empty dictionary.

Adds one test for each handler and updates the existing ones.

Closes #536.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/551)
<!-- Reviewable:end -->
