### PR TITLE
[READY] Filter completers set to None in GetLoadedFiletypeCompleters

### DIFF
--- a/ycmd/server_state.py
+++ b/ycmd/server_state.py
@@ -26,7 +26,7 @@ from builtins import *  # noqa
 import os
 import threading
 import logging
-from future.utils import listvalues
+from future.utils import itervalues
 from ycmd.utils import ForceSemanticCompletion, LoadPythonSource
 from ycmd.completers.general.general_completer_store import (
     GeneralCompleterStore )
@@ -92,7 +92,8 @@ class ServerState( object ):
 
   def GetLoadedFiletypeCompleters( self ):
     with self._filetype_completers_lock:
-      return set( listvalues( self._filetype_completers ) )
+      return set( [ completer for completer in
+                    itervalues( self._filetype_completers ) if completer ] )
 
 
   def FiletypeCompletionAvailable( self, filetypes ):

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -26,7 +26,7 @@ from future.utils import iteritems
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from future.utils import itervalues, PY2
+from future.utils import PY2
 from hamcrest import contains_string, has_entry, has_entries, assert_that
 from mock import patch
 from webtest import TestApp
@@ -232,10 +232,8 @@ def ClearCompletionsCache():
   This function is used when sharing the application between tests so that
   no completions are cached by previous tests."""
   server_state = handlers._server_state
-  filetype_completers = server_state._filetype_completers
-  for completer in itervalues( filetype_completers ):
-    if completer:
-      completer._completions_cache.Invalidate()
+  for completer in server_state.GetLoadedFiletypeCompleters():
+    completer._completions_cache.Invalidate()
   general_completer = server_state.GetGeneralCompleter()
   for completer in general_completer._all_completers:
     completer._completions_cache.Invalidate()


### PR DESCRIPTION
The set returned by `GetLoadedFiletypeCompleters` may contain `None` when a filetype exists with no semantic completer. This results in the following error in [`KeepSubserversAlive`](https://github.com/Valloric/ycmd/blob/master/ycmd/handlers.py#L315):
```python
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/Users/zqb/.vim/bundle/YouCompleteMe/third_party/ycmd/ycmd/../ycmd/handlers.py", line 323, in Keepalive
    completer.ServerIsHealthy()
AttributeError: 'NoneType' object has no attribute 'ServerIsHealthy'
```
We fix this by filtering completers set to `None`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/621)
<!-- Reviewable:end -->
