### PR TITLE
[READY] Fix default include paths for macOS Sierra

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -377,13 +377,20 @@ if OnMac():
   # a Mac because if we don't, libclang would fail to find <vector> etc.  This
   # should be fixed upstream in libclang, but until it does, we need to help
   # users out.
-  # See Valloric/YouCompleteMe#303 for details.
+  # See the following for details:
+  #  - Valloric/YouCompleteMe#303
+  #  - Valloric/YouCompleteMe#2268
   MAC_INCLUDE_PATHS = (
     _PathsForAllMacToolchains( 'usr/include/c++/v1' ) +
     [ '/usr/local/include' ] +
     _PathsForAllMacToolchains( 'usr/include' ) +
     [ '/usr/include', '/System/Library/Frameworks', '/Library/Frameworks' ] +
-    _LatestMacClangIncludes()
+    _LatestMacClangIncludes() +
+    # We include the MacOS platform SDK because some meaningful parts of the
+    # standard library are located there. If users are compiling for (say)
+    # iPhone.platform, etc. they should appear earlier in the include path.
+    [ '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/'
+      'Developer/SDKs/MacOSX.sdk/usr/include' ]
   )
 
 


### PR DESCRIPTION
Fixes https://github.com/Valloric/YouCompleteMe/issues/2268

Apple seeded the GM release of macOS Sierra today, so will be publicly released fairly soon. Let's fix this before it breaks everyone.

Some parts of the standard libraries and include paths are now found in the platform-and-sdk-specific include areas. So to mitigate the number of problems this will cause, we just add a path which we know works.

This isn't super pretty (just hard-coding to MacOSX.platform), but it should work and should prevent random failures for most users. If users using iPhone/tvOS/etc. have problems, we can deal with them when they are raised. It's significantly more fiddly to test those setups.

Testing:
 - install OSX Sierra GM seed in VM
 - install YCM + dips
 - write the following file:

```c++
#include <string>

int main(int argc, char *argv[])
{
  std::string s;
  return 0;
}
```

 - `:YcmDiags` shows cannot find standard library headers 
 - after applying fix, no errors and completion is fine for `s.` etc. (PASSED)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/595)
<!-- Reviewable:end -->