### PR TITLE
[READY] Use OS X 10.11 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: csharp
 os:
   - linux
   - osx
+osx_image: xcode8
 sudo: false
 mono:
   - 4.2.3

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -32,7 +32,9 @@ eval "$(pyenv init -)"
 if [ "${YCMD_PYTHON_VERSION}" == "2.6" ]; then
   PYENV_VERSION="2.6.6"
 elif [ "${YCMD_PYTHON_VERSION}" == "2.7" ]; then
-  PYENV_VERSION="2.7.6"
+  # We need a recent enough version of Python 2.7 on OS X or an error occurs
+  # when installing the psutil dependency for our tests.
+  PYENV_VERSION="2.7.8"
 else
   PYENV_VERSION="3.3.6"
 fi


### PR DESCRIPTION
This fixes our OS X Travis builds. See https://github.com/Valloric/ycmd/pull/612#issuecomment-250829416.

As suggested by @vheon, I went for using the latest version available on Travis. This is currently OS X 10.11 (with Xcode 8) but according to [this blog post](https://blog.travis-ci.com/2016-09-15-new-default-osx-image-coming/), it could be soon macOS 10.12.

When using Python 2.7.6 on this new version of OS X, we get this error while installing (and compiling) the `psutil` dependency for our tests:
```sh
clang: error: no such file or directory: 'Python.framework/Versions/2.7/Python'
error: command 'clang' failed with exit status 1
```
This error goes away with Python 2.7.8 or later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/613)
<!-- Reviewable:end -->
