### PR TITLE
Use utils.OpenForStdHandle instead of open in go_completer.

### DIFF
--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -223,8 +223,8 @@ class GoCompleter( Completer ):
       self._gocode_stderr = LOG_FILENAME_FORMAT.format(
           port = self._gocode_port, std = 'stderr' )
 
-      with open( self._gocode_stdout, 'w' ) as stdout:
-        with open( self._gocode_stderr, 'w' ) as stderr:
+      with utils.OpenForStdHandle( self._gocode_stdout ) as stdout:
+        with utils.OpenForStdHandle( self._gocode_stderr ) as stderr:
           self._gocode_handle = utils.SafePopen( command,
                                                  stdout = stdout,
                                                  stderr = stderr )


### PR DESCRIPTION
This fixes the go completer issue in #607.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/608)
<!-- Reviewable:end -->
