### PR TITLE
Allow using tsserver with JavaScript

### DIFF
--- a/ycmd/completers/javascript/hook.py
+++ b/ycmd/completers/javascript/hook.py
@@ -26,9 +26,15 @@ from builtins import *  # noqa
 from ycmd.completers.javascript.tern_completer import (
   ShouldEnableTernCompleter, TernCompleter )
 
+from ycmd.completers.typescript.typescript_completer import (
+  ShouldEnableTypescriptCompleter, TypeScriptCompleter )
+
 
 def GetCompleter( user_options ):
-  if not ShouldEnableTernCompleter():
-    return None
+  if ShouldEnableTernCompleter():
+    return TernCompleter( user_options )
 
-  return TernCompleter( user_options )
+  if ShouldEnableTypescriptCompleter():
+    return TypeScriptCompleter( user_options )
+
+  return None

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -312,7 +312,7 @@ class TypeScriptCompleter( Completer ):
 
 
   def SupportedFiletypes( self ):
-    return [ 'typescript' ]
+    return [ 'typescript', 'javascript' ]
 
 
   def ComputeCandidatesInner( self, request_data ):
@@ -322,6 +322,19 @@ class TypeScriptCompleter( Completer ):
       'line':   request_data[ 'line_num' ],
       'offset': request_data[ 'start_codepoint' ]
     } )
+
+    # Figure out the filetype because JavaScript and TypeScript need slightly
+    # different behavior
+    try:
+      filetype = request_data[ 'filetypes' ][ 0 ]
+    except KeyError:
+      filetype = None
+
+    if filetype == 'javascript':
+      # When tsserver is used with JavaScript files, it will also return any
+      # identifiers found in the file. Filter those out since there is already
+      # identifier completion.
+      entries = list(filter(lambda e: e[ 'kind' ] != 'warning', entries))
 
     # A less detailed version of the completion data is returned
     # if there are too many entries. This improves responsiveness.

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -36,18 +36,20 @@ from ycmd.utils import ReadFile
 
 
 def RunTest( app, test ):
-  filepath = PathToTestFile( 'test.ts' )
+  testfile = test.get( 'testfile', 'test.ts' )
+  filetype = test.get( 'filetype', 'typescript' )
+  filepath = PathToTestFile( testfile )
   contents = ReadFile( filepath )
 
   event_data = BuildRequest( filepath = filepath,
-                             filetype = 'typescript',
+                             filetype = filetype,
                              contents = contents,
                              event_name = 'BufferVisit' )
 
   app.post_json( '/event_notification', event_data )
 
   completion_data = BuildRequest( filepath = filepath,
-                                  filetype = 'typescript',
+                                  filetype = filetype,
                                   contents = contents,
                                   force_semantic = True,
                                   line_num = 17,
@@ -170,3 +172,23 @@ def GetCompletions_ServerIsNotRunning_test( app ):
   assert_that(
     calling( app.post_json ).with_args( '/completions', completion_data ),
     raises( AppError, 'TSServer is not running.' ) )
+
+
+@SharedYcmd
+def GetJavaScriptCompletions_Basic_test( app ):
+  RunTest( app, {
+    'testfile': 'test.js',
+    'filetype': 'javascript',
+    'expect': {
+      'data': has_entries( {
+        'completions': contains_inanyorder(
+          CompletionEntryMatcher( 'methodA', extra_params = {
+            'menu_text': 'methodA (method) Foo.methodA(): void' } ),
+          CompletionEntryMatcher( 'methodB', extra_params = {
+            'menu_text': 'methodB (method) Foo.methodB(): void' } ),
+          CompletionEntryMatcher( 'methodC', extra_params = {
+            'menu_text': ( 'methodC (method) Foo.methodC(a: any): void' ) } ),
+        )
+      } )
+    }
+  } )

--- a/ycmd/tests/typescript/testdata/test.js
+++ b/ycmd/tests/typescript/testdata/test.js
@@ -1,0 +1,37 @@
+class Foo {
+  // Unicode string: 说话
+  methodA() {}
+  methodB() {}
+  methodC(a) {}
+}
+
+var foo = new Foo();
+
+
+
+
+
+
+
+// line 17, column 6
+foo.m
+
+
+/**
+ * Class documentation
+ *
+ * Multi-line
+ */
+class Bar {
+
+  /**
+   * Method documentation
+   */
+  testMethod() {}
+}
+
+var bar = new Bar();
+bar.testMethod();
+bar.nonExistingMethod();
+
+Bar.apply()


### PR DESCRIPTION
TypeScript's ["Salsa" JavaScript language service](https://github.com/Microsoft/TypeScript/wiki/Salsa) allows tsserver to be used with JavaScript files as well. tsserver starts to work much faster than tern.js.

This change uses tsserver (if it exists) as the fallback when tern.js isn't enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/626)
<!-- Reviewable:end -->
