### PR TITLE
[READY][API] Return debugging information as a dictionary instead of a string

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2011, 2012 Google Inc.
+# Copyright (C) 2011-2012 Google Inc.
+#               2017      ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -30,7 +31,6 @@ import re
 import os.path
 import textwrap
 from ycmd import responses
-from ycmd import extra_conf_store
 from ycmd.utils import ToCppStringCompatible, ToUnicode
 from ycmd.completers.completer import Completer
 from ycmd.completers.completer_utils import GetIncludeStatementValue
@@ -371,52 +371,31 @@ class ClangCompleter( Completer ):
 
 
   def DebugInfo( self, request_data ):
-    filename = request_data[ 'filepath' ]
-    try:
-      extra_conf = extra_conf_store.ModuleFileForSourceFile( filename )
-    except UnknownExtraConf as error:
-      return ( 'C-family completer debug information:\n'
-               '  Configuration file found but not loaded\n'
-               '  Configuration path: {0}'.format(
-                 error.extra_conf_file ) )
-
     try:
       # Note that it only raises NoExtraConfDetected:
       #  - when extra_conf is None and,
       #  - there is no compilation database
-      flags = self._FlagsForRequest( request_data )
-    except NoExtraConfDetected:
-      # No flags
-      return ( 'C-family completer debug information:\n'
-               '  No configuration file found\n'
-               '  No compilation database found' )
-
-    # If _FlagsForRequest returns None or raises, we use an empty list in
-    # practice.
-    flags = flags or []
-
-    if extra_conf:
-      # We got the flags from the extra conf file
-      return ( 'C-family completer debug information:\n'
-               '  Configuration file found and loaded\n'
-               '  Configuration path: {0}\n'
-               '  Flags: {1}'.format( extra_conf, list( flags ) ) )
+      flags = self._FlagsForRequest( request_data ) or []
+    except ( NoExtraConfDetected, UnknownExtraConf ):
+      # If _FlagsForRequest returns None or raises, we use an empty list in
+      # practice.
+      flags = []
 
     try:
-      database = self._flags.FindCompilationDatabase(
-          os.path.dirname( filename ) )
+      database_directory = self._flags.FindCompilationDatabase(
+          os.path.dirname( request_data[ 'filepath' ] ) ).database_directory
     except NoCompilationDatabase:
-      # No flags
-      return ( 'C-family completer debug information:\n'
-               '  No configuration file found\n'
-               '  No compilation database found' )
+      database_directory = None
 
-    # We got the flags from the compilation database
-    return ( 'C-family completer debug information:\n'
-             '  No configuration file found\n'
-             '  Using compilation database from: {0}\n'
-             '  Flags: {1}'.format( database.database_directory,
-                                    list( flags ) ) )
+    database_item = responses.DebugInfoItem(
+      key = 'compilation database path',
+      value = '{0}'.format( database_directory ) )
+    flags_item = responses.DebugInfoItem(
+      key = 'flags', value = '{0}'.format( list( flags ) ) )
+
+    return responses.BuildDebugInfoResponse( name = 'C-family',
+                                             items = [ database_item,
+                                                       flags_item ] )
 
 
   def _FlagsForRequest( self, request_data ):

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 ycmd contributors
+# Copyright (C) 2015-2017 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -256,32 +256,16 @@ class TernCompleter( Completer ):
 
   def DebugInfo( self, request_data ):
     with self._server_state_mutex:
-      if self._ServerIsRunning():
-        return ( 'JavaScript completer debug information:\n'
-                 '  Tern running at: {0}\n'
-                 '  Tern process ID: {1}\n'
-                 '  Tern executable: {2}\n'
-                 '  Tern logfiles:\n'
-                 '    {3}\n'
-                 '    {4}'.format( self._GetServerAddress(),
-                                   self._server_handle.pid,
-                                   PATH_TO_TERN_BINARY,
-                                   self._server_stdout,
-                                   self._server_stderr ) )
+      tern_server = responses.DebugInfoServer(
+        name = 'Tern',
+        handle = self._server_handle,
+        executable = PATH_TO_TERN_BINARY,
+        address = SERVER_HOST,
+        port = self._server_port,
+        logfiles = [ self._server_stdout, self._server_stderr ] )
 
