### PR TITLE
[READY] Remove Python 2.7.11 workaround on AppVeyor

### DIFF
--- a/ci/appveyor/appveyor_install.bat
+++ b/ci/appveyor/appveyor_install.bat
@@ -26,12 +26,6 @@ if %arch% == 32 (
 
 set PATH=%python_path%;%python_path%\Scripts;%PATH%
 python --version
-:: Manually setting PYTHONHOME for python 2.7.11 fix the following error when
-:: running core tests: "ImportError: No module named site"
-:: TODO: check if this is still needed when python 2.7.12 is released.
-if %python% == 27 (
-  set PYTHONHOME=%python_path%
-)
 
 appveyor DownloadFile https://bootstrap.pypa.io/get-pip.py
 python get-pip.py


### PR DESCRIPTION
[Python 2.7.12 is now available on AppVeyor](https://github.com/appveyor/ci/issues/903). This version does not suffer from [the bug affecting 2.7.11](http://bugs.python.org/issue25824).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/571)
<!-- Reviewable:end -->
