### PR TITLE
[READY] Make the do_cache item returned by FlagsForFile optional

### DIFF
--- a/cpp/ycm/.ycm_extra_conf.py
+++ b/cpp/ycm/.ycm_extra_conf.py
@@ -182,7 +182,4 @@ def FlagsForFile( filename, **kwargs ):
     relative_to = DirectoryOfThisScript()
     final_flags = MakeRelativePathsInFlagsAbsolute( flags, relative_to )
 
-  return {
-    'flags': final_flags,
-    'do_cache': True
-  }
+  return { 'flags': final_flags }

--- a/examples/.ycm_extra_conf.py
+++ b/examples/.ycm_extra_conf.py
@@ -139,8 +139,4 @@ def FlagsForFile( filename, **kwargs ):
     relative_to = DirectoryOfThisScript()
     final_flags = MakeRelativePathsInFlagsAbsolute( flags, relative_to )
 
-  return {
-    'flags': final_flags,
-    'do_cache': True
-  }
-
+  return { 'flags': final_flags }

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -104,7 +104,7 @@ class Flags( object ):
                                               filename,
                                               add_extra_clang_flags )
 
-      if results[ 'do_cache' ]:
+      if results.get( 'do_cache', True ):
         self.flags_for_file[ filename ] = sanitized_flags
       return sanitized_flags
 

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -34,8 +34,7 @@ from hamcrest import assert_that, contains
 @patch( 'ycmd.extra_conf_store.ModuleForSourceFile', return_value = Mock() )
 def FlagsForFile_BadNonUnicodeFlagsAreAlsoRemoved_test( *args ):
   fake_flags = {
-    'flags': [ bytes( b'-c' ), '-c', bytes( b'-foo' ), '-bar' ],
-    'do_cache': True
+    'flags': [ bytes( b'-c' ), '-c', bytes( b'-foo' ), '-bar' ]
   }
 
   with patch( 'ycmd.completers.cpp.flags._CallExtraConfFlagsForFile',
@@ -43,6 +42,63 @@ def FlagsForFile_BadNonUnicodeFlagsAreAlsoRemoved_test( *args ):
     flags_object = flags.Flags()
     flags_list = flags_object.FlagsForFile( '/foo', False )
     eq_( list( flags_list ), [ '-foo', '-bar' ] )
+
+
+@patch( 'ycmd.extra_conf_store.ModuleForSourceFile', return_value = Mock() )
+def FlagsForFile_FlagsCachedByDefault_test( *args ):
+  flags_object = flags.Flags()
+
+  results = { 'flags': [ '-x', 'c' ] }
+  with patch( 'ycmd.completers.cpp.flags._CallExtraConfFlagsForFile',
+              return_value = results ):
+    flags_list = flags_object.FlagsForFile( '/foo', False )
+    assert_that( flags_list, contains( '-x', 'c' ) )
+
+  results[ 'flags' ] = [ '-x', 'c++' ]
+  with patch( 'ycmd.completers.cpp.flags._CallExtraConfFlagsForFile',
+              return_value = results ):
+    flags_list = flags_object.FlagsForFile( '/foo', False )
+    assert_that( flags_list, contains( '-x', 'c' ) )
+
+
+@patch( 'ycmd.extra_conf_store.ModuleForSourceFile', return_value = Mock() )
+def FlagsForFile_FlagsNotCachedWhenDoCacheIsFalse_test( *args ):
+  flags_object = flags.Flags()
+
+  results = {
+    'flags': [ '-x', 'c' ],
+    'do_cache': False
+  }
+  with patch( 'ycmd.completers.cpp.flags._CallExtraConfFlagsForFile',
+              return_value = results ):
+    flags_list = flags_object.FlagsForFile( '/foo', False )
+    assert_that( flags_list, contains( '-x', 'c' ) )
+
+  results[ 'flags' ] = [ '-x', 'c++' ]
+  with patch( 'ycmd.completers.cpp.flags._CallExtraConfFlagsForFile',
+              return_value = results ):
+    flags_list = flags_object.FlagsForFile( '/foo', False )
+    assert_that( flags_list, contains( '-x', 'c++' ) )
+
+
+@patch( 'ycmd.extra_conf_store.ModuleForSourceFile', return_value = Mock() )
+def FlagsForFile_FlagsCachedWhenDoCacheIsTrue_test( *args ):
+  flags_object = flags.Flags()
+
+  results = {
+    'flags': [ '-x', 'c' ],
+    'do_cache': True
+  }
+  with patch( 'ycmd.completers.cpp.flags._CallExtraConfFlagsForFile',
+              return_value = results ):
+    flags_list = flags_object.FlagsForFile( '/foo', False )
+    assert_that( flags_list, contains( '-x', 'c' ) )
+
+  results[ 'flags' ] = [ '-x', 'c++' ]
+  with patch( 'ycmd.completers.cpp.flags._CallExtraConfFlagsForFile',
+              return_value = results ):
+    flags_list = flags_object.FlagsForFile( '/foo', False )
+    assert_that( flags_list, contains( '-x', 'c' ) )
 
 
 def SanitizeFlags_Passthrough_test():

--- a/ycmd/tests/clang/testdata/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/.ycm_extra_conf.py
@@ -1,5 +1,2 @@
 def FlagsForFile( filename ):
-  return {
-    'flags': ['-x', 'c++', '-I', '.'],
-    'do_cache': True
-  }
+  return { 'flags': ['-x', 'c++', '-I', '.'] }

--- a/ycmd/tests/clang/testdata/client_data/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/client_data/.ycm_extra_conf.py
@@ -1,5 +1,2 @@
 def FlagsForFile( filename, **kwargs ):
-  return {
-    'flags': kwargs['client_data']['flags'],
-    'do_cache': True
-  }
+  return { 'flags': kwargs[ 'client_data' ][ 'flags' ] }

--- a/ycmd/tests/clang/testdata/general_fallback/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/general_fallback/.ycm_extra_conf.py
@@ -30,7 +30,4 @@ def FlagsForFile(filename, **kwargs):
   if 'throw' in client_data:
     raise ValueError( client_data['throw'] )
 
-  return {
-    'flags': opts,
-    'do_cache': True
-  }
+  return { 'flags': opts }

--- a/ycmd/tests/clang/testdata/noflags/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/noflags/.ycm_extra_conf.py
@@ -1,6 +1,2 @@
 def FlagsForFile( filename ):
-  return {
-    'flags': [],
-    'do_cache': True
-  }
-
+  return { 'flags': [] }

--- a/ycmd/tests/clang/testdata/test-include/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/test-include/.ycm_extra_conf.py
@@ -3,8 +3,5 @@ import os.path
 
 def FlagsForFile( filename, **kwargs ):
   d = os.path.dirname( filename )
-  return {
-    'flags': [ '-iquote', os.path.join( d, 'quote' ),
-               '-I', os.path.join( d, 'system' ) ],
-    'do_cache': True
-  }
+  return { 'flags': [ '-iquote', os.path.join( d, 'quote' ),
+                      '-I', os.path.join( d, 'system' ) ] }


### PR DESCRIPTION
The `do_cache` item returned by the `FlagsForFile` function in `.ycm_extra_conf.py` is generally always set to `True` so let's make it optional with a default value of `True`. This simplifies a little the `.ycm_extra_conf.py` file and should be less confusing for users trying to understand it (cache + filename + flags? Sorry, can't compute).

This change is backward compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/592)
<!-- Reviewable:end -->
