### PR TITLE
[READY] Fix unicode issues when working with current directory on Python 2

### DIFF
--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -33,7 +33,7 @@ from ycmd.completers.completer_utils import ( AtIncludeStatementStart,
                                               GetIncludeStatementValue )
 from ycmd.completers.cpp.clang_completer import InCFamilyFile
 from ycmd.completers.cpp.flags import Flags
-from ycmd.utils import ToUnicode, OnWindows
+from ycmd.utils import GetCurrentDirectory, OnWindows, ToUnicode
 from ycmd import responses
 
 EXTRA_INFO_MAP = { 1 : '[File]', 2 : '[Dir]', 3 : '[File&Dir]' }
@@ -184,7 +184,7 @@ def _GetAbsolutePathForCompletions( path_dir,
     if working_dir:
       return os.path.join( working_dir, path_dir )
     else:
-      return os.path.join( os.getcwd(), path_dir )
+      return os.path.join( GetCurrentDirectory(), path_dir )
   else:
     # Return paths relative to the file
     return os.path.join( os.path.join( os.path.dirname( filepath ) ),

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -154,11 +154,12 @@ class TernCompleter( Completer ):
     if self._ServerIsRunning() and self._do_tern_project_check:
       self._do_tern_project_check = False
 
-      ( tern_project, is_project ) = FindTernProjectFile( os.getcwd() )
+      current_dir = utils.GetCurrentDirectory()
+      ( tern_project, is_project ) = FindTernProjectFile( current_dir )
       if not tern_project:
-        _logger.warning( 'No .tern-project file detected: ' + os.getcwd() )
+        _logger.warning( 'No .tern-project file detected: ' + current_dir )
         raise RuntimeError( 'Warning: Unable to detect a .tern-project file '
-                            'in the hierarchy before ' + os.getcwd() +
+                            'in the hierarchy before ' + current_dir +
                             ' and no global .tern-config file was found. '
                             'This is required for accurate JavaScript '
                             'completion. Please see the User Guide for '
@@ -170,7 +171,7 @@ class TernCompleter( Completer ):
         # are relative to the working directory of Tern server (which is the
         # same as the working directory of ycmd).
         self._server_paths_relative_to = (
-          os.path.dirname( tern_project ) if is_project else os.getcwd() )
+          os.path.dirname( tern_project ) if is_project else current_dir )
 
         _logger.info( 'Tern paths are relative to: '
                       + self._server_paths_relative_to )

--- a/ycmd/tests/filename_completer_test.py
+++ b/ycmd/tests/filename_completer_test.py
@@ -27,10 +27,11 @@ from builtins import *  # noqa
 
 import os
 from hamcrest import assert_that, contains_inanyorder
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 from ycmd.completers.general.filename_completer import FilenameCompleter
 from ycmd.request_wrap import RequestWrap
 from ycmd import user_options_store
+from ycmd.tests.test_utils import CurrentWorkingDirectory, UserOption
 from ycmd.utils import GetCurrentDirectory, ToBytes
 
 TEST_DIR = os.path.dirname( os.path.abspath( __file__ ) )
@@ -337,106 +338,68 @@ class FilenameCompleter_test( object ):
 
 
 def WorkingDir_UseFilePath_test():
-  assert GetCurrentDirectory() != DATA_DIR, ( 'Please run this test from a '
-                                              'different directory' )
+  ok_( GetCurrentDirectory() != DATA_DIR, ( 'Please run this test from a '
+                                            'different directory' ) )
 
-  options = user_options_store.DefaultOptions()
-  options.update( {
-    'filepath_completion_use_working_dir': 0
-  } )
-  completer = FilenameCompleter( options )
+  with UserOption( 'filepath_completion_use_working_dir', 0 ) as options:
+    completer = FilenameCompleter( options )
 
-  data = sorted( _CompletionResultsForLine( completer, 'ls ./include/' ) )
-  eq_( [
-        ( 'Qt',       '[Dir]' ),
-        ( 'QtGui',    '[Dir]' ),
-      ], data )
+    data = sorted( _CompletionResultsForLine( completer, 'ls ./include/' ) )
+    eq_( [
+      ( 'Qt',    '[Dir]' ),
+      ( 'QtGui', '[Dir]' )
+    ], data )
 
 
 def WorkingDir_UseServerWorkingDirectory_test():
-  # Store the working directory so we can return to it.
-  wd = GetCurrentDirectory()
-
   test_dir = os.path.join( DATA_DIR, 'include' )
-  assert wd != test_dir, 'Please run this test from a different directory'
+  with CurrentWorkingDirectory( test_dir ) as old_current_dir:
+    ok_( old_current_dir != test_dir, ( 'Please run this test from a different '
+                                        'directory' ) )
 
-  try:
-    options = user_options_store.DefaultOptions()
-    options.update( {
-      'filepath_completion_use_working_dir': 1
-    } )
+    with UserOption( 'filepath_completion_use_working_dir', 1 ) as options:
+      completer = FilenameCompleter( options )
 
-    completer = FilenameCompleter( options )
-
-    # Change current directory to DATA_DIR/include (path to which we expect
-    # results to be relative).
-    os.chdir( test_dir )
-
-    # We don't supply working_dir in the request, so the current working
-    # directory is used.
-    data = sorted( _CompletionResultsForLine( completer, 'ls ./' ) )
-    eq_( [
-          ( 'Qt',       '[Dir]' ),
-          ( 'QtGui',    '[Dir]' ),
-        ], data )
-
-  finally:
-    os.chdir( wd )
+      # We don't supply working_dir in the request, so the current working
+      # directory is used.
+      data = sorted( _CompletionResultsForLine( completer, 'ls ./' ) )
+      eq_( [
+        ( 'Qt',    '[Dir]' ),
+        ( 'QtGui', '[Dir]' )
+      ], data )
 
 
 def WorkingDir_UseServerWorkingDirectory_Unicode_test():
-  # Store the working directory so we can return to it.
-  wd = GetCurrentDirectory()
-
   test_dir = os.path.join( TEST_DIR, 'testdata', 'filename_completer', '∂†∫' )
-  assert wd != test_dir, 'Please run this test from a different directory'
+  with CurrentWorkingDirectory( test_dir ) as old_current_dir:
+    ok_( old_current_dir != test_dir, ( 'Please run this test from a different '
+                                        'directory' ) )
 
-  try:
-    options = user_options_store.DefaultOptions()
-    options.update( {
-      'filepath_completion_use_working_dir': 1
-    } )
+    with UserOption( 'filepath_completion_use_working_dir', 1 ) as options:
+      completer = FilenameCompleter( options )
 
-    completer = FilenameCompleter( options )
-
-    # Change current directory to path with unicode characters.
-    os.chdir( test_dir )
-
-    # We don't supply working_dir in the request, so the current working
-    # directory is used.
-    data = sorted( _CompletionResultsForLine( completer, 'ls ./' ) )
-    eq_( [
-          ( '†es†.txt', '[File]' )
-        ], data )
-
-  finally:
-    os.chdir( wd )
+      # We don't supply working_dir in the request, so the current working
+      # directory is used.
+      data = sorted( _CompletionResultsForLine( completer, 'ls ./' ) )
+      eq_( [
+        ( '†es†.txt', '[File]' )
+      ], data )
 
 
 def WorkingDir_UseClientWorkingDirectory_test():
-  # Store the working directory so we can return to it.
-  wd = GetCurrentDirectory()
-
   test_dir = os.path.join( DATA_DIR, 'include' )
-  assert wd != test_dir, 'Please run this test from a different directory'
+  ok_( GetCurrentDirectory() != test_dir, ( 'Please run this test from a '
+                                            'different directory' ) )
 
-  try:
-    options = user_options_store.DefaultOptions()
-    options.update( {
-      'filepath_completion_use_working_dir': 1
-    } )
-
+  with UserOption( 'filepath_completion_use_working_dir', 1 ) as options:
     completer = FilenameCompleter( options )
 
-    # We supply working_dir in the request, so we expect results to be relative
-    # to the supplied path.
+    # We supply working_dir in the request, so we expect results to be
+    # relative to the supplied path.
     data = sorted( _CompletionResultsForLine( completer, 'ls ./', {
-      'working_dir': os.path.join( DATA_DIR, 'include' )
+      'working_dir': test_dir
     } ) )
     eq_( [
-          ( 'Qt',       '[Dir]' ),
-          ( 'QtGui',    '[Dir]' ),
-        ], data )
-
-  finally:
-    os.chdir( wd )
+      ( 'Qt',    '[Dir]' ),
+      ( 'QtGui', '[Dir]' )
+    ], data )

