### PR TITLE
[READY] Add end of range to diagnostics in C# completer

### DIFF
--- a/ycmd/tests/cs/testdata/testy/DiagnosticRange.cs
+++ b/ycmd/tests/cs/testdata/testy/DiagnosticRange.cs
@@ -1,0 +1,4 @@
+public class Class
+{
+    public int attribute;
+}


### PR DESCRIPTION
For some diagnostics (especially warnings), the OmniSharp server returns a valid end of range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/575)
<!-- Reviewable:end -->
