### PR TITLE
[READY] Fix shutdown request in example client

### DIFF
--- a/examples/example_client.py
+++ b/examples/example_client.py
@@ -257,6 +257,8 @@ class YcmdHandle( object ):
 
 
 def ToBytes( value ):
+  if not value:
+    return bytes()
   if isinstance( value, bytes ):
     return value
   if isinstance( value, int ):


### PR DESCRIPTION
When shutting down the server in the example client, we get the following traceback:
```python
Traceback (most recent call last):
  File "./examples/example_client.py", line 494, in <module>
    Main()
  File "./examples/example_client.py", line 490, in Main
    server.Shutdown()
  File "./examples/example_client.py", line 116, in Shutdown
    self.PostToHandlerAndLog( 'shutdown' )
  File "./examples/example_client.py", line 120, in PostToHandlerAndLog
    self._CallHttpie( 'post', handler, data )
  File "./examples/example_client.py", line 249, in _CallHttpie
    data )
  File "./examples/example_client.py", line 220, in _HmacForRequest
    self._hmac_secret ) ), 'utf8' )
  File "./examples/example_client.py", line 276, in CreateRequestHmac
    body = ToBytes( body )
  File "./examples/example_client.py", line 266, in ToBytes
    return bytes( value, encoding = 'utf-8' )
TypeError: encoding or errors without a string argument
```
It happens because we are trying to convert a `None` body to bytes to create the HMAC key while preparing the shutdown request. Handle this case by returning an empty bytes (like we do in [ycmd ToBytes](https://github.com/Valloric/ycmd/blob/master/ycmd/utils.py#L103)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/594)
<!-- Reviewable:end -->
