### PR TITLE
[READY] Properly remove logfiles at program termination

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -27,7 +27,6 @@ from future.utils import itervalues
 
 from collections import defaultdict
 import os
-import time
 import re
 from ycmd.completers.completer import Completer
 from ycmd.utils import ForceSemanticCompletion, CodepointOffsetToByteOffset
@@ -72,10 +71,9 @@ class CsharpCompleter( Completer ):
 
 
   def Shutdown( self ):
-    if ( self.user_options[ 'auto_stop_csharp_server' ] ):
+    if self.user_options[ 'auto_stop_csharp_server' ]:
       for solutioncompleter in itervalues( self._completer_per_solution ):
-        if solutioncompleter._ServerIsRunning():
-          solutioncompleter._StopServer()
+        solutioncompleter._StopServer()
 
 
   def SupportedFiletypes( self ):
@@ -411,40 +409,20 @@ class CsharpSolutionCompleter( object ):
   def _StopServer( self ):
     """ Stop the OmniSharp server using a lock. """
     with self._server_state_lock:
-      if not self._ServerIsRunning():
-        return
-
-      self._logger.info( 'Stopping OmniSharp server' )
-
-      self._TryToStopServer()
-
-      # Terminate it if it's still up
       if self._ServerIsRunning():
-        self._logger.info( 'Terminating OmniSharp server' )
-        self._omnisharp_phandle.terminate()
+        self._logger.info( 'Stopping OmniSharp server with PID {0}'.format(
+                               self._omnisharp_phandle.pid ) )
+        self._GetResponse( '/stopserver' )
         self._omnisharp_phandle.wait()
+        self._logger.info( 'Stopped OmniSharp server' )
 
-      self._CleanupAfterServerStop()
-
-      self._logger.info( 'Stopped OmniSharp server' )
-
-
-  def _TryToStopServer( self ):
-    for _ in range( 5 ):
-      try:
-        self._GetResponse( '/stopserver', timeout = .1 )
-      except:
-        pass
-      for _ in range( 10 ):
-        if not self._ServerIsRunning():
-          return
-        time.sleep( .1 )
+      self._CleanUp()
 
 
-  def _CleanupAfterServerStop( self ):
+  def _CleanUp( self ):
     self._omnisharp_port = None
     self._omnisharp_phandle = None
-    if ( not self._keep_logfiles ):
+    if not self._keep_logfiles:
       if self._filename_stdout:
         utils.RemoveIfExists( self._filename_stdout )
         self._filename_stdout = None

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -418,10 +418,11 @@ class CsharpSolutionCompleter( object ):
 
       self._TryToStopServer()
 
-      # Kill it if it's still up
+      # Terminate it if it's still up
       if self._ServerIsRunning():
-        self._logger.info( 'Killing OmniSharp server' )
-        self._omnisharp_phandle.kill()
+        self._logger.info( 'Terminating OmniSharp server' )
+        self._omnisharp_phandle.terminate()
+        self._omnisharp_phandle.wait()
 
       self._CleanupAfterServerStop()
 

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -413,8 +413,12 @@ class CsharpSolutionCompleter( object ):
         self._logger.info( 'Stopping OmniSharp server with PID {0}'.format(
                                self._omnisharp_phandle.pid ) )
         self._GetResponse( '/stopserver' )
-        self._omnisharp_phandle.wait()
-        self._logger.info( 'Stopped OmniSharp server' )
+        try:
+          utils.WaitUntilProcessIsTerminated( self._omnisharp_phandle,
+                                              timeout = 5 )
+          self._logger.info( 'OmniSharp server stopped' )
+        except RuntimeError:
+          self._logger.exception( 'Error while stopping OmniSharp server' )
 
       self._CleanUp()
 

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -232,27 +232,29 @@ class GoCompleter( Completer ):
   def _StopServer( self ):
     """Stop the Gocode server."""
     with self._gocode_lock:
-      _logger.info( 'Stopping Gocode server' )
-
       if self._ServerIsRunning():
