### PR TITLE
[READY] Do not reload extra conf file

### DIFF
--- a/ycmd/extra_conf_store.py
+++ b/ycmd/extra_conf_store.py
@@ -147,14 +147,13 @@ def Load( module_file, force = False ):
   if not module_file:
     return None
 
-  if not force:
-    with _module_for_module_file_lock:
-      if module_file in _module_for_module_file:
-        return _module_for_module_file[ module_file ]
+  with _module_for_module_file_lock:
+    if module_file in _module_for_module_file:
+      return _module_for_module_file[ module_file ]
 
-    if not _ShouldLoad( module_file ):
-      Disable( module_file )
-      return None
+  if not force and not _ShouldLoad( module_file ):
+    Disable( module_file )
+    return None
 
   # This has to be here because a long time ago, the ycm_extra_conf.py files
   # used to import clang_helpers.py from the cpp folder. This is not needed

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -283,7 +283,7 @@ def GetCompletions_FilteredNoResults_Fallback_test( app ):
   } )
 
 
-@SharedYcmd
+@IsolatedYcmd
 def GetCompletions_WorksWithExplicitFlags_test( app ):
   app.post_json(
     '/ignore_extra_conf_file',
@@ -317,7 +317,7 @@ int main()
   eq_( 7, response_data[ 'completion_start_column' ] )
 
 
-@SharedYcmd
+@IsolatedYcmd
 def GetCompletions_NoCompletionsWhenAutoTriggerOff_test( app ):
   with UserOption( 'auto_trigger', False ):
     app.post_json(

--- a/ycmd/tests/extra_conf_store_test.py
+++ b/ycmd/tests/extra_conf_store_test.py
@@ -26,7 +26,8 @@ from builtins import *  # noqa
 import inspect
 from mock import patch
 
-from hamcrest import assert_that, calling, equal_to, has_length, none, raises
+from hamcrest import ( assert_that, calling, equal_to, has_length, none, raises,
+                       same_instance )
 from ycmd import extra_conf_store
 from ycmd.responses import UnknownExtraConf
 from ycmd.tests import PathToTestFile
@@ -139,3 +140,29 @@ class ExtraConfStore_test():
     logger.exception.assert_called_with( 'Error occurred while '
                                          'loading global extra conf '
                                          '{0}'.format( extra_conf_file ) )
+
+
+  def Load_DoNotReloadExtraConf_NoForce_test( self ):
+    extra_conf_file = PathToTestFile( 'extra_conf', 'project',
+                                      '.ycm_extra_conf.py' )
+    with patch( 'ycmd.extra_conf_store._ShouldLoad', return_value = True ):
+      module = extra_conf_store.Load( extra_conf_file )
+      assert_that( inspect.ismodule( module ) )
+      assert_that( inspect.getfile( module ), equal_to( extra_conf_file ) )
+      assert_that(
+        extra_conf_store.Load( extra_conf_file ),
+        same_instance( module )
+      )
+
+
+  def Load_DoNotReloadExtraConf_ForceEqualsTrue_test( self ):
+    extra_conf_file = PathToTestFile( 'extra_conf', 'project',
+                                      '.ycm_extra_conf.py' )
+    with patch( 'ycmd.extra_conf_store._ShouldLoad', return_value = True ):
+      module = extra_conf_store.Load( extra_conf_file )
+      assert_that( inspect.ismodule( module ) )
+      assert_that( inspect.getfile( module ), equal_to( extra_conf_file ) )
+      assert_that(
+        extra_conf_store.Load( extra_conf_file, force = True ),
+        same_instance( module )
+      )


### PR DESCRIPTION
When the extra conf file is already loaded as a module and we attempt to force load it, instead of reusing the module, we reload it and lose its current state. This makes impossible to share variables between the `YcmCorePreload`, `VimLeave`, and `Shutdown` methods of the same global extra conf file.

For now, this PR only adds tests to show the issue. Once the builds have failed, I'll update it with one possible fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/651)
<!-- Reviewable:end -->