-      if self._server_stdout and self._server_stderr:
-        return ( 'JavaScript completer debug information:\n'
-                 '  Tern no longer running\n'
-                 '  Tern executable: {0}\n'
-                 '  Tern logfiles:\n'
-                 '    {1}\n'
-                 '    {2}\n'.format( PATH_TO_TERN_BINARY,
-                                     self._server_stdout,
-                                     self._server_stderr ) )
-
-      return ( 'JavaScript completer debug information:\n'
-               '  Tern is not running\n'
-               '  Tern executable: {0}'.format( PATH_TO_TERN_BINARY ) )
+      return responses.BuildDebugInfoResponse( name = 'JavaScript',
+                                               servers = [ tern_server ] )
 
 
   def Shutdown( self ):

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -1,6 +1,7 @@
-# Copyright (C) 2011, 2012 Stephen Sugden <me@stephensugden.com>
-#                          Google Inc.
-#                          Stanislav Golovanov <stgolovanov@gmail.com>
+# Copyright (C) 2011-2012 Stephen Sugden <me@stephensugden.com>
+#                         Google Inc.
+#                         Stanislav Golovanov <stgolovanov@gmail.com>
+#               2017      ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -387,37 +388,19 @@ class JediCompleter( Completer ):
 
   def DebugInfo( self, request_data ):
     with self._server_lock:
-      if self._ServerIsRunning():
-        return ( 'Python completer debug information:\n'
-                 '  JediHTTP running at: http://127.0.0.1:{0}\n'
-                 '  JediHTTP process ID: {1}\n'
-                 '  JediHTTP executable: {2}\n'
-                 '  JediHTTP logfiles:\n'
-                 '    {3}\n'
-                 '    {4}\n'
-                 '  Python interpreter: {5}'.format(
-                   self._jedihttp_port,
-                   self._jedihttp_phandle.pid,
-                   PATH_TO_JEDIHTTP,
-                   self._logfile_stdout,
-                   self._logfile_stderr,
-                   self._python_binary_path ) )
+      jedihttp_server = responses.DebugInfoServer(
+        name = 'JediHTTP',
+        handle = self._jedihttp_phandle,
+        executable = PATH_TO_JEDIHTTP,
+        address = '127.0.0.1',
+        port = self._jedihttp_port,
+        logfiles = [ self._logfile_stdout, self._logfile_stderr ] )
 
-      if self._logfile_stdout and self._logfile_stderr:
-        return ( 'Python completer debug information:\n'
-                 '  JediHTTP no longer running\n'
-                 '  JediHTTP executable: {0}\n'
-                 '  JediHTTP logfiles:\n'
-                 '    {1}\n'
-                 '    {2}\n'
-                 '  Python interpreter: {3}'.format(
-                   PATH_TO_JEDIHTTP,
-                   self._logfile_stdout,
-                   self._logfile_stderr,
-                   self._python_binary_path ) )
+      python_interpreter_item = responses.DebugInfoItem(
+        key = 'Python interpreter',
+        value = self._python_binary_path )
 
-      return ( 'Python completer debug information:\n'
-               '  JediHTTP is not running\n'
-               '  JediHTTP executable: {0}\n'
-               '  Python interpreter: {1}'.format( PATH_TO_JEDIHTTP,
-                                                   self._python_binary_path ) )
+      return responses.BuildDebugInfoResponse(
+        name = 'Python',
+        servers = [ jedihttp_server ],
+        items = [ python_interpreter_item ] )

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -1,5 +1,5 @@
-# Copyright (C) 2015 - 2016 Google Inc.
-#               2016 ycmd contributors
+# Copyright (C) 2015-2016 Google Inc.
+#               2016-2017 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -566,24 +566,13 @@ class TypeScriptCompleter( Completer ):
 
   def DebugInfo( self, request_data ):
     with self._server_lock:
