### PR TITLE
[READY] Disable flake8 for Python 2.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ install:
   - source ci/travis/travis_install.sh
 compiler:
   - gcc
-script: ./run_tests.py
+script:
+  - ci/travis/travis_script.sh
 after_success:
   - codecov
 env:
@@ -23,16 +24,17 @@ env:
     - YCM_CORES=3
     - COVERAGE=true
   matrix:
-    - USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6
-    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6
-    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7
-    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=3.3
+    # Since 3.0.4, Flake8 is not working anymore on Python 2.6.
+    - USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6 YCMD_FLAKE8=false
+    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6 YCMD_FLAKE8=false
+    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7 YCMD_FLAKE8=true
+    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=3.3 YCMD_FLAKE8=true
 matrix:
   exclude:
     - os: osx
-      env: USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6
+      env: USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6 YCMD_FLAKE8=false
     - os: osx
-      env: USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6
+      env: USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6 YCMD_FLAKE8=false
 addons:
   # If this doesn't make much sense to you, see the travis docs:
   #    https://docs.travis-ci.com/user/migrating-from-legacy/

--- a/ci/travis/travis_script.sh
+++ b/ci/travis/travis_script.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "${YCMD_FLAKE8}" = true ]; then
+  ./run_tests.py
+else
+  ./run_tests.py --no-flake8
+fi


### PR DESCRIPTION
Last version of flake8 cannot be used anymore on our code base with Python 2.6. In fact, [support for Python 2.6, 3.2 and 3.3 was dropped in version 3.0.0](http://flake8.pycqa.org/en/latest/release-notes/3.0.0.html#id1). I thought about freezing its version to the last working one (3.0.3) but new versions of flake8 may detect issues in the code that weren't found before (see https://github.com/Valloric/ycmd/pull/472 for instance). So, I went for disabling it for Python 2.6 (but not for Python 3.3 since it is still working with this version).

There is also the option to drop support for Python 2.6 (Python 3.3 is out of the question; it is [maintained until September 2017](https://www.python.org/dev/peps/pep-0398/#id11)). Thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/570)
<!-- Reviewable:end -->