+        _logger.info( 'Stopping Gocode server with PID {0}'.format(
+                          self._gocode_handle.pid ) )
         self._ExecuteCommand( [ self._gocode_binary_path,
                                 '-addr', self._gocode_address,
                                 'close' ] )
-        self._gocode_handle.terminate()
         self._gocode_handle.wait()
+        _logger.info( 'Gocode server stopped' )
 
-      self._gocode_handle = None
-      self._gocode_port = None
-      self._gocode_address = None
+      self._CleanUp()
 
-      if not self._keep_logfiles:
-        if self._gocode_stdout:
-          utils.RemoveIfExists( self._gocode_stdout )
-          self._gocode_stdout = None
 
-        if self._gocode_stderr:
-          utils.RemoveIfExists( self._gocode_stderr )
-          self._gocode_stderr = None
+  def _CleanUp( self ):
+    self._gocode_handle = None
+    self._gocode_port = None
+    self._gocode_address = None
+    if not self._keep_logfiles:
+      if self._gocode_stdout:
+        utils.RemoveIfExists( self._gocode_stdout )
+        self._gocode_stdout = None
+      if self._gocode_stderr:
+        utils.RemoveIfExists( self._gocode_stderr )
+        self._gocode_stderr = None
 
 
   def _RestartServer( self ):

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -240,8 +240,11 @@ class GoCompleter( Completer ):
                                 '-sock', 'tcp',
                                 '-addr', self._gocode_address,
                                 'close' ] )
