### PR TITLE
[READY] Fix javascript subcommand errors for relative paths.

### DIFF
--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -53,8 +53,9 @@ def Subcommands_DefinedSubcommands_test( app ):
                       subcommands_data ).json )
 
 
-def RunTest( app, test ):
-  contents = ReadFile( test[ 'request' ][ 'filepath' ] )
+def RunTest( app, test, contents = None ):
+  if not contents:
+    contents = ReadFile( test[ 'request' ][ 'filepath' ] )
 
   def CombineRequest( request, data ):
     kw = request
@@ -155,6 +156,31 @@ def Subcommands_GoTo_test( app ):
       } )
     }
   } )
+
+
+@IsolatedYcmd
+def Subcommands_GoTo_RelativePath_test( app ):
+  WaitUntilCompleterServerReady( app, 'javascript' )
+  RunTest(
+    app,
+    {
+      'description': 'GoTo works when the buffer differs from the file on disk',
+      'request': {
+        'command': 'GoTo',
+        'line_num': 43,
+        'column_num': 25,
+        'filepath': PathToTestFile( 'simple_test.js' ),
+      },
+      'expect': {
+        'response': requests.codes.ok,
+        'data': has_entries( {
+          'filepath': PathToTestFile( 'simple_test.js' ),
+          'line_num': 31,
+          'column_num': 5,
+        } )
+      }
+    },
+    contents = ReadFile( PathToTestFile( 'simple_test.modified.js' ) ) )
 
 
 @SharedYcmd

--- a/ycmd/tests/javascript/testdata/simple_test.modified.js
+++ b/ycmd/tests/javascript/testdata/simple_test.modified.js
@@ -1,0 +1,51 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+var simple_test_obect = {
+  'a_simple_function': function( param ) {
+    return 'yes';
+  },
+
+  'basic_type': 100,
+
+  'object': {
+    'basic_type': 'test_string'
+  }
+};
+
+var simple_assignment = simple_test_obect.
+var query_assignment = simple_test_obect.typ
+var query_assignment = simple_test_obect.asf
+
+function blah( simple_test_obect ) {
+    simple_test_obect.a_simple_function;
+}
+
+blah( simple_test_obect ); simple_test_obect = null;


### PR DESCRIPTION
The Tern server returns relative paths. When using a
.tern-project file, paths are returned relative to that file. When
no .tern-project file exists, paths are relative to the working
directory of the Tern server.

Fixes https://github.com/Valloric/YouCompleteMe/issues/2322

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/596)
<!-- Reviewable:end -->