-      if self._ServerIsRunning():
-        return ( 'TypeScript completer debug information:\n'
-                 '  TSServer running\n'
-                 '  TSServer process ID: {0}\n'
-                 '  TSServer executable: {1}\n'
-                 '  TSServer logfile: {2}'.format( self._tsserver_handle.pid,
-                                                   PATH_TO_TSSERVER,
-                                                   self._logfile ) )
-      if self._logfile:
-        return ( 'TypeScript completer debug information:\n'
-                 '  TSServer no longer running\n'
-                 '  TSServer executable: {0}\n'
-                 '  TSServer logfile: {1}'.format( PATH_TO_TSSERVER,
-                                                   self._logfile ) )
+      tsserver = responses.DebugInfoServer( name = 'TSServer',
+                                            handle = self._tsserver_handle,
+                                            executable = PATH_TO_TSSERVER,
+                                            logfiles = [ self._logfile ] )
 
-      return ( 'TypeScript completer debug information:\n'
-               '  TSServer is not running\n'
-               '  TSServer executable: {0}'.format( PATH_TO_TSSERVER ) )
+      return responses.BuildDebugInfoResponse( name = 'TypeScript',
+                                               servers = [ tsserver ] )
 
 
 def _LogLevel():

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2013 Google Inc.
+#               2017 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -26,6 +27,8 @@ from builtins import *  # noqa
 import bottle
 import json
 import logging
+import platform
+import sys
 import time
 import traceback
 from bottle import request
@@ -33,7 +36,8 @@ from threading import Thread
 
 import ycm_core
 from ycmd import extra_conf_store, hmac_plugin, server_state, user_options_store
-from ycmd.responses import BuildExceptionResponse, BuildCompletionResponse
+from ycmd.responses import ( BuildExceptionResponse, BuildCompletionResponse,
+                             UnknownExtraConf )
 from ycmd.request_wrap import RequestWrap
 from ycmd.bottle_utils import SetResponseHeader
 from ycmd.completers.completer_utils import FilterAndSortCandidatesWrap
@@ -205,24 +209,42 @@ def IgnoreExtraConfFile():
 @app.post( '/debug_info' )
 def DebugInfo():
   _logger.info( 'Received debug info request' )
-
-  output = []
-  has_clang_support = ycm_core.HasClangSupport()
-  output.append( 'Server has Clang support compiled in: {0}'.format(
-    has_clang_support ) )
-
-  if has_clang_support:
-    output.append( 'Clang version: ' + ycm_core.ClangVersion() )
-
   request_data = RequestWrap( request.json )
-  try:
-    output.append(
-        _GetCompleterForRequestData( request_data ).DebugInfo( request_data ) )
-  except Exception:
-    _logger.debug( 'Exception in debug info request: '
-                   + traceback.format_exc() )
 
-  return _JsonResponse( '\n'.join( output ) )
+  has_clang_support = ycm_core.HasClangSupport()
+  clang_version = ycm_core.ClangVersion() if has_clang_support else None
+
+  filepath = request_data[ 'filepath' ]
+  try:
+    extra_conf_path = extra_conf_store.ModuleFileForSourceFile( filepath )
+    is_loaded = bool( extra_conf_path )
+  except UnknownExtraConf as error:
+    extra_conf_path = error.extra_conf_file
+    is_loaded = False
+
+  response = {
+    'python': {
+      'executable': sys.executable,
+      'version': platform.python_version()
+    },
+    'clang': {
+      'has_support': has_clang_support,
+      'version': clang_version
+    },
+    'extra_conf': {
+      'path': extra_conf_path,
+      'is_loaded': is_loaded
+    },
+    'completer': None
+  }
+
+  try:
+    response[ 'completer' ] = _GetCompleterForRequestData(
+        request_data ).DebugInfo( request_data )
+  except Exception as error:
+    _logger.exception( error )
+
+  return _JsonResponse( response )
 
 
 @app.post( '/shutdown' )

--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 ycmd contributors
+# Copyright (C) 2016-2017 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -31,7 +31,6 @@ import functools
 import json
 import os
 import psutil
-import re
 import requests
 import subprocess
 import sys
@@ -171,18 +170,11 @@ class Client_test( object ):
                     filetype = filetype )
     ).json()
 
