### PR TITLE
Add GetDoc command for rust completer

### DIFF
--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -380,6 +380,8 @@ class RustCompleter( Completer ):
                            self._StopServer() ),
       'RestartServer' : ( lambda self, request_data, args:
                            self._RestartServer() ),
+      'GetDoc' : ( lambda self, request_data, args:
+                           self._GetDoc(request_data) ),
     }
 
 
@@ -394,6 +396,16 @@ class RustCompleter( Completer ):
       _logger.exception( e )
       raise RuntimeError( 'Can\'t jump to definition.' )
 
+  def _GetDoc( self, request_data ):
+    try:
+      definitions = self._GetResponse( '/find_definition',
+                                      request_data )
+
+      docs = [definitions['context'], definitions['docs']]
+      return responses.BuildDetailedInfoResponse('\n---\n'.join(docs))
+    except Exception as e:
+      _logger.exception( e )
+      raise RuntimeError( 'Can\'t lookup docs.' )
 
   def Shutdown( self ):
     self._StopServer()

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -381,7 +381,7 @@ class RustCompleter( Completer ):
       'RestartServer' : ( lambda self, request_data, args:
                            self._RestartServer() ),
       'GetDoc' : ( lambda self, request_data, args:
-                           self._GetDoc(request_data) ),
+                           self._GetDoc( request_data ) ),
     }
 
 
@@ -396,13 +396,14 @@ class RustCompleter( Completer ):
       _logger.exception( e )
       raise RuntimeError( 'Can\'t jump to definition.' )
 
+
   def _GetDoc( self, request_data ):
     try:
-      definitions = self._GetResponse( '/find_definition',
+      definition = self._GetResponse( '/find_definition',
                                       request_data )
 
-      docs = [definitions['context'], definitions['docs']]
-      return responses.BuildDetailedInfoResponse('\n---\n'.join(docs))
+      docs = [ definition[ 'context' ], definition[ 'docs' ] ]
+      return responses.BuildDetailedInfoResponse( '\n---\n'.join( docs ) )
     except Exception as e:
       _logger.exception( e )
       raise RuntimeError( 'Can\'t lookup docs.' )

--- a/ycmd/tests/rust/subcommands_test.py
+++ b/ycmd/tests/rust/subcommands_test.py
@@ -61,3 +61,25 @@ def Subcommands_GoTo_all_test():
 
   for test in tests:
     yield RunGoToTest, test
+
+
+@SharedYcmd
+def Subcommands_GetDoc_Method_test( app ):
+  # Testcase1
+  filepath = PathToTestFile( 'docs.rs' )
+  contents = ReadFile( filepath )
+
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'rust',
+                             line_num = 7,
+                             column_num = 9,
+                             contents = contents,
+                             command_arguments = [ 'GetDoc' ],
+                             completer_target = 'filetype_default' )
+
+  response = app.post_json( '/run_completer_command', event_data ).json
+
+  eq_( response, {
+    'detailed_info': 'pub fn fun()\n---\n'
+                     'some docs on a function'
+  } )

--- a/ycmd/tests/rust/subcommands_test.py
+++ b/ycmd/tests/rust/subcommands_test.py
@@ -65,7 +65,6 @@ def Subcommands_GoTo_all_test():
 
 @SharedYcmd
 def Subcommands_GetDoc_Method_test( app ):
-  # Testcase1
   filepath = PathToTestFile( 'docs.rs' )
   contents = ReadFile( filepath )
 
@@ -83,3 +82,26 @@ def Subcommands_GetDoc_Method_test( app ):
     'detailed_info': 'pub fn fun()\n---\n'
                      'some docs on a function'
   } )
+
+
+@SharedYcmd
+def Subcommands_GetDoc_Fail_Method_test( app ):
+  filepath = PathToTestFile( 'docs.rs' )
+  contents = ReadFile( filepath )
+
+  # no docs exist for this function
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'rust',
+                             line_num = 8,
+                             column_num = 9,
+                             contents = contents,
+                             command_arguments = [ 'GetDoc' ],
+                             completer_target = 'filetype_default' )
+
+  response = app.post_json(
+          '/run_completer_command',
+          event_data,
+          expect_errors=True ).json
+
+  eq_( response[ 'exception' ][ 'TYPE' ], 'RuntimeError' )
+  eq_( response[ 'message' ], 'Can\'t lookup docs.' )

--- a/ycmd/tests/rust/testdata/docs.rs
+++ b/ycmd/tests/rust/testdata/docs.rs
@@ -4,5 +4,6 @@ mod t {
 }
 
 pub fn main() {
-    t::fun()
+    t::fun();
+    t::dne();
 }

--- a/ycmd/tests/rust/testdata/docs.rs
+++ b/ycmd/tests/rust/testdata/docs.rs
@@ -1,0 +1,8 @@
+mod t {
+    /// some docs on a function
+    pub fn fun() { }
+}
+
+pub fn main() {
+    t::fun()
+}


### PR DESCRIPTION
I've updated `racerd` (https://github.com/jwilm/racerd/commit/e4731aaa5af6f972ae49ed84a7f570ad4ac5f4e5) to include the docs in its response, so we can now easily add this to ycmd.

Are there any docs which I should also update with this change when if it can be merged?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/628)
<!-- Reviewable:end -->
