### PR TITLE
[READY] Keep subservers alive while ycmd is up

### DIFF
--- a/ycmd/__main__.py
+++ b/ycmd/__main__.py
@@ -104,7 +104,7 @@ def ParseArguments():
                        help = 'num idle seconds before server shuts down')
   parser.add_argument( '--check_interval_seconds', type = int, default = 600,
                        help = 'interval in seconds to check server '
-                              'inactivity' )
+                              'inactivity and keep subservers alive' )
   parser.add_argument( '--options_file', type = str, required = True,
                        help = 'file with user options, in JSON format' )
   parser.add_argument( '--stdout', type = str, default = None,
@@ -171,6 +171,7 @@ def Main():
   from ycmd.watchdog_plugin import WatchdogPlugin
   handlers.UpdateUserOptions( options )
   handlers.SetHmacSecret( hmac_secret )
+  handlers.KeepSubserversAlive( args.check_interval_seconds )
   SetUpSignalHandler( args.stdout, args.stderr, args.keep_logfiles )
   handlers.app.install( WatchdogPlugin( args.idle_suicide_seconds,
                                         args.check_interval_seconds ) )

--- a/ycmd/server_state.py
+++ b/ycmd/server_state.py
@@ -26,6 +26,7 @@ from builtins import *  # noqa
 import os
 import threading
 import logging
+from future.utils import listvalues
 from ycmd.utils import ForceSemanticCompletion, LoadPythonSource
 from ycmd.completers.general.general_completer_store import (
     GeneralCompleterStore )
@@ -87,6 +88,11 @@ class ServerState( object ):
 
     raise ValueError( 'No semantic completer exists for filetypes: {0}'.format(
         current_filetypes ) )
+
+
+  def GetLoadedFiletypeCompleters( self ):
+    with self._filetype_completers_lock:
+      return set( listvalues( self._filetype_completers ) )
 
 
   def FiletypeCompletionAvailable( self, filetypes ):


### PR DESCRIPTION
We don't want subservers from filetype completers to automatically shut down for inactivity while ycmd is still up so we periodically check if they are healthy (by calling the `ServerIsHealthy` method for each loaded filetype completer), which should effectively keep them alive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/576)
<!-- Reviewable:end -->
