### PR TITLE
[READY] Search os.py file to find standard library path in sys.path

### DIFF
--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 # No other imports from `future` because this module is loaded before we have
 # put our submodules in sys.path
 
-from distutils import sysconfig
 import io
 import logging
 import os
@@ -146,10 +145,8 @@ def PathToNearestThirdPartyFolder( path ):
 
 
 def GetStandardLibraryIndexInSysPath():
-  standard_library_path = os.path.normcase(
-    sysconfig.get_python_lib( standard_lib = True ) )
   for path in sys.path:
-    if os.path.normcase( path ) == standard_library_path:
+    if os.path.isfile( os.path.join( path, 'os.py' ) ):
       return sys.path.index( path )
   raise RuntimeError( 'Could not find standard library path in Python path.' )
 

--- a/ycmd/tests/server_utils_test.py
+++ b/ycmd/tests/server_utils_test.py
@@ -33,6 +33,7 @@ import sys
 from ycmd.server_utils import ( AddNearestThirdPartyFoldersToSysPath,
                                 CompatibleWithCurrentCore,
                                 PathToNearestThirdPartyFolder )
+from ycmd.tests import PathToTestFile
 
 DIR_OF_THIRD_PARTY = os.path.abspath(
   os.path.join( os.path.dirname( __file__ ), '..', '..', 'third_party' ) )
@@ -169,12 +170,11 @@ def AddNearestThirdPartyFoldersToSysPath_Failure_test():
     raises( RuntimeError, '.*third_party folder.*' ) )
 
 
-@patch( 'sys.path', [ '/some/path',
-                      '/path/to/standard/library',
-                      '/path/to/standard/library/site-packages',
-                      '/another/path' ] )
-@patch( 'distutils.sysconfig.get_python_lib',
-        return_value = '/path/to/standard/library' )
+@patch( 'sys.path', [
+  PathToTestFile( 'python-future', 'some', 'path' ),
+  PathToTestFile( 'python-future', 'standard_library' ),
+  PathToTestFile( 'python-future', 'standard_library', 'site-packages' ),
+  PathToTestFile( 'python-future', 'another', 'path' ) ] )
 def AddNearestThirdPartyFoldersToSysPath_FutureAfterStandardLibrary_test(
   *args ):
   AddNearestThirdPartyFoldersToSysPath( __file__ )
@@ -182,18 +182,17 @@ def AddNearestThirdPartyFoldersToSysPath_FutureAfterStandardLibrary_test(
     *THIRD_PARTY_FOLDERS
   ) )
   assert_that( sys.path[ len( THIRD_PARTY_FOLDERS ) : ], contains(
-    '/some/path',
-    '/path/to/standard/library',
+    PathToTestFile( 'python-future', 'some', 'path' ),
+    PathToTestFile( 'python-future', 'standard_library' ),
     os.path.join( DIR_OF_THIRD_PARTY, 'python-future', 'src' ),
-    '/path/to/standard/library/site-packages',
-    '/another/path'
+    PathToTestFile( 'python-future', 'standard_library', 'site-packages' ),
+    PathToTestFile( 'python-future', 'another', 'path' )
   ) )
 
 
-@patch( 'sys.path', [ '/some/path',
-                      '/another/path' ] )
-@patch( 'distutils.sysconfig.get_python_lib',
-        return_value = '/path/to/standard/library' )
+@patch( 'sys.path', [
+  PathToTestFile( 'python_future', 'some', 'path' ),
+  PathToTestFile( 'python_future', 'another', 'path' ) ] )
 def AddNearestThirdPartyFoldersToSysPath_ErrorIfNoStandardLibrary_test( *args ):
   assert_that(
     calling( AddNearestThirdPartyFoldersToSysPath ).with_args( __file__ ),


### PR DESCRIPTION
It turns out that using `get_python_lib` from the `sysconfig` module to find the standard library path in `sys.path` is not reliable. See issue https://github.com/Valloric/YouCompleteMe/issues/2293. Instead, we now look for the `os.py` file through all paths of `sys.path`. You may ask why `os.py` and not another file from the standard library. Python itself is using this file to [find the `sys.prefix` path](https://github.com/python/cpython/blob/master/Modules/getpath.c#L109) so it is a safe bet.

Fixes https://github.com/Valloric/YouCompleteMe/issues/2293.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/579)
<!-- Reviewable:end -->
