### PR TITLE
[READY] Document .ycm_extra_conf.py format

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,66 @@ is supposed to provide to configure certain semantic completers. More
 information on it can also be found in the [corresponding section of YCM's _User
 Guide_][extra-conf-doc].
 
+### `.ycm_extra_conf.py` specification
+
+The `.ycm_extra_conf.py` module must define the following methods:
+
+#### `FlagsForFile( filename, **kwargs )`
+
+Required for c-family language support.
+
+This method is called by the c-family completer to get the
+compiler flags to use when compiling the file with absolute path `filename`.
+The following additional arguments are optionally supplied depending on user
+configuration:
+
+- `client_data`: any additional data supplied by the client application.
+   See the [YouCompleteMe documentation][extra-conf-vim-data-doc] for an
+   example.
+
+The return value must be one of the following:
+
+- `None` meaning no flags are known for this file, or
+
+- a dictionary containing the following items:
+
+  - `flags`: (mandatory) a list of compiler flags.
+
+  - `do_cache`: (optional) a boolean indicating whether or not the result of
+    this call (i.e. the list of flags) should be cached for this file name.
+    Defaults to `True`. If unsure, the default is almost always correct.
+
+  - `flags_ready`: (optional) a boolean indicating that the flags should be
+    used. Defaults to `True`. If unsure, the default is almost always correct.
+
+A minimal example which simply returns a list of flags is:
+
+```python
+def FlagsForFile( filename, **kwargs ):
+  return {
+    'flags': [ '-x', 'c++' ]
+  }
+```
+
+### Global extra conf file specification
+
+The global extra module must expose the same functions as the
+`.ycm_extra_conf.py` module with the following additions:
+
+#### `YcmCorePreLoad()`
+
+Optional.
+
+This method, if defined, is called by the server prior to importing the c++
+python plugin. It is not usually required and its use is for advanced users
+only.
+
+#### `Shutdown()`
+
+Optional.
+
+Called prior to the server exiting cleanly. It is not usually required and its
+use is for advanced users only.
 
 Backwards compatibility
 -----------------------
@@ -260,4 +320,4 @@ This software is licensed under the [GPL v3 license][gpl].
 [ccoc]: https://github.com/Valloric/ycmd/blob/master/CODE_OF_CONDUCT.md
 [dev-setup]: https://github.com/Valloric/ycmd/blob/master/DEV_SETUP.md
 [test-setup]: https://github.com/Valloric/ycmd/blob/master/TESTS.md
-
+[extra-conf-vim-data-doc]: https://github.com/Valloric/YouCompleteMe#the-gycm_extra_conf_vim_data-option


### PR DESCRIPTION
It makes sense to actually document the file format, as mentioned in https://github.com/Valloric/YouCompleteMe/issues/2310

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/591)
<!-- Reviewable:end -->