--- a/ycmd/tests/filename_completer_test.py
+++ b/ycmd/tests/filename_completer_test.py
@@ -35,9 +35,9 @@ from ycmd.utils import ToBytes
 
 TEST_DIR = os.path.dirname( os.path.abspath( __file__ ) )
 DATA_DIR = os.path.join( TEST_DIR,
-                         "testdata",
-                         "filename_completer",
-                         "inner_dir" )
+                         'testdata',
+                         'filename_completer',
+                         'inner_dir' )
 PATH_TO_TEST_FILE = os.path.join( DATA_DIR, "test.cpp" )
 
 REQUEST_DATA = {
@@ -336,9 +336,9 @@ class FilenameCompleter_test( object ):
                                       ( '∂†∫', '[Dir]' )  ) )
 
 
-def WorkingDir_Use_File_Path_test():
-  assert os.getcwd() != DATA_DIR, ( "Please run this test from a different "
-                                    "directory" )
+def WorkingDir_UseFilePath_test():
+  assert os.getcwd() != DATA_DIR, ( 'Please run this test from a different '
+                                    'directory' )
 
   options = user_options_store.DefaultOptions()
   options.update( {
@@ -353,12 +353,12 @@ def WorkingDir_Use_File_Path_test():
       ], data )
 
 
