### PR TITLE
[READY] Fix warnings when resetting process handle

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -553,6 +553,7 @@ class TypeScriptCompleter( Completer ):
 
 
   def _CleanUp( self ):
+    utils.CloseStandardStreams( self._tsserver_handle )
     self._tsserver_handle = None
     if not self.user_options[ 'server_keep_logfiles' ]:
       utils.RemoveIfExists( self._logfile )

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -288,6 +288,14 @@ def WaitUntilProcessIsTerminated( handle, timeout = 5 ):
     time.sleep( 0.1 )
 
 
+def CloseStandardStreams( handle ):
+  if not handle:
+    return
+  for stream in [ handle.stdin, handle.stdout, handle.stderr ]:
+    if stream:
+      stream.close()
+
+
 def PathsToAllParentFolders( path ):
   folder = os.path.normpath( path )
   if os.path.isdir( folder ):


### PR DESCRIPTION
This PR suppresses the `ResourceWarning` exceptions we get when running our tests on Python 3. For example:

``` sh
/home/travis/build/Valloric/ycmd/ycmd/completers/javascript/tern_completer.py:314: ResourceWarning: unclosed file <_io.BufferedWriter name=7>
  self._server_handle = None
```

They are caused by setting to `None` a process handle while its standard piped streams are still open.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/635)

<!-- Reviewable:end -->
