### PR TITLE
[WIP] Fix compile error with gcc 4.4

### DIFF
--- a/cpp/ycm/LetterNodeListMap.cpp
+++ b/cpp/ycm/LetterNodeListMap.cpp
@@ -52,6 +52,7 @@ LetterNodeListMap::LetterNodeListMap( const LetterNodeListMap &other ) {
 LetterNodeListMap &LetterNodeListMap::operator=( const LetterNodeListMap &other ) {
   if ( this != &other && other.letters_ )
     letters_.reset( new NearestLetterNodeArray( *other.letters_ ) );
+  return *this;
 }
 
 

--- a/cpp/ycm/LetterNodeListMap.cpp
+++ b/cpp/ycm/LetterNodeListMap.cpp
@@ -49,6 +49,12 @@ LetterNodeListMap::LetterNodeListMap( const LetterNodeListMap &other ) {
 }
 
 
+LetterNodeListMap &LetterNodeListMap::operator=( const LetterNodeListMap &other ) {
+  if ( this != &other && other.letters_ )
+    letters_.reset( new NearestLetterNodeArray( *other.letters_ ) );
+}
+
+
 NearestLetterNodeIndices &LetterNodeListMap::operator[] ( char letter ) {
   if ( !letters_ )
     letters_.reset( new NearestLetterNodeArray() );

--- a/cpp/ycm/LetterNodeListMap.h
+++ b/cpp/ycm/LetterNodeListMap.h
@@ -66,6 +66,7 @@ class LetterNodeListMap {
 public:
   LetterNodeListMap();
   LetterNodeListMap( const LetterNodeListMap &other );
+  LetterNodeListMap &operator=( const LetterNodeListMap &other );
 
   NearestLetterNodeIndices &operator[] ( char letter );
 


### PR DESCRIPTION
The code doesn't compile with gcc version 4.4.5 (Debian 4.4.5-8), see this issue: https://github.com/Valloric/YouCompleteMe/issues/2227

It seems that `boost::movelib::unique_ptr< NearestLetterNodeArray > letters_;` has a private copy construct, thus meets the condition of [Deleted implicitly-declared copy assignment operator](http://en.cppreference.com/w/cpp/language/copy_assignment) scenario:

> T has a non-static data member or a direct or virtual base class that cannot be copy-assigned (overload resolution for the copy assignment fails, or selects a deleted or inaccessible function);

So, I tried to add the definition of the missing copy assignment operator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/658)
<!-- Reviewable:end -->
