### PR TITLE
[READY] Use Node.js v4 LTS on Linux Travis

### DIFF
--- a/ci/travis/travis_install.linux.sh
+++ b/ci/travis/travis_install.linux.sh
@@ -13,3 +13,6 @@ export PATH=${HOME}/bin:${PATH}
 # In order to work with ycmd, python *must* be built as a shared library. This
 # is set via the PYTHON_CONFIGURE_OPTS option.
 export PYTHON_CONFIGURE_OPTS="--enable-shared"
+
+# Pre-installed Node.js is too old. Install latest Node.js v4 LTS.
+nvm install 4

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -ev
+# Exit immediately if a command returns a non-zero status.
+set -e
 
 ####################
 # OS-specific setup
@@ -57,7 +58,6 @@ test ${python_version} == ${YCMD_PYTHON_VERSION}
 
 pip install -U pip wheel setuptools
 pip install -r test_requirements.txt
-npm install -g typescript
 
 # Enable coverage for Python subprocesses. See:
 # http://coverage.readthedocs.org/en/coverage-4.0.3/subprocess.html
@@ -80,7 +80,10 @@ popd
 multirust update stable
 multirust default stable
 
-# The build infrastructure prints a lot of spam after this script runs, so make
-# sure to disable printing, and failing on non-zero exit code after this script
-# finishes
-set +ev
+###############
+# Node.js setup
+###############
+
+npm install -g typescript
+
+set +e


### PR DESCRIPTION
Our Linux builds on Travis are failing because the latest version of TSServer (2.0.6) is not working with Node.js 0.12 or older (see issue https://github.com/Microsoft/TypeScript/issues/11840) and the pre-installed version of Node.js on Travis is 0.10.36. [The TSServer issue is fixed upstream](https://github.com/Microsoft/TypeScript/pull/11845) but we can't wait for TypeScript 2.1 to be released. We have two options here:
 - pin the version of TypeScript to the last working version (2.0.3);
 - use a newer version of Node.js.

I went for the second solution as [support for the current version of Node.js on Travis will be dropped very soon](https://github.com/nodejs/LTS).

I removed the shell debugging option `set -v`  because when this option is enabled, the build is failing while running the `nvm` command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/632)
<!-- Reviewable:end -->
