### PR TITLE
[READY] Extract filtering of tags as a generator

### DIFF
--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -119,8 +119,7 @@ class IdentifierCompleter( GeneralCompleter ):
         ToCppStringCompatible( filepath ) )
 
 
-  def AddIdentifiersFromTagFiles( self, tag_files ):
-    absolute_paths_to_tag_files = ycm_core.StringVector()
+  def _FilterUnchangedTagFiles( self, tag_files ):
     for tag_file in tag_files:
       try:
         current_mtime = os.path.getmtime( tag_file )
@@ -134,6 +133,12 @@ class IdentifierCompleter( GeneralCompleter ):
         continue
 
       self._tags_file_last_mtime[ tag_file ] = current_mtime
+      yield tag_file
+
+
+  def AddIdentifiersFromTagFiles( self, tag_files ):
+    absolute_paths_to_tag_files = ycm_core.StringVector()
+    for tag_file in self._FilterUnchangedTagFiles( tag_files ):
       absolute_paths_to_tag_files.append( ToCppStringCompatible( tag_file ) )
 
     if not absolute_paths_to_tag_files:

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -26,11 +26,12 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
+import os
 from hamcrest import assert_that, equal_to, has_items, contains_string
 from mock import patch
 from nose.tools import eq_
 
-from ycmd.tests import SharedYcmd
+from ycmd.tests import SharedYcmd, PathToTestFile
 from ycmd.tests.test_utils import ( BuildRequest, CompletionEntryMatcher,
                                     DummyCompleter, PatchCompleter,
                                     UserOption, ExpectedFailure )
@@ -191,6 +192,22 @@ def GetCompletions_IdentifierCompleter_SyntaxKeywordsAdded_test( app ):
   assert_that( results,
                has_items( CompletionEntryMatcher( 'foo' ),
                           CompletionEntryMatcher( 'zoo' ) ) )
+
+
+@SharedYcmd
+def GetCompletions_IdentifierCompleter_TagsAdded_test( app ):
+  event_data = BuildRequest( event_name = 'FileReadyToParse',
+                             tag_files = [ PathToTestFile( 'basic.tags' ) ] )
+  app.post_json( '/event_notification', event_data )
+
+  completion_data = BuildRequest( contents = 'oo',
+                                  column_num = 3,
+                                  filetype = 'cpp' )
+  results = app.post_json( '/completions',
+                           completion_data ).json[ 'completions' ]
+  assert_that( results,
+               has_items( CompletionEntryMatcher( 'foosy' ),
+                          CompletionEntryMatcher( 'fooaaa' ) ) )
 
 
 @SharedYcmd

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -26,7 +26,6 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-import os
 from hamcrest import assert_that, equal_to, has_items, contains_string
 from mock import patch
 from nose.tools import eq_

--- a/ycmd/tests/identifier_completer_test.py
+++ b/ycmd/tests/identifier_completer_test.py
@@ -29,15 +29,8 @@ from ycmd.user_options_store import DefaultOptions
 from ycmd.completers.all import identifier_completer as ic
 from ycmd.completers.all.identifier_completer import IdentifierCompleter
 from ycmd.request_wrap import RequestWrap
+from ycmd.tests import PathToTestFile
 from ycmd.tests.test_utils import BuildRequest
-
-
-TEST_DIR = os.path.dirname( os.path.abspath( __file__ ) )
-DATA_DIR = os.path.join( TEST_DIR,
-                         '..', '..',
-                         'cpp', 'ycm',
-                         'tests',
-                         'testdata' )
 
 
 def BuildRequestWrap( contents, column_num, line_num = 1 ):
@@ -166,7 +159,7 @@ def FilterUnchangedTagFiles_SkipBadFiles_test():
 
 def FilterUnchangedTagFiles_KeepGoodFiles_test():
   ident_completer = IdentifierCompleter( DefaultOptions() )
-  tag_file = os.path.join( DATA_DIR, 'basic.tags' )
+  tag_file = PathToTestFile( 'basic.tags' )
   eq_( [ tag_file ],
        list( ident_completer._FilterUnchangedTagFiles( [ tag_file ] ) ) )
 
@@ -175,7 +168,7 @@ def FilterUnchangedTagFiles_SkipUnchangesFiles_test():
   ident_completer = IdentifierCompleter( DefaultOptions() )
 
   # simulate an already open tags file that didn't change in the meantime.
-  tag_file = os.path.join( DATA_DIR, 'basic.tags' )
+  tag_file = PathToTestFile( 'basic.tags' )
   ident_completer._tags_file_last_mtime[ tag_file ] = os.path.getmtime(
       tag_file )
 

--- a/ycmd/tests/testdata/basic.tags
+++ b/ycmd/tests/testdata/basic.tags
@@ -1,0 +1,10 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	2	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.8	//
+i1	foo	junky;'junklanguage:C++
+i1	bar	junky;'junklanguage:C++
+foosy	foo	junky;"'junk	language:C++	zanzibar
+fooaaa	bar	junky;"'junk	language:C++	zanzibar


### PR DESCRIPTION
Looking at the coverage of the Python layer of ycmd I noticed that one of the least tested file was the `identifier_completer.py` file. I understand that this file is actually just a thin wrapper around the cpp class (conversion to/from ycm_core data structure) so is understandable that is not 100% tested, but one big section that was not tested is the tag insertion: before inserting the file paths into an array and passing it to the cpp class we filter some paths based on the last update time of the file. So I extracted that section of the function as a generator and unit tested that function. I've marked this as WIP because I'm adding also a test that actually exercise the feature end-to-end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/637)
<!-- Reviewable:end -->
