### PR TITLE
[READY] Rename GetDocQuick subcommand to GetDocImprecise

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -145,7 +145,7 @@ class ClangCompleter( Completer ):
                                 reparse = True,
                                 func = 'GetDocsForLocationInFile',
                                 response_builder = _BuildGetDocResponse ) ),
-      'GetDocQuick'              : ( lambda self, request_data, args:
+      'GetDocImprecise'          : ( lambda self, request_data, args:
          self._GetSemanticInfo( request_data,
                                 reparse = False,
                                 func = 'GetDocsForLocationInFile',

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -43,6 +43,25 @@ from ycmd.utils import ReadFile
 
 
 @SharedYcmd
+def Subcommands_DefinedSubcommands_test( app ):
+  subcommands_data = BuildRequest( completer_target = 'cpp' )
+  eq_( sorted( [ 'ClearCompilationFlagCache',
+                 'FixIt',
+                 'GetDoc',
+                 'GetDocImprecise',
+                 'GetParent',
+                 'GetType',
+                 'GetTypeImprecise',
+                 'GoTo',
+                 'GoToDeclaration',
+                 'GoToDefinition',
+                 'GoToImprecise',
+                 'GoToInclude' ] ),
+       app.post_json( '/defined_subcommands',
+                      subcommands_data ).json )
+
+
+@SharedYcmd
 def Subcommands_GoTo_ZeroBasedLineAndColumn_test( app ):
   contents = ReadFile( PathToTestFile(
     'GoTo_Clang_ZeroBasedLineAndColumn_test.cc' ) )
@@ -941,7 +960,7 @@ def Subcommands_GetDoc_NoCursor_test( app ):
 
 # Following tests repeat the tests above, but without re-parsing the file
 @SharedYcmd
-def Subcommands_GetDocQuick_Variable_test( app ):
+def Subcommands_GetDocImprecise_Variable_test( app ):
   filepath = PathToTestFile( 'GetDoc_Clang.cc' )
   contents = ReadFile( filepath )
 
@@ -958,7 +977,7 @@ def Subcommands_GetDocQuick_Variable_test( app ):
                              line_num = 70,
                              column_num = 24,
                              contents = contents,
-                             command_arguments = [ 'GetDocQuick' ],
+                             command_arguments = [ 'GetDocImprecise' ],
                              completer_target = 'filetype_default' )
 
   response = app.post_json( '/run_completer_command', event_data ).json
@@ -978,7 +997,7 @@ The first line of comment is the brief.""" } )
 
 
 @SharedYcmd
-def Subcommands_GetDocQuick_Method_test( app ):
+def Subcommands_GetDocImprecise_Method_test( app ):
   filepath = PathToTestFile( 'GetDoc_Clang.cc' )
   contents = ReadFile( filepath )
 
@@ -997,7 +1016,7 @@ def Subcommands_GetDocQuick_Method_test( app ):
                              line_num = 22,
                              column_num = 13,
                              contents = contents,
-                             command_arguments = [ 'GetDocQuick' ],
+                             command_arguments = [ 'GetDocImprecise' ],
                              completer_target = 'filetype_default' )
 
   response = app.post_json( '/run_completer_command', event_data ).json
@@ -1021,7 +1040,7 @@ This is more information
 
 
 @SharedYcmd
-def Subcommands_GetDocQuick_Namespace_test( app ):
+def Subcommands_GetDocImprecise_Namespace_test( app ):
   filepath = PathToTestFile( 'GetDoc_Clang.cc' )
   contents = ReadFile( filepath )
 
@@ -1040,7 +1059,7 @@ def Subcommands_GetDocQuick_Namespace_test( app ):
                              line_num = 65,
                              column_num = 14,
                              contents = contents,
-                             command_arguments = [ 'GetDocQuick' ],
+                             command_arguments = [ 'GetDocImprecise' ],
                              completer_target = 'filetype_default' )
 
   response = app.post_json( '/run_completer_command', event_data ).json
@@ -1058,7 +1077,7 @@ This is a test namespace""" } ) # noqa
 
 
 @SharedYcmd
-def Subcommands_GetDocQuick_Undocumented_test( app ):
+def Subcommands_GetDocImprecise_Undocumented_test( app ):
   filepath = PathToTestFile( 'GetDoc_Clang.cc' )
   contents = ReadFile( filepath )
 
@@ -1077,7 +1096,7 @@ def Subcommands_GetDocQuick_Undocumented_test( app ):
                              line_num = 81,
                              column_num = 17,
                              contents = contents,
-                             command_arguments = [ 'GetDocQuick' ],
+                             command_arguments = [ 'GetDocImprecise' ],
                              completer_target = 'filetype_default' )
 
   response = app.post_json( '/run_completer_command',
@@ -1091,7 +1110,7 @@ def Subcommands_GetDocQuick_Undocumented_test( app ):
 
 
 @SharedYcmd
-def Subcommands_GetDocQuick_NoCursor_test( app ):
+def Subcommands_GetDocImprecise_NoCursor_test( app ):
   filepath = PathToTestFile( 'GetDoc_Clang.cc' )
   contents = ReadFile( filepath )
 
@@ -1110,7 +1129,7 @@ def Subcommands_GetDocQuick_NoCursor_test( app ):
                              line_num = 1,
                              column_num = 1,
                              contents = contents,
-                             command_arguments = [ 'GetDocQuick' ],
+                             command_arguments = [ 'GetDocImprecise' ],
                              completer_target = 'filetype_default' )
 
   response = app.post_json( '/run_completer_command',
@@ -1124,7 +1143,7 @@ def Subcommands_GetDocQuick_NoCursor_test( app ):
 
 
 @SharedYcmd
-def Subcommands_GetDocQuick_NoReadyToParse_test( app ):
+def Subcommands_GetDocImprecise_NoReadyToParse_test( app ):
   filepath = PathToTestFile( 'GetDoc_Clang.cc' )
   contents = ReadFile( filepath )
 
@@ -1134,7 +1153,7 @@ def Subcommands_GetDocQuick_NoReadyToParse_test( app ):
                              line_num = 11,
                              column_num = 18,
                              contents = contents,
-                             command_arguments = [ 'GetDocQuick' ],
+                             command_arguments = [ 'GetDocImprecise' ],
                              completer_target = 'filetype_default' )
 
   response = app.post_json( '/run_completer_command', event_data ).json


### PR DESCRIPTION
For consistency with other subcommands (`GoToImprecise` and `GetTypeImprecise`). We don't care about backward compatibility because this subcommand is not documented.

Added a test to check the list of subcommands defined by the Clang completer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/615)
<!-- Reviewable:end -->