-def WorkingDir_Use_ycmd_WD_test():
-  # Store the working directory so we can return to it
+def WorkingDir_UseServerWorkingDirectory_test():
+  # Store the working directory so we can return to it.
   wd = os.getcwd()
 
   test_dir = os.path.join( DATA_DIR, 'include' )
-  assert wd != test_dir, "Please run this test from a different directory"
+  assert wd != test_dir, 'Please run this test from a different directory'
 
   try:
     options = user_options_store.DefaultOptions()
@@ -369,7 +369,7 @@ def WorkingDir_Use_ycmd_WD_test():
     completer = FilenameCompleter( options )
 
     # Change current directory to DATA_DIR/include (path to which we expect
-    # results to be relative)
+    # results to be relative).
     os.chdir( test_dir )
 
     # We don't supply working_dir in the request, so the current working
@@ -384,12 +384,41 @@ def WorkingDir_Use_ycmd_WD_test():
     os.chdir( wd )
 
 
-def WorkingDir_Use_Client_WD_test():
-  # Store the working directory so we can return to it
+def WorkingDir_UseServerWorkingDirectory_Unicode_test():
+  # Store the working directory so we can return to it.
+  wd = os.getcwd()
+
+  test_dir = os.path.join( TEST_DIR, 'testdata', 'filename_completer', '∂†∫' )
+  assert wd != test_dir, 'Please run this test from a different directory'
+
+  try:
+    options = user_options_store.DefaultOptions()
+    options.update( {
+      'filepath_completion_use_working_dir': 1
+    } )
+
+    completer = FilenameCompleter( options )
+
+    # Change current directory to path with unicode characters.
+    os.chdir( test_dir )
+
+    # We don't supply working_dir in the request, so the current working
+    # directory is used.
+    data = sorted( _CompletionResultsForLine( completer, 'ls ./' ) )
+    eq_( [
+          ( '†es†.txt', '[File]' )
+        ], data )
+
+  finally:
+    os.chdir( wd )
+
+
+def WorkingDir_UseClientWorkingDirectory_test():
+  # Store the working directory so we can return to it.
   wd = os.getcwd()
 
   test_dir = os.path.join( DATA_DIR, 'include' )
-  assert wd != test_dir, "Please run this test from a different directory"
+  assert wd != test_dir, 'Please run this test from a different directory'
 
   try:
     options = user_options_store.DefaultOptions()
@@ -400,7 +429,7 @@ def WorkingDir_Use_Client_WD_test():
     completer = FilenameCompleter( options )
 
     # We supply working_dir in the request, so we expect results to be relative
-    # to the supplied path
+    # to the supplied path.
     data = sorted( _CompletionResultsForLine( completer, 'ls ./', {
       'working_dir': os.path.join( DATA_DIR, 'include' )
     } ) )

--- a/ycmd/tests/filename_completer_test.py
+++ b/ycmd/tests/filename_completer_test.py
@@ -31,7 +31,7 @@ from nose.tools import eq_
 from ycmd.completers.general.filename_completer import FilenameCompleter
 from ycmd.request_wrap import RequestWrap
 from ycmd import user_options_store