-    pid_match = re.search( 'process ID: (\d+)', response )
-    if not pid_match:
-      raise RuntimeError( 'Cannot find PID in debug informations for {0} '
-                          'filetype.'.format( filetype ) )
-    subserver_pid = int( pid_match.group( 1 ) )
-    self._servers.append( psutil.Process( subserver_pid ) )
-
-    logfiles = re.findall( '(\S+\.log)', response )
-    if not logfiles:
-      raise RuntimeError( 'Cannot find logfiles in debug informations for {0} '
-                          'filetype.'.format( filetype ) )
-    self._logfiles.extend( logfiles )
+    for server in response[ 'completer' ][ 'servers' ]:
+      pid = server[ 'pid' ]
+      if pid:
+        self._servers.append( psutil.Process( pid ) )
+      self._logfiles.extend( server[ 'logfiles' ] )
 
 
   def AssertServersAreRunning( self ):

--- a/ycmd/tests/go/go_completer_test.py
+++ b/ycmd/tests/go/go_completer_test.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 #
 # Copyright (C) 2015 Google Inc.
+#               2017 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -103,7 +104,7 @@ def ComputeCandidatesInner_BeforeUnicode_test( completer, execute_command ):
   # Col 8 corresponds to cursor at log.Pr^int("Line 7 ...
   completer.ComputeCandidatesInner( BuildRequest( 7, 8 ) )
   execute_command.assert_called_once_with(
-    [ DUMMY_BINARY, '-sock', 'tcp', '-addr', completer._gocode_address,
+    [ DUMMY_BINARY, '-sock', 'tcp', '-addr', completer._gocode_host,
       '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '119' ],
     contents = ToBytes( ReadFile( PATH_TO_TEST_FILE ) ) )
 
@@ -116,7 +117,7 @@ def ComputeCandidatesInner_AfterUnicode_test( completer, execute_command ):
   # Col 9 corresponds to cursor at log.Pri^nt("Line 7 ...
   completer.ComputeCandidatesInner( BuildRequest( 9, 9 ) )
   execute_command.assert_called_once_with(
-    [ DUMMY_BINARY, '-sock', 'tcp', '-addr', completer._gocode_address,
+    [ DUMMY_BINARY, '-sock', 'tcp', '-addr', completer._gocode_host,
       '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '212' ],
     contents = ToBytes( ReadFile( PATH_TO_TEST_FILE ) ) )
 
@@ -129,7 +130,7 @@ def ComputeCandidatesInner_test( completer, execute_command ):
   # Col 40 corresponds to cursor at ..., log.Prefi^x ...
   result = completer.ComputeCandidatesInner( BuildRequest( 10, 40 ) )
   execute_command.assert_called_once_with(
-    [ DUMMY_BINARY, '-sock', 'tcp', '-addr', completer._gocode_address,
+    [ DUMMY_BINARY, '-sock', 'tcp', '-addr', completer._gocode_host,
       '-f=json', 'autocomplete', PATH_TO_TEST_FILE, '287' ],
     contents = ToBytes( ReadFile( PATH_TO_TEST_FILE ) ) )
   eq_( result, [ {

--- a/ycmd/tests/javascript/debug_info_test.py
+++ b/ycmd/tests/javascript/debug_info_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 ycmd contributors
+# Copyright (C) 2016-2017 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -23,48 +23,30 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from hamcrest import assert_that, matches_regexp
+from hamcrest import ( assert_that, contains, empty, has_entries, has_entry,
+                       instance_of )
 
-from ycmd.tests.javascript import IsolatedYcmd, SharedYcmd
-from ycmd.tests.test_utils import BuildRequest, StopCompleterServer, UserOption
+from ycmd.tests.javascript import SharedYcmd
+from ycmd.tests.test_utils import BuildRequest
 
 
 @SharedYcmd
-def DebugInfo_ServerIsRunning_test( app ):
+def DebugInfo_test( app ):
   request_data = BuildRequest( filetype = 'javascript' )
   assert_that(
     app.post_json( '/debug_info', request_data ).json,
-    matches_regexp( 'JavaScript completer debug information:\n'
-                    '  Tern running at: http://127.0.0.1:\d+\n'
-                    '  Tern process ID: \d+\n'
-                    '  Tern executable: .+\n'
-                    '  Tern logfiles:\n'
-                    '    .+\n'
-                    '    .+' ) )
-
-
-@IsolatedYcmd
-def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
-  with UserOption( 'server_keep_logfiles', True ):
-    StopCompleterServer( app, 'javascript' )
-    request_data = BuildRequest( filetype = 'javascript' )
-    assert_that(
-      app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'JavaScript completer debug information:\n'
-                      '  Tern no longer running\n'
-                      '  Tern executable: .+\n'
-                      '  Tern logfiles:\n'
-                      '    .+\n'
-                      '    .+' ) )
-
-
-@IsolatedYcmd
-def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
-  with UserOption( 'server_keep_logfiles', False ):
-    StopCompleterServer( app, 'javascript' )
-    request_data = BuildRequest( filetype = 'javascript' )
-    assert_that(
-      app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'JavaScript completer debug information:\n'
-                      '  Tern is not running\n'
-                      '  Tern executable: .+' ) )
+    has_entry( 'completer', has_entries( {
+      'name': 'JavaScript',
+      'servers': contains( has_entries( {
+        'name': 'Tern',
+        'is_running': instance_of( bool ),
+        'executable': instance_of( str ),
+        'pid': instance_of( int ),
+        'address': instance_of( str ),
+        'port': instance_of( int ),
+        'logfiles': contains( instance_of( str ),
+                              instance_of( str ) )
+      } ) ),
+      'items': empty()
+    } ) )
+  )

--- a/ycmd/tests/python/debug_info_test.py
+++ b/ycmd/tests/python/debug_info_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 ycmd contributors
+# Copyright (C) 2016-2017 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -23,51 +23,32 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from hamcrest import assert_that, matches_regexp
+from hamcrest import assert_that, contains, has_entry, has_entries, instance_of
 
-from ycmd.tests.python import IsolatedYcmd, SharedYcmd
-from ycmd.tests.test_utils import BuildRequest, StopCompleterServer, UserOption
+from ycmd.tests.python import SharedYcmd
+from ycmd.tests.test_utils import BuildRequest
 
 
 @SharedYcmd
-def DebugInfo_ServerIsRunning_test( app ):
+def DebugInfo_test( app ):
   request_data = BuildRequest( filetype = 'python' )
   assert_that(
     app.post_json( '/debug_info', request_data ).json,
-    matches_regexp( 'Python completer debug information:\n'
-                    '  JediHTTP running at: http://127.0.0.1:\d+\n'
-                    '  JediHTTP process ID: \d+\n'
-                    '  JediHTTP executable: .+\n'
-                    '  JediHTTP logfiles:\n'
-                    '    .+\n'
-                    '    .+\n'
-                    '  Python interpreter: .+' ) )
-
-
-@IsolatedYcmd
-def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
-  with UserOption( 'server_keep_logfiles', True ):
-    StopCompleterServer( app, 'python' )
-    request_data = BuildRequest( filetype = 'python' )
-    assert_that(
-      app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Python completer debug information:\n'
-                      '  JediHTTP no longer running\n'
-                      '  JediHTTP executable: .+\n'
-                      '  JediHTTP logfiles:\n'
-                      '    .+\n'
-                      '    .+\n'
-                      '  Python interpreter: .+' ) )
-
-
-@IsolatedYcmd
-def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
-  with UserOption( 'server_keep_logfiles', False ):
-    StopCompleterServer( app, 'python' )
-    request_data = BuildRequest( filetype = 'python' )
-    assert_that(
-      app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Python completer debug information:\n'
-                      '  JediHTTP is not running\n'
-                      '  JediHTTP executable: .+\n'
-                      '  Python interpreter: .+' ) )
+    has_entry( 'completer', has_entries( {
+      'name': 'Python',
+      'servers': contains( has_entries( {
+        'name': 'JediHTTP',
+        'is_running': instance_of( bool ),
+        'executable': instance_of( str ),
+        'pid': instance_of( int ),
+        'address': instance_of( str ),
+        'port': instance_of( int ),
+        'logfiles': contains( instance_of( str ),
+                              instance_of( str ) )
+      } ) ),
+      'items': contains( has_entries( {
+        'key': 'Python interpreter',
+        'value': instance_of( str )
+      } ) )
+    } ) )
+  )

--- a/ycmd/tests/rust/debug_info_test.py
+++ b/ycmd/tests/rust/debug_info_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 ycmd contributors
+# Copyright (C) 2016-2017 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -23,51 +23,32 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from hamcrest import assert_that, matches_regexp
+from hamcrest import assert_that, contains, has_entries, has_entry, instance_of
 
-from ycmd.tests.rust import IsolatedYcmd, SharedYcmd
-from ycmd.tests.test_utils import BuildRequest, StopCompleterServer, UserOption
+from ycmd.tests.rust import SharedYcmd
+from ycmd.tests.test_utils import BuildRequest
 
 
 @SharedYcmd
-def DebugInfo_ServerIsRunning_test( app ):
+def DebugInfo_test( app ):
   request_data = BuildRequest( filetype = 'rust' )
   assert_that(
     app.post_json( '/debug_info', request_data ).json,
-    matches_regexp( 'Rust completer debug information:\n'
-                    '  Racerd running at: http://127.0.0.1:\d+\n'
-                    '  Racerd process ID: \d+\n'
-                    '  Racerd executable: .+\n'
-                    '  Racerd logfiles:\n'
-                    '    .+\n'
-                    '    .+\n'
-                    '  Rust sources: .+' ) )
-
-
-@IsolatedYcmd
-def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
-  with UserOption( 'server_keep_logfiles', True ):
-    StopCompleterServer( app, 'rust' )
-    request_data = BuildRequest( filetype = 'rust' )
-    assert_that(
-      app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Rust completer debug information:\n'
-                      '  Racerd no longer running\n'
-                      '  Racerd executable: .+\n'
-                      '  Racerd logfiles:\n'
-                      '    .+\n'
-                      '    .+\n'
-                      '  Rust sources: .+' ) )
-
-
-@IsolatedYcmd
-def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
-  with UserOption( 'server_keep_logfiles', False ):
-    StopCompleterServer( app, 'rust' )
-    request_data = BuildRequest( filetype = 'rust' )
-    assert_that(
-      app.post_json( '/debug_info', request_data ).json,
-      matches_regexp( 'Rust completer debug information:\n'
-                      '  Racerd is not running\n'
-                      '  Racerd executable: .+\n'
-                      '  Rust sources: .+' ) )
+    has_entry( 'completer', has_entries( {
+      'name': 'Rust',
+      'servers': contains( has_entries( {
+        'name': 'Racerd',
+        'is_running': instance_of( bool ),
+        'executable': instance_of( str ),
+        'pid': instance_of( int ),
+        'address': instance_of( str ),
+        'port': instance_of( int ),
+        'logfiles': contains( instance_of( str ),
+                              instance_of( str ) )
+      } ) ),
+      'items': contains( has_entries( {
+        'key': 'Rust sources',
+        'value': None
+      } ) )
+    } ) )
+  )


### PR DESCRIPTION
Currently, the data returned by the `debug_info` handler is a block of text. This makes it difficult for clients to retrieve a specific information on the server (e.g. the path of the logfiles, the process identifier of a sub-server, etc.) or to customize the way it is displayed to the user.

We improve this by returning a dictionary instead of a string. Its structure is fully explained in [the new `debug_info` API documentation](http://micbou.github.io/ycmd/#path--debug_info).

There are two important changes on its content:
- add information on the Python interpreter used to start the ycmd server: its path and its version.
- move information on the `.ycm_extra_conf.py` file (its path and if it is loaded or not) from the Clang completer to ycmd itself since it is not supposed to be specific to this completer.

This is obviously an API-breaking change but not a big one since it only affects the `debug_info` handler.

@abingham @Qusic @LuckyGeck @mawww @richard1122

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/601)

<!-- Reviewable:end -->
