### PR TITLE
[READY] Support GetTypeQuick completer subcommand in clang completer

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -131,6 +131,10 @@ class ClangCompleter( Completer ):
          self._ClearCompilationFlagCache() ),
       'GetType'                  : ( lambda self, request_data, args:
          self._GetSemanticInfo( request_data, func = 'GetTypeAtLocation' ) ),
+      'GetTypeImprecise'         : ( lambda self, request_data, args:
+         self._GetSemanticInfo( request_data,
+                                func = 'GetTypeAtLocation',
+                                reparse = False ) ),
       'GetParent'                : ( lambda self, request_data, args:
          self._GetSemanticInfo( request_data,
                                 func = 'GetEnclosingFunctionAtLocation' ) ),

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -385,6 +385,14 @@ def Subcommands_GetType_test():
             test,
             [ 'GetType' ] )
 
+  # For every practical scenario, GetTypeImprecise is the same as GetType (it
+  # just skips the reparse)
+  for test in tests:
+    yield ( RunGetSemanticTest,
+            'GetType_Clang_test.cc',
+            test,
+            [ 'GetTypeImprecise' ] )
+
 
 def Subcommands_GetParent_test():
   tests = [


### PR DESCRIPTION
This sacrifices accuracy for speed, so that it can be used from, say, a vim auto command.

I've had this for a _long_ time in my fork, and a number of people have requested PR for it, so here it is.

I know there was some discussion that is should be GetTypeImprecise, but personally I think that's a bit of a mouthful (fistful?) to type... Open to thoughts, though all my bindings are to `GetTypeQuick` so I am totally biassed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/609)
<!-- Reviewable:end -->