-from ycmd.utils import ToBytes
+from ycmd.utils import GetCurrentDirectory, ToBytes
 
 TEST_DIR = os.path.dirname( os.path.abspath( __file__ ) )
 DATA_DIR = os.path.join( TEST_DIR,
@@ -337,8 +337,8 @@ class FilenameCompleter_test( object ):
 
 
 def WorkingDir_UseFilePath_test():
-  assert os.getcwd() != DATA_DIR, ( 'Please run this test from a different '
-                                    'directory' )
+  assert GetCurrentDirectory() != DATA_DIR, ( 'Please run this test from a '
+                                              'different directory' )
 
   options = user_options_store.DefaultOptions()
   options.update( {
@@ -355,7 +355,7 @@ def WorkingDir_UseFilePath_test():
 
 def WorkingDir_UseServerWorkingDirectory_test():
   # Store the working directory so we can return to it.
-  wd = os.getcwd()
+  wd = GetCurrentDirectory()
 
   test_dir = os.path.join( DATA_DIR, 'include' )
   assert wd != test_dir, 'Please run this test from a different directory'
@@ -386,7 +386,7 @@ def WorkingDir_UseServerWorkingDirectory_test():
 
 def WorkingDir_UseServerWorkingDirectory_Unicode_test():
   # Store the working directory so we can return to it.
-  wd = os.getcwd()
+  wd = GetCurrentDirectory()
 
   test_dir = os.path.join( TEST_DIR, 'testdata', 'filename_completer', '∂†∫' )
   assert wd != test_dir, 'Please run this test from a different directory'
@@ -415,7 +415,7 @@ def WorkingDir_UseServerWorkingDirectory_Unicode_test():
 
 def WorkingDir_UseClientWorkingDirectory_test():
   # Store the working directory so we can return to it.
-  wd = os.getcwd()
+  wd = GetCurrentDirectory()
 
   test_dir = os.path.join( DATA_DIR, 'include' )
   assert wd != test_dir, 'Please run this test from a different directory'

--- a/ycmd/tests/javascript/__init__.py
+++ b/ycmd/tests/javascript/__init__.py
@@ -30,6 +30,7 @@ from ycmd import handlers
 from ycmd.tests.test_utils import ( ClearCompletionsCache, SetUpApp,
                                     StopCompleterServer,
                                     WaitUntilCompleterServerReady )
+from ycmd.utils import GetCurrentDirectory
 
 shared_app = None
 shared_current_dir = None
@@ -48,7 +49,7 @@ def setUpPackage():
   global shared_app, shared_current_dir
 
   shared_app = SetUpApp()
-  shared_current_dir = os.getcwd()
+  shared_current_dir = GetCurrentDirectory()
   os.chdir( PathToTestFile() )
   WaitUntilCompleterServerReady( shared_app, 'javascript' )
 
@@ -87,7 +88,7 @@ def IsolatedYcmd( test ):
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
     old_server_state = handlers._server_state
-    old_current_dir = os.getcwd()
+    old_current_dir = GetCurrentDirectory()
     app = SetUpApp()
     os.chdir( PathToTestFile() )
     try:

--- a/ycmd/tests/javascript/__init__.py
+++ b/ycmd/tests/javascript/__init__.py
@@ -27,7 +27,9 @@ import functools
 import os
 
 from ycmd import handlers
-from ycmd.tests.test_utils import ( ClearCompletionsCache, SetUpApp,
+from ycmd.tests.test_utils import ( ClearCompletionsCache,
+                                    CurrentWorkingDirectory,
+                                    SetUpApp,
                                     StopCompleterServer,
                                     WaitUntilCompleterServerReady )
 from ycmd.utils import GetCurrentDirectory
@@ -88,13 +90,11 @@ def IsolatedYcmd( test ):
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
     old_server_state = handlers._server_state
-    old_current_dir = GetCurrentDirectory()
     app = SetUpApp()
-    os.chdir( PathToTestFile() )
     try:
-      test( app, *args, **kwargs )
+      with CurrentWorkingDirectory( PathToTestFile() ):
+        test( app, *args, **kwargs )
     finally:
       StopCompleterServer( app, 'javascript' )
-      os.chdir( old_current_dir )
       handlers._server_state = old_server_state
   return Wrapper

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -33,7 +33,7 @@ import os
 from ycmd.tests.test_utils import ( BuildRequest, ErrorMatcher,
                                     WaitUntilCompleterServerReady )
 from ycmd.tests.javascript import IsolatedYcmd, PathToTestFile
-from ycmd.utils import ReadFile
+from ycmd.utils import GetCurrentDirectory, ReadFile
 
 
 @IsolatedYcmd
@@ -98,7 +98,7 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
     response.json,
     ErrorMatcher( RuntimeError,
                   'Warning: Unable to detect a .tern-project file '
-                  'in the hierarchy before ' + os.getcwd() +
+                  'in the hierarchy before ' + GetCurrentDirectory() +
                   ' and no global .tern-config file was found. '
                   'This is required for accurate JavaScript '
                   'completion. Please see the User Guide for '
@@ -143,7 +143,7 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
     response.json,
     ErrorMatcher( RuntimeError,
                   'Warning: Unable to detect a .tern-project file '
-                  'in the hierarchy before ' + os.getcwd() +
+                  'in the hierarchy before ' + GetCurrentDirectory() +
                   ' and no global .tern-config file was found. '
                   'This is required for accurate JavaScript '
                   'completion. Please see the User Guide for '

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -163,7 +163,7 @@ def UserOption( key, value ):
     user_options = current_options.copy()
     user_options.update( { key: value } )
     handlers.UpdateUserOptions( user_options )
-    yield
+    yield user_options
   finally:
     handlers.UpdateUserOptions( current_options )
 
@@ -173,7 +173,7 @@ def CurrentWorkingDirectory( path ):
   old_cwd = GetCurrentDirectory()
   os.chdir( path )
   try:
-    yield
+    yield old_cwd
   finally:
     os.chdir( old_cwd )
 

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -42,7 +42,7 @@ import stat
 from ycmd import handlers, user_options_store
 from ycmd.completers.completer import Completer
 from ycmd.responses import BuildCompletionData
-from ycmd.utils import OnMac, OnWindows, ToUnicode
+from ycmd.utils import GetCurrentDirectory, OnMac, OnWindows, ToUnicode
 import ycm_core
 
 try:
@@ -170,7 +170,7 @@ def UserOption( key, value ):
 
 @contextlib.contextmanager
 def CurrentWorkingDirectory( path ):
-  old_cwd = os.getcwd()
+  old_cwd = GetCurrentDirectory()
   os.chdir( path )
   try:
     yield

--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -567,3 +567,15 @@ def FindExecutable_CurrentDirectory_test():
 def FindExecutable_AdditionalPathExt_test():
   with TemporaryExecutable( extension = '.xyz' ) as executable:
     eq_( executable, utils.FindExecutable( executable ) )
+
+
+@Py2Only
+def GetCurrentDirectory_Py2NoCurrentDirectory_test():
+  with patch( 'os.getcwdu', side_effect = OSError ):
+    eq_( utils.GetCurrentDirectory(), tempfile.gettempdir() )
+
+
+@Py3Only
+def GetCurrentDirectory_Py3NoCurrentDirectory_test():
+  with patch( 'os.getcwd', side_effect = FileNotFoundError ): # noqa
+    eq_( utils.GetCurrentDirectory(), tempfile.gettempdir() )

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -445,3 +445,17 @@ def SplitLines( contents ):
     lines.append( '' )
 
   return lines
+
+
+def GetCurrentDirectory():
+  """Returns the current directory as an unicode object. If the current
+  directory does not exist anymore, returns the temporary folder instead."""
+  try:
+    if PY2:
+      return os.getcwdu()
+    return os.getcwd()
+  # os.getcwdu throws an OSError exception when the current directory has been
+  # deleted while os.getcwd throws a FileNotFoundError, which is a subclass of
+  # OSError.
+  except OSError:
+    return tempfile.gettempdir()


### PR DESCRIPTION
On Python 2, `os.getcwd` does not return a unicode object but bytes. Since we are internally always working with unicode objects, we need to use [`os.getcwdu`](https://docs.python.org/2/library/os.html#os.getcwdu) instead. Another reason to use the unicode version is that `os.getcwd` returns an invalid path for paths containing unicode characters on Windows.

The current directory is used in two places: the filename completer and the JavaScript completer. I added a test that currently fails for the filename completer but not for the JS completer as it needed too much refactoring.

For now, I am only pushing the test so that you can see the issue. I'll send the fix once the builds have failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/622)
<!-- Reviewable:end -->
