### PR TITLE
[READY] Avoid to wrap around when searching for previous identifier

### DIFF
--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -199,7 +199,12 @@ def _PreviousIdentifier( min_num_candidate_size_chars, request_data ):
       return ''
     return ident
 
-  prev_line = contents_per_line[ line_num - 1 ]
+  line_num = line_num - 1
+
+  if line_num < 0:
+    return ''
+
+  prev_line = contents_per_line[ line_num ]
   ident = PreviousIdentifierOnLine( prev_line, len( prev_line ), filetype )
   if len( ident ) < min_num_candidate_size_chars:
     return ''

--- a/ycmd/tests/identifier_completer_test.py
+++ b/ycmd/tests/identifier_completer_test.py
@@ -84,8 +84,10 @@ def PreviousIdentifier_Simple_test():
   eq_( 'foo', ic._PreviousIdentifier( 2, BuildRequestWrap( 'foo', 4 ) ) )
 
 
-def PreviousIdentifier_ColumnInMiddleStillWholeIdent_test():
-  eq_( 'foobar', ic._PreviousIdentifier( 2, BuildRequestWrap( 'foobar', 4 ) ) )
+def PreviousIdentifier_WholeIdentShouldBeBeforeColumn_test():
+  eq_( '',
+       ic._PreviousIdentifier( 2, BuildRequestWrap( 'foobar',
+                                                    column_num = 4 ) ) )
 
 
 def PreviousIdentifier_IgnoreForwardIdents_test():

--- a/ycmd/tests/identifier_completer_test.py
+++ b/ycmd/tests/identifier_completer_test.py
@@ -90,6 +90,12 @@ def PreviousIdentifier_WholeIdentShouldBeBeforeColumn_test():
                                                     column_num = 4 ) ) )
 
 
+def PreviousIdentifier_DoNotWrap_test():
+  eq_( '',
+       ic._PreviousIdentifier( 2, BuildRequestWrap( 'foobar\n bar',
+                                                    column_num = 4 ) ) )
+
+
 def PreviousIdentifier_IgnoreForwardIdents_test():
   eq_( 'foo',
        ic._PreviousIdentifier( 2, BuildRequestWrap( 'foo bar zoo', 4 ) ) )


### PR DESCRIPTION
I was looking at the `identifier_completer` and its tests and I something do not adds up: from implementation of `_PreviousIdentifier` it seems that we are looking for the whole identifier before the cursor but there is a test that expects the function to return the identifier under the cursor. I think that the test is wrong also because for the identifier under the cursor we have a separate function `AddIdentifierUnderCursor`. Moreover the `PreviousIdentifier_ColumnInMiddleStillWholeIdent_test` test is passing because in the `_PreviousIdentifier` function we wrap the buffer; so in the test we first check for the previous identifier before the cursor, we don't find it because it ends after the `column` and then we check the previous line but since the buffer has only one line we check it again but this time with `column` as the line length therefore the test pass.

In this first commit I've pushed only the new failing test, after I'll push the fix with a new test explicitly stating that we don't want to wrap the buffer for the previous identifier.

I hope I got all of this right 😝

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/634)
<!-- Reviewable:end -->
