### PR TITLE
[READY] Use GCC 4.8 instead of GCC 6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ addons:
     packages:
      - cmake-data
      - cmake
-     - g++-6
+     # 4.8.1 is the first version of GCC with full C++11 support.
+     - g++-4.8
      - ninja-build
      # Everything below is a Python build dep (though it depends on Python
      # version). We need them because pyenv builds Python.

--- a/ci/travis/travis_install.linux.sh
+++ b/ci/travis/travis_install.linux.sh
@@ -5,8 +5,8 @@
 
 mkdir ${HOME}/bin
 
-ln -s /usr/bin/g++-6 ${HOME}/bin/c++
-ln -s /usr/bin/gcc-6 ${HOME}/bin/cc
+ln -s /usr/bin/g++-4.8 ${HOME}/bin/c++
+ln -s /usr/bin/gcc-4.8 ${HOME}/bin/cc
 
 export PATH=${HOME}/bin:${PATH}
 


### PR DESCRIPTION
Since we are planning to move the code base to C++11, using on Travis [the first version of GCC that fully support it](https://gcc.gnu.org/projects/cxx-status.html#cxx11) makes sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/616)
<!-- Reviewable:end -->
