### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -319,7 +319,7 @@ add_library( ${PROJECT_NAME} SHARED
              ${SERVER_SOURCES}
            )
 
-if ( USE_CLANG_COMPLETER AND "${LIBCLANG_TARGET}" STREQUAL "" )
+if ( USE_CLANG_COMPLETER AND NOT LIBCLANG_TARGET )
      message( FATAL_ERROR "Using Clang completer, but no libclang found. "
                           "Try setting EXTERNAL_LIBCLANG_PATH or revise "
                           "your configuration" )

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -319,6 +319,11 @@ add_library( ${PROJECT_NAME} SHARED
              ${SERVER_SOURCES}
            )
 
+if ( USE_CLANG_COMPLETER AND
+     "${LIBCLANG_TARGET}" STREQUAL "" )
+     message( FATAL_ERROR "Using Clang completer, but no libclang found. Try setting EXTERNAL_LIBCLANG_PATH or revise your configuration" )
+endif()
+
 target_link_libraries( ${PROJECT_NAME}
                        ${Boost_LIBRARIES}
                        ${PYTHON_LIBRARIES}

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -319,9 +319,10 @@ add_library( ${PROJECT_NAME} SHARED
              ${SERVER_SOURCES}
            )
 
-if ( USE_CLANG_COMPLETER AND
-     "${LIBCLANG_TARGET}" STREQUAL "" )
-     message( FATAL_ERROR "Using Clang completer, but no libclang found. Try setting EXTERNAL_LIBCLANG_PATH or revise your configuration" )
+if ( USE_CLANG_COMPLETER AND "${LIBCLANG_TARGET}" STREQUAL "" )
+     message( FATAL_ERROR "Using Clang completer, but no libclang found. "
+                          "Try setting EXTERNAL_LIBCLANG_PATH or revise "
+                          "your configuration" )
 endif()
 
 target_link_libraries( ${PROJECT_NAME}


### PR DESCRIPTION
When building YCM through ./install.py with a link to hand-downloaded clang (for ex. when working in environment with blocked github access) this one will silently fail, i.e. build ycm_core.so without clang support.
Examplary call that fails silently:
CXXFLAGS="-I${PATH_TO_CLANG_INCLUDE}" EXTRA_CMAKE_ARGS="-DPATH_TO_LLVM_ROOT=${LLVM_PATH}" python ./install.py --clang-completer
Examplary proper call:
CXXFLAGS="-I${PATH_TO_CLANG_INCLUDE}" EXTRA_CMAKE_ARGS="-DPATH_TO_LLVM_ROOT=${LLVM_PATH} -DEXTERNAL_LIBCLANG_PATH=${LLVM_PATH}/build/lib/libclang.so.3.8" python ./install.py --clang-completer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/565)
<!-- Reviewable:end -->
