### PR TITLE
[READY] Add language flag only for C++ compilers

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -176,7 +176,7 @@ def _CallExtraConfFlagsForFile( module, filename, client_data ):
 
 
 def PrepareFlagsForClang( flags, filename, add_extra_clang_flags = True ):
-  flags = _CompilerToLanguageFlag( flags )
+  flags = _AddLanguageFlagWhenAppropriate( flags )
   flags = _RemoveXclangFlags( flags )
   flags = _RemoveUnusedFlags( flags, filename )
   if add_extra_clang_flags:
@@ -240,22 +240,24 @@ def _RemoveFlagsPrecedingCompiler( flags ):
   return flags[ :-1 ]
 
 
-def _CompilerToLanguageFlag( flags ):
-  """When flags come from the compile_commands.json file, the flag preceding
-  the first flag starting with a dash is usually the path to the compiler that
-  should be invoked.  We want to replace it with a corresponding language flag.
-  E.g., -x c for gcc and -x c++ for g++."""
+def _AddLanguageFlagWhenAppropriate( flags ):
+  """When flags come from the compile_commands.json file, the flag preceding the
+  first flag starting with a dash is usually the path to the compiler that
+  should be invoked. Since LibClang does not deduce the language from the
+  compiler name, we explicitely set the language to C++ if the compiler is a C++
+  one (g++, clang++, etc.). Otherwise, we let LibClang guess the language from
+  the file extension. This handles the case where the .h extension is used for
+  C++ headers."""
 
   flags = _RemoveFlagsPrecedingCompiler( flags )
 
-  # First flag is now the compiler path or a flag starting with a dash
-  if flags[ 0 ].startswith( '-' ):
-    return flags
+  # First flag is now the compiler path or a flag starting with a dash.
+  first_flag = flags[ 0 ]
 
-  language = ( 'c++' if CPP_COMPILER_REGEX.search( flags[ 0 ] ) else
-               'c' )
-
-  return flags[ :1 ] + [ '-x', language ] + flags[ 1: ]
+  if ( not first_flag.startswith( '-' ) and
+       CPP_COMPILER_REGEX.search( first_flag ) ):
+    return [ first_flag, '-x', 'c++' ] + flags[ 1: ]
+  return flags
 
 
 def _RemoveUnusedFlags( flags, filename ):

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -300,12 +300,12 @@ def RemoveXclangFlags_test():
        flags._RemoveXclangFlags( expected + to_remove + expected ) )
 
 
-def CompilerToLanguageFlag_Passthrough_test():
+def AddLanguageFlagWhenAppropriate_Passthrough_test():
   eq_( [ '-foo', '-bar' ],
-       flags._CompilerToLanguageFlag( [ '-foo', '-bar' ] ) )
+       flags._AddLanguageFlagWhenAppropriate( [ '-foo', '-bar' ] ) )
 
 
-def _ReplaceCompilerTester( compiler, language ):
+def _AddLanguageFlagWhenAppropriateTester( compiler, language_flag = [] ):
   to_removes = [
     [],
     [ '/usr/bin/ccache' ],
@@ -314,19 +314,20 @@ def _ReplaceCompilerTester( compiler, language ):
   expected = [ '-foo', '-bar' ]
 
   for to_remove in to_removes:
-    eq_( [ compiler, '-x', language ] + expected,
-         flags._CompilerToLanguageFlag( to_remove + [ compiler ] + expected ) )
+    eq_( [ compiler ] + language_flag + expected,
+         flags._AddLanguageFlagWhenAppropriate( to_remove + [ compiler ] +
+                                                expected ) )
 
 
-def CompilerToLanguageFlag_ReplaceCCompiler_test():
+def AddLanguageFlagWhenAppropriate_CCompiler_test():
   compilers = [ 'cc', 'gcc', 'clang', '/usr/bin/cc',
                 '/some/other/path', 'some_command' ]
 
   for compiler in compilers:
-    yield _ReplaceCompilerTester, compiler, 'c'
+    yield _AddLanguageFlagWhenAppropriateTester, compiler
 
 
-def CompilerToLanguageFlag_ReplaceCppCompiler_test():
+def AddLanguageFlagWhenAppropriate_CppCompiler_test():
   compilers = [ 'c++', 'g++', 'clang++', '/usr/bin/c++',
                 '/some/other/path++', 'some_command++',
                 'c++-5', 'g++-5.1', 'clang++-3.7.3', '/usr/bin/c++-5',
@@ -335,7 +336,7 @@ def CompilerToLanguageFlag_ReplaceCppCompiler_test():
                 '/some/other/path++-4.9.31', 'some_command++-5.10' ]
 
   for compiler in compilers:
-    yield _ReplaceCompilerTester, compiler, 'c++'
+    yield _AddLanguageFlagWhenAppropriateTester, compiler, [ '-x', 'c++' ]
 
 
 def ExtraClangFlags_test():


### PR DESCRIPTION
Currently, if we find a compiler path in the list of flags and its name is not a C++ one, we set the language flag `-x` to `c`. This is unnecessary and even harmful in some cases because libclang guesses the language mode from the file extension. For instance, if the compiler name is `clang` and the file extension is `.cpp`, libclang will automatically use C++. We don't want to set the language to C in this case.

Fixes #538.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/603)
<!-- Reviewable:end -->
