### PR TITLE
[READY] Insert python-future module just after the standard library path

### DIFF
--- a/ycmd/tests/server_utils_test.py
+++ b/ycmd/tests/server_utils_test.py
@@ -170,50 +170,32 @@ def AddNearestThirdPartyFoldersToSysPath_Failure_test():
 
 
 @patch( 'sys.path', [ '/some/path',
-                      '/first/path/to/site-packages',
-                      '/another/path',
-                      '/second/path/to/site-packages' ] )
-def AddNearestThirdPartyFoldersToSysPath_FutureBeforeSitePackages_test():
+                      '/path/to/standard/library',
+                      '/path/to/standard/library/site-packages',
+                      '/another/path' ] )
+@patch( 'distutils.sysconfig.get_python_lib',
+        return_value = '/path/to/standard/library' )
+def AddNearestThirdPartyFoldersToSysPath_FutureAfterStandardLibrary_test(
+  *args ):
   AddNearestThirdPartyFoldersToSysPath( __file__ )
   assert_that( sys.path[ : len( THIRD_PARTY_FOLDERS ) ], contains_inanyorder(
     *THIRD_PARTY_FOLDERS
   ) )
   assert_that( sys.path[ len( THIRD_PARTY_FOLDERS ) : ], contains(
     '/some/path',
+    '/path/to/standard/library',
     os.path.join( DIR_OF_THIRD_PARTY, 'python-future', 'src' ),
-    '/first/path/to/site-packages',
-    '/another/path',
-    '/second/path/to/site-packages',
-  ) )
-
-
-@patch( 'sys.path', [ '/some/path',
-                      '/first/path/to/dist-packages',
-                      '/another/path',
-                      '/second/path/to/dist-packages' ] )
-def AddNearestThirdPartyFoldersToSysPath_FutureBeforeDistPackages_test():
-  AddNearestThirdPartyFoldersToSysPath( __file__ )
-  assert_that( sys.path[ : len( THIRD_PARTY_FOLDERS ) ], contains_inanyorder(
-    *THIRD_PARTY_FOLDERS
-  ) )
-  assert_that( sys.path[ len( THIRD_PARTY_FOLDERS ) : ], contains(
-    '/some/path',
-    os.path.join( DIR_OF_THIRD_PARTY, 'python-future', 'src' ),
-    '/first/path/to/dist-packages',
-    '/another/path',
-    '/second/path/to/dist-packages',
+    '/path/to/standard/library/site-packages',
+    '/another/path'
   ) )
 
 
 @patch( 'sys.path', [ '/some/path',
                       '/another/path' ] )
-def AddNearestThirdPartyFoldersToSysPath_FutureLastIfNoPackages_test():
-  AddNearestThirdPartyFoldersToSysPath( __file__ )
-  assert_that( sys.path[ : len( THIRD_PARTY_FOLDERS ) ], contains_inanyorder(
-    *THIRD_PARTY_FOLDERS
-  ) )
-  assert_that( sys.path[ len( THIRD_PARTY_FOLDERS ) : ], contains(
-    '/some/path',
-    '/another/path',
-    os.path.join( DIR_OF_THIRD_PARTY, 'python-future', 'src' ),
-  ) )
+@patch( 'distutils.sysconfig.get_python_lib',
+        return_value = '/path/to/standard/library' )
+def AddNearestThirdPartyFoldersToSysPath_ErrorIfNoStandardLibrary_test( *args ):
+  assert_that(
+    calling( AddNearestThirdPartyFoldersToSysPath ).with_args( __file__ ),
+    raises( RuntimeError,
+            'Could not find standard library path in Python path.' ) )


### PR DESCRIPTION
In PR #448, I made the assumption that the `site-packages` paths are always placed after the standard library path so that if we insert the `python-future` module just before the first `site-packages` path, it would necessary be after the standard library. Turns out that it is not true when a `site-packages` path is added to the `PYTHONPATH` environment variable, e.g, when using the software [ROS](http://www.ros.org/). See issue https://github.com/Valloric/YouCompleteMe/issues/2186. When this happens, the `python-future` module will raise the following exception on Python 3:
```python
ImportError: This package should not be accessible on Python 3.
Either you are trying to run from the python-future src folder or
your installation of python-future is corrupted.
```

We prevent this by looking for the standard library path in `sys.path` and by inserting the `python-future` module just after it. If we can't find it, we raise an exception since YCM and ycmd cannot work without it.

Fixes https://github.com/Valloric/YouCompleteMe/issues/2186.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/578)
<!-- Reviewable:end -->
