### PR TITLE
[READY] Use codecov bash uploader on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ compiler:
 script:
   - ci/travis/travis_script.sh
 after_success:
-  - codecov
+  - bash <(curl -s https://codecov.io/bash)
 env:
   global:
     - MONO_THREADS_PER_CPU=2000

--- a/TESTS.md
+++ b/TESTS.md
@@ -96,7 +96,6 @@ automated integration tests.
 Run it like this:
 
 ```
-$ pip install coverage
 $ ./run_tests.py --coverage
 ```
 

--- a/ci/appveyor/appveyor_install.bat
+++ b/ci/appveyor/appveyor_install.bat
@@ -31,6 +31,8 @@ appveyor DownloadFile https://bootstrap.pypa.io/get-pip.py
 python get-pip.py
 pip install -r test_requirements.txt
 if %errorlevel% neq 0 exit /b %errorlevel%
+pip install codecov
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 ::
 :: Typescript configuration

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,4 +9,4 @@ unittest2>=1.1.0
 psutil>=3.3.0
 # This needs to be kept in sync with submodule checkout in third_party
 future==0.15.2
-codecov>=2.0.5
+coverage>=4.2


### PR DESCRIPTION
Since we added C++ coverage with PR #636, our coverage reports are stuck with the following message:
```
Waiting for CI to finish and reports to complete processing. Please review commit coverage with caution, it may change.
```
This is caused by one of our Travis build (Linux, Python 3.3) that fails to upload coverage to codecov with this Python encoding error:
```
Error: 'latin-1' codec can't encode character '\u2013' in position 14079665: ordinal not in range(256)
```
I've contacted codecov support about this error and they suggested to use the bash uploader instead of the Python one.

Since the bash uploader cannot be used on AppVeyor, we still need `codecov` but not as a test dependency so we remove it from `test_requirements.txt` and install it directly in the AppVeyor script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/649)
<!-- Reviewable:end -->
