### PR TITLE
[READY] Fix flake8 errors

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -371,6 +371,7 @@ def _LatestMacClangIncludes():
 
   return []
 
+
 MAC_INCLUDE_PATHS = []
 
 if OnMac():

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -240,6 +240,7 @@ def ErrorHandler( httperror ):
   hmac_plugin.SetHmacHeader( body, _hmac_secret )
   return body
 
+
 # For every error Bottle encounters it will use this as the default handler
 app.default_error_handler = ErrorHandler
 


### PR DESCRIPTION
This fixes new errors detected by the last version of `pycodestyle` (2.2.0), which is a dependency of `flake8`:
```
C:\projects\ycmd\ycmd\handlers.py:244:1: E305 expected 2 blank lines after class or function definition, found 1
C:\projects\ycmd\ycmd\completers\cpp\flags.py:374:1: E305 expected 2 blank lines after class or function definition, found 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/644)
<!-- Reviewable:end -->
