### PR TITLE
[READY] Print a message equivalent to that printed by waitress.serve

### DIFF
--- a/ycmd/wsgi_server.py
+++ b/ycmd/wsgi_server.py
@@ -38,6 +38,13 @@ class StoppableWSGIServer( TcpWSGIServer ):
   def Run( self ):
     """Wrapper of TcpWSGIServer run method. It prevents a traceback from
     asyncore."""
+
+    # Message for compatibility with clients who expect the output from
+    # waitress.serve here
+    print( 'serving on http://{0}:{1}'.format(
+      self.effective_host,
+      self.effective_port ) )
+
     try:
       self.run()
     except select.error:


### PR DESCRIPTION
#282 breaks emacs-ycmd as it parses the standard output to get the port that ycmd is listening on.

While it probably makes sense for emacs-ycmd to specify the port, this is a regression so we re-introduce the output equivalent to [`waitress.serve`](https://github.com/Pylons/waitress/blob/3850e4c09aa9a55dc5c61985981b4ef719d5ebb8/waitress/__init__.py#L13-L14)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/555)
<!-- Reviewable:end -->
