### PR TITLE
[RFC] Add keep_logfiles option

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -90,7 +90,7 @@ class CsharpCompleter( Completer ):
 
     with self._solution_state_lock:
       if solution not in self._completer_per_solution:
-        keep_logfiles = self.user_options[ 'server_keep_logfiles' ]
+        keep_logfiles = self.user_options[ 'keep_logfiles' ]
         desired_omnisharp_port = self.user_options.get( 'csharp_server_port' )
         completer = CsharpSolutionCompleter( solution,
                                              keep_logfiles,

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -117,7 +117,7 @@ class GoCompleter( Completer ):
 
     self._godef_binary_path = FindBinary( 'godef', user_options )
 
-    self._keep_logfiles = user_options[ 'server_keep_logfiles' ]
+    self._keep_logfiles = user_options[ 'keep_logfiles' ]
 
     self._StartServer()
 

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -120,7 +120,7 @@ class TernCompleter( Completer ):
   def __init__( self, user_options ):
     super( TernCompleter, self ).__init__( user_options )
 
-    self._server_keep_logfiles = user_options[ 'server_keep_logfiles' ]
+    self._keep_logfiles = user_options[ 'keep_logfiles' ]
 
     # Used to ensure that starting/stopping of the server is synchronised
     self._server_state_mutex = threading.RLock()
@@ -470,7 +470,7 @@ class TernCompleter( Completer ):
     utils.CloseStandardStreams( self._server_handle )
     self._server_handle = None
     self._server_port = None
-    if not self._server_keep_logfiles:
+    if not self._keep_logfiles:
       utils.RemoveIfExists( self._server_stdout )
       self._server_stdout = None
       utils.RemoveIfExists( self._server_stderr )

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -66,7 +66,7 @@ class JediCompleter( Completer ):
     self._logger = logging.getLogger( __name__ )
     self._logfile_stdout = None
     self._logfile_stderr = None
-    self._keep_logfiles = user_options[ 'server_keep_logfiles' ]
+    self._keep_logfiles = user_options[ 'keep_logfiles' ]
     self._hmac_secret = ''
     self._python_binary_path = sys.executable
 

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -106,7 +106,7 @@ class RustCompleter( Completer ):
     self._racerd_binary = FindRacerdBinary( user_options )
     self._racerd_host = None
     self._server_state_lock = threading.RLock()
-    self._keep_logfiles = user_options[ 'server_keep_logfiles' ]
+    self._keep_logfiles = user_options[ 'keep_logfiles' ]
     self._hmac_secret = ''
     self._rust_source_path = self._GetRustSrcPath()
 

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -555,7 +555,7 @@ class TypeScriptCompleter( Completer ):
   def _CleanUp( self ):
     utils.CloseStandardStreams( self._tsserver_handle )
     self._tsserver_handle = None
-    if not self.user_options[ 'server_keep_logfiles' ]:
+    if not self.user_options[ 'keep_logfiles' ]:
       utils.RemoveIfExists( self._logfile )
       self._logfile = None
 

--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -38,7 +38,7 @@
   "use_ultisnips_completer": 1,
   "csharp_server_port": 0,
   "hmac_secret": "",
-  "server_keep_logfiles": 0,
+  "keep_logfiles": 0,
   "gocode_binary_path": "",
   "godef_binary_path": "",
   "rust_src_path": "",

--- a/ycmd/tests/cs/debug_info_test.py
+++ b/ycmd/tests/cs/debug_info_test.py
@@ -70,7 +70,7 @@ def DebugInfo_ServerIsNotRunning_NoSolution_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
-  with UserOption( 'server_keep_logfiles', True ):
+  with UserOption( 'keep_logfiles', True ):
     filepath = PathToTestFile( 'testy', 'Program.cs' )
     contents = ReadFile( filepath )
     event_data = BuildRequest( filepath = filepath,
@@ -97,7 +97,7 @@ def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
-  with UserOption( 'server_keep_logfiles', False ):
+  with UserOption( 'keep_logfiles', False ):
     filepath = PathToTestFile( 'testy', 'Program.cs' )
     contents = ReadFile( filepath )
     event_data = BuildRequest( filepath = filepath,

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -509,7 +509,7 @@ def Subcommands_StopServer_NoErrorIfNotStarted_test( app ):
 
 @IsolatedYcmd
 def StopServer_KeepLogFiles( app, keeping_log_files ):
-  with UserOption( 'server_keep_logfiles', keeping_log_files ):
+  with UserOption( 'keep_logfiles', keeping_log_files ):
     filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
     contents = ReadFile( filepath )
     event_data = BuildRequest( filepath = filepath,

--- a/ycmd/tests/go/debug_info_test.py
+++ b/ycmd/tests/go/debug_info_test.py
@@ -46,7 +46,7 @@ def DebugInfo_ServerIsRunning_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
-  with UserOption( 'server_keep_logfiles', True ):
+  with UserOption( 'keep_logfiles', True ):
     StopCompleterServer( app, 'go' )
     request_data = BuildRequest( filetype = 'go' )
     assert_that(
@@ -62,7 +62,7 @@ def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
-  with UserOption( 'server_keep_logfiles', False ):
+  with UserOption( 'keep_logfiles', False ):
     StopCompleterServer( app, 'go' )
     request_data = BuildRequest( filetype = 'go' )
     assert_that(

--- a/ycmd/tests/javascript/debug_info_test.py
+++ b/ycmd/tests/javascript/debug_info_test.py
@@ -45,7 +45,7 @@ def DebugInfo_ServerIsRunning_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
-  with UserOption( 'server_keep_logfiles', True ):
+  with UserOption( 'keep_logfiles', True ):
     StopCompleterServer( app, 'javascript' )
     request_data = BuildRequest( filetype = 'javascript' )
     assert_that(
@@ -60,7 +60,7 @@ def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
-  with UserOption( 'server_keep_logfiles', False ):
+  with UserOption( 'keep_logfiles', False ):
     StopCompleterServer( app, 'javascript' )
     request_data = BuildRequest( filetype = 'javascript' )
     assert_that(

--- a/ycmd/tests/python/debug_info_test.py
+++ b/ycmd/tests/python/debug_info_test.py
@@ -46,7 +46,7 @@ def DebugInfo_ServerIsRunning_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
-  with UserOption( 'server_keep_logfiles', True ):
+  with UserOption( 'keep_logfiles', True ):
     StopCompleterServer( app, 'python' )
     request_data = BuildRequest( filetype = 'python' )
     assert_that(
@@ -62,7 +62,7 @@ def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
-  with UserOption( 'server_keep_logfiles', False ):
+  with UserOption( 'keep_logfiles', False ):
     StopCompleterServer( app, 'python' )
     request_data = BuildRequest( filetype = 'python' )
     assert_that(

--- a/ycmd/tests/rust/debug_info_test.py
+++ b/ycmd/tests/rust/debug_info_test.py
@@ -46,7 +46,7 @@ def DebugInfo_ServerIsRunning_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
-  with UserOption( 'server_keep_logfiles', True ):
+  with UserOption( 'keep_logfiles', True ):
     StopCompleterServer( app, 'rust' )
     request_data = BuildRequest( filetype = 'rust' )
     assert_that(
@@ -62,7 +62,7 @@ def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
-  with UserOption( 'server_keep_logfiles', False ):
+  with UserOption( 'keep_logfiles', False ):
     StopCompleterServer( app, 'rust' )
     request_data = BuildRequest( filetype = 'rust' )
     assert_that(

--- a/ycmd/tests/typescript/debug_info_test.py
+++ b/ycmd/tests/typescript/debug_info_test.py
@@ -43,7 +43,7 @@ def DebugInfo_ServerIsRunning_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
-  with UserOption( 'server_keep_logfiles', True ):
+  with UserOption( 'keep_logfiles', True ):
     StopCompleterServer( app, filetype = 'typescript' )
     request_data = BuildRequest( filetype = 'typescript' )
     assert_that(
@@ -56,7 +56,7 @@ def DebugInfo_ServerIsNotRunning_LogfilesExist_test( app ):
 
 @IsolatedYcmd
 def DebugInfo_ServerIsNotRunning_LogfilesDoNotExist_test( app ):
-  with UserOption( 'server_keep_logfiles', False ):
+  with UserOption( 'keep_logfiles', False ):
     StopCompleterServer( app, filetype = 'typescript' )
     request_data = BuildRequest( filetype = 'typescript' )
     assert_that(


### PR DESCRIPTION
Currently, we have two switches to control the removal of logfiles at shutdown:
 - the `--keep_logfiles` parameter for the ycmd logfiles;
 - the `server_keep_logfiles` option for the completers logfiles.

It would be simpler to have one global switch instead.

This is done by deprecating the `--keep-logfiles` parameter and the `server_keep_logfiles` option in favor of the new `keep_logfiles` option.

The deprecation is implemented as follows:
 - if `keep_logfiles` is given, ignore `server_keep_logfiles` and `--keep_logfiles`;
 - otherwise, `server_keep_logfiles` takes precedence over `--keep_logfiles`:
 - raise a warning and log it if `server_keep_logfiles` and/or `--keep_logfiles` are given.

Here's an example of how the logs look like if both deprecated options are used:
```
2016-11-11 18:17:07,913 - WARNING - __main__.py:147: DeprecationWarning: The '--keep_logfiles' argument is deprecated in favor of the 'keep_logfiles' option
  DeprecationWarning )

2016-11-11 18:17:07,913 - WARNING - __main__.py:153: DeprecationWarning: The 'server_keep_logfiles' option is deprecated in favor of the 'keep_logfiles' option
  DeprecationWarning )

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/642)
<!-- Reviewable:end -->
