### PR TITLE
Add utils.JoinLinesAsUnicode.

### DIFF
--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -32,7 +32,7 @@ from shutil import rmtree
 import ycm_core
 from future.utils import native
 from mock import patch, call
-from nose.tools import eq_, ok_
+from nose.tools import eq_, ok_, raises
 from ycmd import utils
 from ycmd.tests.test_utils import ( Py2Only, Py3Only, WindowsOnly, UnixOnly,
                                     CurrentWorkingDirectory,
@@ -159,6 +159,57 @@ def ToUnicode_None_test():
   value = utils.ToUnicode( None )
   eq_( value, u'' )
   ok_( isinstance( value, str ) )
+
+
+@Py2Only
+def JoinLinesAsUnicode_Py2Bytes_test():
+  value = utils.JoinLinesAsUnicode( [ bytes( 'abc' ), bytes( 'xyz' ) ] )
+  eq_( value, u'abc\nxyz' )
+  ok_( isinstance( value, str ) )
+
+
+@Py2Only
+def JoinLinesAsUnicode_Py2Str_test():
+  value = utils.JoinLinesAsUnicode( [ 'abc', 'xyz' ] )
+  eq_( value, u'abc\nxyz' )
+  ok_( isinstance( value, str ) )
+
+
+@Py2Only
+def JoinLinesAsUnicode_Py2FutureStr_test():
+  value = utils.JoinLinesAsUnicode( [ str( 'abc' ), str( 'xyz' ) ] )
+  eq_( value, u'abc\nxyz' )
+  ok_( isinstance( value, str ) )
+
+
+@Py2Only
+def JoinLinesAsUnicode_Py2Unicode_test():
+  value = utils.JoinLinesAsUnicode( [ u'abc', u'xyz' ] )
+  eq_( value, u'abc\nxyz' )
+  ok_( isinstance( value, str ) )
+
+
+def JoinLinesAsUnicode_Bytes_test():
+  value = utils.JoinLinesAsUnicode( [ bytes( b'abc' ), bytes( b'xyz' ) ] )
+  eq_( value, u'abc\nxyz' )
+  ok_( isinstance( value, str ) )
+
+
+def JoinLinesAsUnicode_Str_test():
+  value = utils.JoinLinesAsUnicode( [ u'abc', u'xyz' ] )
+  eq_( value, u'abc\nxyz' )
+  ok_( isinstance( value, str ) )
+
+
+def JoinLinesAsUnicode_EmptyList_test():
+  value = utils.JoinLinesAsUnicode( [ ] )
+  eq_( value, u'' )
+  ok_( isinstance( value, str ) )
+
+
+@raises( ValueError )
+def JoinLinesAsUnicode_BadInput_test():
+  utils.JoinLinesAsUnicode( [ 42 ] )
 
 
 @Py2Only

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -97,6 +97,22 @@ def ToUnicode( value ):
   return str( value )
 
 
+# When lines is an iterable of all strings or all bytes, equivalent to
+#   '\n'.join( ToUnicode( lines ) )
+# but faster on large inputs.
+def JoinLinesAsUnicode( lines ):
+  try:
+    first = next( iter( lines ) )
+  except StopIteration:
+    return str()
+
+  if isinstance( first, str ):
+    return ToUnicode( '\n'.join( lines ) )
+  if isinstance( first, bytes ):
+    return ToUnicode( b'\n'.join( lines ) )
+  raise ValueError( 'lines must contain either strings or bytes.' )
+
+
 # Consistently returns the new bytes() type from python-future. Assumes incoming
 # strings are either UTF-8 or unicode (which is converted to UTF-8).
 def ToBytes( value ):


### PR DESCRIPTION
This is a (much) faster equivalent to

  '\n'.join ( utils.ToUnicode( x ) for x in lines )

This is useful in the YCM routines that read in the entire buffer from
vim -- using this instead of ToUnicode reduces the keypress latency for
me on a large file (15+k loc) from ~100ms to <10ms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/617)
<!-- Reviewable:end -->