-        self._gocode_handle.wait()
-        _logger.info( 'Gocode server stopped' )
+        try:
+          utils.WaitUntilProcessIsTerminated( self._gocode_handle, timeout = 5 )
+          _logger.info( 'Gocode server stopped' )
+        except RuntimeError:
+          _logger.exception( 'Error while stopping Gocode server' )
 
       self._CleanUp()
 

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -141,6 +141,7 @@ class GoCompleter( Completer ):
                              request_data[ 'start_column' ] )
 
     stdoutdata = self._ExecuteCommand( [ self._gocode_binary_path,
+                                         '-sock', 'tcp',
                                          '-addr', self._gocode_address,
                                          '-f=json', 'autocomplete',
                                          filename, str( offset ) ],
@@ -236,6 +237,7 @@ class GoCompleter( Completer ):
         _logger.info( 'Stopping Gocode server with PID {0}'.format(
                           self._gocode_handle.pid ) )
         self._ExecuteCommand( [ self._gocode_binary_path,
+                                '-sock', 'tcp',
                                 '-addr', self._gocode_address,
                                 'close' ] )
         self._gocode_handle.wait()
@@ -314,6 +316,7 @@ class GoCompleter( Completer ):
 
     try:
       self._ExecuteCommand( [ self._gocode_binary_path,
+                              '-sock', 'tcp',
                               '-addr', self._gocode_address,
                               'status' ] )
       return True

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -441,8 +441,12 @@ class TernCompleter( Completer ):
         _logger.info( 'Stopping Tern server with PID {0}'.format(
                           self._server_handle.pid ) )
         self._server_handle.terminate()
-        self._server_handle.wait()
-        _logger.info( 'Tern server stopped.' )
+        try:
+          utils.WaitUntilProcessIsTerminated( self._server_handle,
+                                              timeout = 5 )
+          _logger.info( 'Tern server stopped' )
+        except RuntimeError:
+          _logger.exception( 'Error while stopping Tern server' )
 
       self._Reset()
 

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -438,16 +438,13 @@ class TernCompleter( Completer ):
   def _StopServer( self ):
     with self._server_state_mutex:
       if self._ServerIsRunning():
-        _logger.info( 'Stopping Tern server with PID '
-                      + str( self._server_handle.pid )
-                      + '...' )
-
+        _logger.info( 'Stopping Tern server with PID {0}'.format(
+                          self._server_handle.pid ) )
         self._server_handle.terminate()
         self._server_handle.wait()
+        _logger.info( 'Tern server stopped.' )
 
-        _logger.info( 'Tern server terminated.' )
-
-        self._Reset()
+      self._Reset()
 
 
   def _ServerIsRunning( self ):

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -91,8 +91,7 @@ class JediCompleter( Completer ):
 
 
   def Shutdown( self ):
-    if self._ServerIsRunning():
-      self._StopServer()
+    self._StopServer()
 
 
   def ServerIsHealthy( self ):
@@ -130,18 +129,24 @@ class JediCompleter( Completer ):
 
   def _StopServer( self ):
     with self._server_lock:
-      self._logger.info( 'Stopping JediHTTP' )
-      if self._jedihttp_phandle:
+      if self._ServerIsRunning():
+        self._logger.info( 'Stopping JediHTTP server with PID {0}'.format(
+                               self._jedihttp_phandle.pid ) )
         self._jedihttp_phandle.terminate()
         self._jedihttp_phandle.wait()
-        self._jedihttp_phandle = None
-        self._jedihttp_port = None
+        self._logger.info( 'JediHTTP server stopped' )
 
-      if not self._keep_logfiles:
-        utils.RemoveIfExists( self._logfile_stdout )
-        self._logfile_stdout = None
-        utils.RemoveIfExists( self._logfile_stderr )
-        self._logfile_stderr = None
+      self._CleanUp()
+
+
+  def _CleanUp( self ):
+    self._jedihttp_phandle = None
+    self._jedihttp_port = None
+    if not self._keep_logfiles:
+      utils.RemoveIfExists( self._logfile_stdout )
+      self._logfile_stdout = None
+      utils.RemoveIfExists( self._logfile_stderr )
+      self._logfile_stderr = None
 
 
   def _StartServer( self ):

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -133,8 +133,12 @@ class JediCompleter( Completer ):
         self._logger.info( 'Stopping JediHTTP server with PID {0}'.format(
                                self._jedihttp_phandle.pid ) )
         self._jedihttp_phandle.terminate()
-        self._jedihttp_phandle.wait()
-        self._logger.info( 'JediHTTP server stopped' )
+        try:
+          utils.WaitUntilProcessIsTerminated( self._jedihttp_phandle,
+                                              timeout = 5 )
+          self._logger.info( 'JediHTTP server stopped' )
+        except RuntimeError:
+          self._logger.exception( 'Error while stopping JediHTTP server' )
 
       self._CleanUp()
 

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -133,6 +133,7 @@ class JediCompleter( Completer ):
       self._logger.info( 'Stopping JediHTTP' )
       if self._jedihttp_phandle:
         self._jedihttp_phandle.terminate()
+        self._jedihttp_phandle.wait()
         self._jedihttp_phandle = None
         self._jedihttp_port = None
 

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -335,8 +335,12 @@ class RustCompleter( Completer ):
         _logger.info( 'Stopping Racerd with PID {0}'.format(
                           self._racerd_phandle.pid ) )
         self._racerd_phandle.terminate()
-        self._racerd_phandle.wait()
-        _logger.info( 'Racerd stopped' )
+        try:
+          utils.WaitUntilProcessIsTerminated( self._racerd_phandle,
+                                              timeout = 5 )
+          _logger.info( 'Racerd stopped' )
+        except RuntimeError:
+          _logger.exception( 'Error while stopping Racerd' )
 
       self._CleanUp()
 

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -332,21 +332,25 @@ class RustCompleter( Completer ):
   def _StopServer( self ):
     with self._server_state_lock:
       if self._racerd_phandle:
+        _logger.info( 'Stopping Racerd with PID {0}'.format(
+                          self._racerd_phandle.pid ) )
         self._racerd_phandle.terminate()
         self._racerd_phandle.wait()
-        self._racerd_phandle = None
-        self._racerd_host = None
+        _logger.info( 'Racerd stopped' )
 
-      if not self._keep_logfiles:
-        # Remove stdout log
-        if self._server_stdout:
-          utils.RemoveIfExists( self._server_stdout )
-          self._server_stdout = None
+      self._CleanUp()
 
-        # Remove stderr log
-        if self._server_stderr:
-          utils.RemoveIfExists( self._server_stderr )
-          self._server_stderr = None
+
+  def _CleanUp( self ):
+    self._racerd_phandle = None
+    self._racerd_host = None
+    if not self._keep_logfiles:
+      if self._server_stdout:
+        utils.RemoveIfExists( self._server_stdout )
+        self._server_stdout = None
+      if self._server_stderr:
+        utils.RemoveIfExists( self._server_stderr )
+        self._server_stderr = None
 
 
   def _RestartServer( self ):

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -253,7 +253,7 @@ class TypeScriptCompleter( Completer ):
         self._tsserver_handle.stdin.write( serialized_request )
         self._tsserver_handle.stdin.flush()
       # IOError is an alias of OSError in Python 3.
-      except IOError:
+      except ( AttributeError, IOError ):
         _logger.exception( SERVER_NOT_RUNNING_MESSAGE )
         raise RuntimeError( SERVER_NOT_RUNNING_MESSAGE )
 
@@ -551,6 +551,7 @@ class TypeScriptCompleter( Completer ):
 
 
   def _CleanUp( self ):
+    self._tsserver_handle = None
     if not self.user_options[ 'server_keep_logfiles' ]:
       utils.RemoveIfExists( self._logfile )
       self._logfile = None

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -536,15 +536,20 @@ class TypeScriptCompleter( Completer ):
 
   def _StopServer( self ):
     with self._server_lock:
-      if not self._ServerIsRunning():
-        return
+      if self._ServerIsRunning():
+        _logger.info( 'Stopping TSServer with PID {0}'.format(
+                          self._tsserver_handle.pid ) )
+        self._SendCommand( 'exit' )
+        self._tsserver_handle.wait()
+        _logger.info( 'TSServer stopped' )
 
-      self._SendCommand( 'exit' )
-      self._tsserver_handle.wait()
+      self._CleanUp()
 
-      if not self.user_options[ 'server_keep_logfiles' ]:
-        utils.RemoveIfExists( self._logfile )
-        self._logfile = None
+
+  def _CleanUp( self ):
+    if not self.user_options[ 'server_keep_logfiles' ]:
+      utils.RemoveIfExists( self._logfile )
+      self._logfile = None
 
 
   def Shutdown( self ):

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -540,8 +540,12 @@ class TypeScriptCompleter( Completer ):
         _logger.info( 'Stopping TSServer with PID {0}'.format(
                           self._tsserver_handle.pid ) )
         self._SendCommand( 'exit' )
-        self._tsserver_handle.wait()
-        _logger.info( 'TSServer stopped' )
+        try:
+          utils.WaitUntilProcessIsTerminated( self._tsserver_handle,
+                                              timeout = 5 )
+          _logger.info( 'TSServer stopped' )
+        except RuntimeError:
+          _logger.exception( 'Error while stopping TSServer' )
 
       self._CleanUp()
 

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -23,7 +23,6 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-import atexit
 import bottle
 import json
 import logging
@@ -282,7 +281,6 @@ def ServerShutdown():
   terminator.start()
 
 
-@atexit.register
 def ServerCleanup():
   if _server_state:
     _server_state.Shutdown()

--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -130,10 +130,10 @@ class Client_test( object ):
 
 
   def _WaitUntilReady( self, filetype = None, timeout = 5 ):
-    total_slept = 0
+    expiration = time.time() + timeout
     while True:
       try:
-        if total_slept > timeout:
+        if time.time() > expiration:
           server = ( 'the {0} subserver'.format( filetype ) if filetype else
                      'ycmd' )
           raise RuntimeError( 'Waited for {0} to be ready for {1} seconds, '
@@ -145,7 +145,6 @@ class Client_test( object ):
         pass
       finally:
         time.sleep( 0.1 )
-        total_slept += 0.1
 
 
   def StartSubserverForFiletype( self, filetype ):

--- a/ycmd/tests/go/go_completer_test.py
+++ b/ycmd/tests/go/go_completer_test.py
@@ -103,7 +103,7 @@ def ComputeCandidatesInner_BeforeUnicode_test( completer, execute_command ):
   # Col 8 corresponds to cursor at log.Pr^int("Line 7 ...
   completer.ComputeCandidatesInner( BuildRequest( 7, 8 ) )
   execute_command.assert_called_once_with(
-    [ DUMMY_BINARY, '-addr', completer._gocode_address,
+    [ DUMMY_BINARY, '-sock', 'tcp', '-addr', completer._gocode_address,
       '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '119' ],
     contents = ToBytes( ReadFile( PATH_TO_TEST_FILE ) ) )
 
@@ -116,7 +116,7 @@ def ComputeCandidatesInner_AfterUnicode_test( completer, execute_command ):
   # Col 9 corresponds to cursor at log.Pri^nt("Line 7 ...
   completer.ComputeCandidatesInner( BuildRequest( 9, 9 ) )
   execute_command.assert_called_once_with(
-    [ DUMMY_BINARY, '-addr', completer._gocode_address,
+    [ DUMMY_BINARY, '-sock', 'tcp', '-addr', completer._gocode_address,
       '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '212' ],
     contents = ToBytes( ReadFile( PATH_TO_TEST_FILE ) ) )
 
@@ -129,7 +129,7 @@ def ComputeCandidatesInner_test( completer, execute_command ):
   # Col 40 corresponds to cursor at ..., log.Prefi^x ...
   result = completer.ComputeCandidatesInner( BuildRequest( 10, 40 ) )
   execute_command.assert_called_once_with(
-    [ DUMMY_BINARY, '-addr', completer._gocode_address,
+    [ DUMMY_BINARY, '-sock', 'tcp', '-addr', completer._gocode_address,
       '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '287' ],
     contents = ToBytes( ReadFile( PATH_TO_TEST_FILE ) ) )
   eq_( result, [ {

--- a/ycmd/tests/shutdown_test.py
+++ b/ycmd/tests/shutdown_test.py
@@ -30,18 +30,19 @@ from ycmd.tests.client_test import Client_test
 
 class Shutdown_test( Client_test ):
 
-  @Client_test.CaptureOutputFromServer
+  @Client_test.CaptureLogfiles
   def FromHandlerWithoutSubserver_test( self ):
     self.Start()
-    self.AssertServerAndSubserversAreRunning()
+    self.AssertServersAreRunning()
 
     response = self.PostRequest( 'shutdown' )
     self.AssertResponse( response )
     assert_that( response.json(), equal_to( True ) )
-    self.AssertServerAndSubserversShutDown( timeout = 5 )
+    self.AssertServersShutDown( timeout = 5 )
+    self.AssertLogfilesAreRemoved()
 
 
-  @Client_test.CaptureOutputFromServer
+  @Client_test.CaptureLogfiles
   def FromHandlerWithSubservers_test( self ):
     self.Start()
 
@@ -53,23 +54,25 @@ class Shutdown_test( Client_test ):
                   'rust' ]
     for filetype in filetypes:
       self.StartSubserverForFiletype( filetype )
-    self.AssertServerAndSubserversAreRunning()
+    self.AssertServersAreRunning()
 
     response = self.PostRequest( 'shutdown' )
     self.AssertResponse( response )
     assert_that( response.json(), equal_to( True ) )
-    self.AssertServerAndSubserversShutDown( timeout = 5 )
+    self.AssertServersShutDown( timeout = 5 )
+    self.AssertLogfilesAreRemoved()
 
 
-  @Client_test.CaptureOutputFromServer
+  @Client_test.CaptureLogfiles
   def FromWatchdogWithoutSubserver_test( self ):
     self.Start( idle_suicide_seconds = 2, check_interval_seconds = 1 )
-    self.AssertServerAndSubserversAreRunning()
+    self.AssertServersAreRunning()
 
-    self.AssertServerAndSubserversShutDown( timeout = 5 )
+    self.AssertServersShutDown( timeout = 5 )
+    self.AssertLogfilesAreRemoved()
 
 
-  @Client_test.CaptureOutputFromServer
+  @Client_test.CaptureLogfiles
   def FromWatchdogWithSubservers_test( self ):
     self.Start( idle_suicide_seconds = 2, check_interval_seconds = 1 )
 
@@ -81,6 +84,7 @@ class Shutdown_test( Client_test ):
                   'rust' ]
     for filetype in filetypes:
       self.StartSubserverForFiletype( filetype )
-    self.AssertServerAndSubserversAreRunning()
+    self.AssertServersAreRunning()
 
-    self.AssertServerAndSubserversShutDown( timeout = 5 )
+    self.AssertServersShutDown( timeout = 5 )
+    self.AssertLogfilesAreRemoved()

--- a/ycmd/tests/shutdown_test.py
+++ b/ycmd/tests/shutdown_test.py
@@ -74,7 +74,7 @@ class Shutdown_test( Client_test ):
 
   @Client_test.CaptureLogfiles
   def FromWatchdogWithSubservers_test( self ):
-    self.Start( idle_suicide_seconds = 2, check_interval_seconds = 1 )
+    self.Start( idle_suicide_seconds = 5, check_interval_seconds = 1 )
 
     filetypes = [ 'cs',
                   'go',
@@ -86,5 +86,5 @@ class Shutdown_test( Client_test ):
       self.StartSubserverForFiletype( filetype )
     self.AssertServersAreRunning()
 
-    self.AssertServersShutDown( timeout = 5 )
+    self.AssertServersShutDown( timeout = 15 )
     self.AssertLogfilesAreRemoved()

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -26,13 +26,13 @@ standard_library.install_aliases()
 from builtins import *  # noqa
 from future.utils import PY2, native
 
-import tempfile
 import os
-import sys
-import signal
 import socket
 import stat
 import subprocess
+import sys
+import tempfile
+import time
 
 
 # Creation flag to disable creating a console window on Windows. See
@@ -281,18 +281,15 @@ def ProcessIsRunning( handle ):
   return handle is not None and handle.poll() is None
 
 
-# From here: http://stackoverflow.com/a/8536476/1672783
-def TerminateProcess( pid ):
-  if OnWindows():
-    import ctypes
-    PROCESS_TERMINATE = 1
-    handle = ctypes.windll.kernel32.OpenProcess( PROCESS_TERMINATE,
-                                                 False,
-                                                 pid )
-    ctypes.windll.kernel32.TerminateProcess( handle, -1 )
-    ctypes.windll.kernel32.CloseHandle( handle )
-  else:
-    os.kill( pid, signal.SIGTERM )
+def WaitUntilProcessIsTerminated( handle, timeout = 5 ):
+  expiration = time.time() + timeout
+  while True:
+    if time.time() > expiration:
+      raise RuntimeError( 'Waited process to terminate for {0} seconds, '
+                          'aborting.'.format( timeout ) )
+    if not ProcessIsRunning( handle ):
+      return
+    time.sleep( 0.1 )
 
 
 def PathsToAllParentFolders( path ):


### PR DESCRIPTION
With this PR, we now remove `ycmd` logfiles at program termination and not only when receiving the `SIGTERM` or `SIGINT` signals. This fixes the long-standing bug where logfiles were never removed on Windows and the regression where they were not removed anymore on Unix platforms when receiving the `shutdown` request or through the watchdog plugin.

In addition, when shutting down a sub-server in a completer, we always wait for its process to be terminated before removing the logfiles. We need this on Windows because we cannot remove a file that it still used by a process on this platform. Most of the completers were already waiting but not the Python and C♯ completers.

Shutdown tests are updated to check if the logfiles are removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/572)
<!-- Reviewable:end -->
