### PR TITLE
[READY] Coverage for c++ code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,11 @@ third_party/tern_runtime/node_modules
 
 # Exclude vagrant directory
 .vagrant/
+
+# Exclude the coverage build output directory
+.build/
+
+# Exclude gcov output
+*.gcov
+# And python coverage output, when running manually
+coverage.xml

--- a/TESTS.md
+++ b/TESTS.md
@@ -62,7 +62,7 @@ a non-standard build environment (e.g. `cmake28`, self-build of clang, etc.)
  (default: 14). Windows only.
 * `--arch`: Force architecture to 32 or 64 bits on Windows (default: python
 interpreter architecture). Windows Only.
-* `--coverage`: Output test coverage report
+* `--coverage`: Generate code coverage data
 
 Remaining arguments are passed to "nosetests" directly. This means that you
 can run a specific script or a specific test as follows:
@@ -81,7 +81,15 @@ NOTE: you must have UTF8 support in your terminal when you do this, e.g.:
 
 ## Coverage testing
 
-There's a coverage module for Python which works nicely with `nosetests`. This
+We can generate coverage data for both the C++ layer and the Python layer. The
+CI system will pass this coverage data to codecov.io where you can view coverage
+after pushing a branch.
+
+C++ coverage testing is available only on Linux/Mac and uses gcov.
+Stricly speaking, we use the `-coverage` option to your compiler, which in the
+case of GNU and LLVM compilers, generate gcov-compatible data.
+
+For Python, there's a coverage module which works nicely with `nosetests`. This
 is very useful for highlighting areas of your code which are not covered by the
 automated integration tests.
 
@@ -89,7 +97,7 @@ Run it like this:
 
 ```
 $ pip install coverage
-$ ./run_tests.py --coverage --cover-html
+$ ./run_tests.py --coverage
 ```
 
 This will print a summary and generate HTML output in `./cover`

--- a/build.py
+++ b/build.py
@@ -268,6 +268,11 @@ def ParseArguments():
                        action = 'store_true',
                        help   = 'For developers: build ycm_core library with '
                                 'debug symbols' )
+  parser.add_argument( '--build-dir',
+                       help   = 'For developers: perform the build in the '
+                                'specified directory, and do not delete the '
+                                'build output. This is useful for incremental '
+                                'builds' )
 
   args = parser.parse_args()
 
@@ -339,7 +344,17 @@ def ExitIfYcmdLibInUseOnWindows():
 
 
 def BuildYcmdLib( args ):
-  build_dir = mkdtemp( prefix = 'ycm_build_' )
+  if args.build_dir:
+    build_dir = args.build_dir
+
+    if os.path.exists( build_dir ):
+      print( 'The supplied build directory (' + build_dir + ' exists, '
+             'deleting it.' )
+      rmtree( build_dir, ignore_errors = OnTravisOrAppVeyor() )
+
+    os.makedirs( build_dir )
+  else:
+    build_dir = mkdtemp( prefix = 'ycm_build_' )
 
   try:
     full_cmake_args = [ '-G', GetGenerator( args ) ]
@@ -376,7 +391,11 @@ def BuildYcmdLib( args ):
       RunYcmdTests( build_dir )
   finally:
     os.chdir( DIR_OF_THIS_SCRIPT )
-    rmtree( build_dir, ignore_errors = OnTravisOrAppVeyor() )
+
+    if args.build_dir:
+      print( 'The build files are in: ' + build_dir )
+    else:
+      rmtree( build_dir, ignore_errors = OnTravisOrAppVeyor() )
 
 
 def BuildOmniSharp():

--- a/ci/travis/travis_install.linux.sh
+++ b/ci/travis/travis_install.linux.sh
@@ -7,6 +7,7 @@ mkdir ${HOME}/bin
 
 ln -s /usr/bin/g++-4.8 ${HOME}/bin/c++
 ln -s /usr/bin/gcc-4.8 ${HOME}/bin/cc
+ln -s /usr/bin/gcov-4.8 ${HOME}/bin/gcov
 
 export PATH=${HOME}/bin:${PATH}
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,15 @@ coverage:
     patch: true
     changes: true
 
+  # We don't want statistics for the tests themselves and certainly not for the
+  # boost libraries. Note that while we exclude the gcov data for these patterns
+  # in the codecov call (codecov --gcov-glob ...), the fact that our code
+  # references these areas also means we need to tell codecov itself to ignore
+  # them from the stats.
+  ignore:
+  - .*/tests/.*
+  - .*/BoostParts/.*
+
 comment:
   layout: "header, diff, changes, uncovered"
   behavior: default  # update if exists else create new

--- a/run_tests.py
+++ b/run_tests.py
@@ -179,6 +179,13 @@ def BuildYcmdLibs( args ):
     if args.msvc:
       build_cmd.extend( [ '--msvc', str( args.msvc ) ] )
 
+    if args.coverage:
+      # In order to generate coverage data for C++, we use gcov. This requires
+      # some files generated when building (*.gcno), so we store the build
+      # output in a known directory, which is then used by the CI infrastructure
+      # to generate the c++ coverage information.
+      build_cmd.extend( [ '--enable-coverage', '--build-dir', '.build' ] )
+
     subprocess.check_call( build_cmd )
 
 


### PR DESCRIPTION
### Overview 

This PR adds support for sending c++ coverage data (via gcov) to codecov.

The basic approach is to just enable building with gcov via the `-coverage` flag, and to tell `codecov` to ignore the `tests` and `BoostParts` directories.

Please excuse the insane number of commits, it was a big old slog to get this to actually work. I will squash when we're happy with it.

I've pulled out some highlights of what's included in this change:

### `build-dir` switch

I merged a change from my fork to add `--build-dir` to `build.py`. While I find this generally useful (as it reduces the rebuild time when developing and updating ycmd, without having to go through the full instructions), but it is also required here so that we keep the gcov data files around for `codecov` to pick them up. 

This could really have been a separate PR, so that's still an option if you guys prefer.

### Exclusions

We don't care about `tests` and `BoostParts` as these are third-party libraries and test code itself. We exclude them from codecov using its difficult to find `ignore` yaml entry.

### Windows

As far as I can tell, there is no support for MSVC coverage in codecov. I understand that it is enabled with the `/Profile` flag to the compiler. I don't think we have os-switched code in the c++ layer, so I don't expect this to be an issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/636)
<!-- Reviewable:end -->