### PR TITLE
Add insertion_snippet field for clang completer

### DIFF
--- a/cpp/ycm/ClangCompleter/CompletionData.cpp
+++ b/cpp/ycm/ClangCompleter/CompletionData.cpp
@@ -148,6 +148,54 @@ std::string OptionalChunkToString( CXCompletionString completion_string,
 }
 
 
+std::string ChunkToSnippet( CXCompletionString completion_string,
+                            uint chunk_num,
+                            uint &idx_placeholder ) {
+  std::string snippet;
+
+  if ( !completion_string )
+    return snippet;
+
+  CXCompletionChunkKind kind = clang_getCompletionChunkKind(
+                                 completion_string, chunk_num );
+
+  if ( kind == CXCompletionChunk_Optional ) {
+    CXCompletionString optional_completion_string =
+      clang_getCompletionChunkCompletionString (
+        completion_string, chunk_num );
+
+    if ( optional_completion_string ) {
+      uint optional_num_chunks = clang_getNumCompletionChunks(
+                                   optional_completion_string );
+
+      for ( uint j = 0; j < optional_num_chunks; ++j ) {
+        snippet.append( ChunkToSnippet(
+          optional_completion_string, j, idx_placeholder ) );
+      }
+    }
+  }
+
+  else if ( kind == CXCompletionChunk_Informative ) {
+  }
+
+  else if ( kind == CXCompletionChunk_Placeholder ) {
+    idx_placeholder++;
+    snippet.append( "${" )
+    .append( std::to_string( idx_placeholder ) )
+    .append( ":" )
+    .append( ChunkToString( completion_string, chunk_num ) )
+    .append( "}" );
+  }
+
+  else {
+    snippet.append(
+      ChunkToString( completion_string, chunk_num ) );
+  }
+
+  return snippet;
+}
+
+
 // foo( -> foo
 // foo() -> foo
 std::string RemoveTrailingParens( std::string text ) {
@@ -173,13 +221,15 @@ CompletionData::CompletionData( const CXCompletionResult &completion_result ) {
   bool saw_left_paren = false;
   bool saw_function_params = false;
   bool saw_placeholder = false;
+  uint idx_placeholder = 0;
 
   for ( uint j = 0; j < num_chunks; ++j ) {
     ExtractDataFromChunk( completion_string,
                           j,
                           saw_left_paren,
                           saw_function_params,
-                          saw_placeholder );
+                          saw_placeholder,
+                          idx_placeholder );
   }
 
   original_string_ = RemoveTrailingParens( boost::move( original_string_ ) );
@@ -199,7 +249,8 @@ void CompletionData::ExtractDataFromChunk( CXCompletionString completion_string,
                                            uint chunk_num,
                                            bool &saw_left_paren,
                                            bool &saw_function_params,
-                                           bool &saw_placeholder ) {
+                                           bool &saw_placeholder,
+                                           uint &idx_placeholder ) {
   CXCompletionChunkKind kind = clang_getCompletionChunkKind(
                                  completion_string, chunk_num );
 
@@ -229,6 +280,9 @@ void CompletionData::ExtractDataFromChunk( CXCompletionString completion_string,
       everything_except_return_type_.append(
         ChunkToString( completion_string, chunk_num ) );
     }
+
+    completion_snippet_.append(
+      ChunkToSnippet( completion_string, chunk_num, idx_placeholder ) );
   }
 
   switch ( kind ) {

--- a/cpp/ycm/ClangCompleter/CompletionData.h
+++ b/cpp/ycm/ClangCompleter/CompletionData.h
@@ -61,6 +61,13 @@ struct CompletionData {
     return original_string_;
   }
 
+  // For supported clients. For a function like "int foo(int a, float b)", this
+  // is "int foo(${1:int a}, ${2:float b})". For other candidates without text
+  // placeholders, this is the same as the value of TextToInsertInBuffer.
+  std::string SnippetToInsertInBuffer() const {
+    return completion_snippet_;
+  }
+
   // Currently, here we show the full function signature (without the return
   // type) if the current completion is a function or just the raw TypedText if
   // the completion is, say, a data member. So for a function like "int foo(int
@@ -93,7 +100,8 @@ struct CompletionData {
       kind_ == other.kind_ &&
       everything_except_return_type_ == other.everything_except_return_type_ &&
       return_type_ == other.return_type_ &&
-      original_string_ == other.original_string_;
+      original_string_ == other.original_string_ &&
+      completion_snippet_ == other.completion_snippet_;
     // detailed_info_ doesn't matter
   }
 
@@ -109,6 +117,8 @@ struct CompletionData {
   // completion string.
   std::string original_string_;
 
+  std::string completion_snippet_;
+
   std::string everything_except_return_type_;
 
   std::string doc_string_;
@@ -119,7 +129,8 @@ private:
                              uint chunk_num,
                              bool &saw_left_paren,
                              bool &saw_function_params,
-                             bool &saw_placeholder );
+                             bool &saw_placeholder,
+                             uint &idx_placeholder );
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/tests/ClangCompleter/ClangCompleter_test.cpp
+++ b/cpp/ycm/tests/ClangCompleter/ClangCompleter_test.cpp
@@ -64,6 +64,24 @@ TEST( ClangCompleterTest, BufferTextNoParens ) {
 }
 
 
+TEST( ClangCompleterTest, BufferSnippetParens ) {
+  ClangCompleter completer;
+  std::vector< CompletionData > completions =
+    completer.CandidatesForLocationInFile(
+      PathToTestFile( "basic.cpp" ).string(),
+      15,
+      7,
+      std::vector< UnsavedFile >(),
+      std::vector< std::string >() );
+
+  EXPECT_TRUE( !completions.empty() );
+  EXPECT_THAT( completions,
+               Contains(
+                 Property( &CompletionData::SnippetToInsertInBuffer,
+                           StrEq( "foobar(${1:int t})" ) ) ) );
+}
+
+
 TEST( ClangCompleterTest, CandidatesObjCForLocationInFile ) {
   ClangCompleter completer;
   std::vector< std::string > flags;
@@ -79,6 +97,8 @@ TEST( ClangCompleterTest, CandidatesObjCForLocationInFile ) {
 
   EXPECT_TRUE( !completions.empty() );
   EXPECT_THAT( completions[0].TextToInsertInBuffer(), StrEq( "withArg2:" ) );
+  EXPECT_THAT( completions[0].SnippetToInsertInBuffer(), StrEq(
+    "withArg2:${1:(int)} withArg3:${2:(int)}" ) );
 }
 
 
@@ -98,6 +118,9 @@ TEST( ClangCompleterTest, CandidatesObjCFuncForLocationInFile ) {
   EXPECT_TRUE( !completions.empty() );
   EXPECT_THAT(
     completions[0].TextToInsertInBuffer(),
+    StrEq( "(void)test:(int)arg1 withArg2:(int)arg2 withArg3:(int)arg3" ) );
+  EXPECT_THAT(
+    completions[0].SnippetToInsertInBuffer(),
     StrEq( "(void)test:(int)arg1 withArg2:(int)arg2 withArg3:(int)arg3" ) );
 }
 

--- a/cpp/ycm/tests/testdata/basic.cpp
+++ b/cpp/ycm/tests/testdata/basic.cpp
@@ -3,8 +3,8 @@ struct Foo {
   int y;
   char c;
 
-  int foobar() {
-    return 5;
+  int foobar(int t) {
+    return t;
   }
 };
 

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -126,6 +126,7 @@ BOOST_PYTHON_MODULE(ycm_core)
 
   class_< CompletionData >( "CompletionData" )
     .def( "TextToInsertInBuffer", &CompletionData::TextToInsertInBuffer )
+    .def( "SnippetToInsertInBuffer", &CompletionData::SnippetToInsertInBuffer )
     .def( "MainCompletionText", &CompletionData::MainCompletionText )
     .def( "ExtraMenuInfo", &CompletionData::ExtraMenuInfo )
     .def( "DetailedInfoForPreviewWindow",

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -403,6 +403,7 @@ class ClangCompleter( Completer ):
 def ConvertCompletionData( completion_data ):
   return responses.BuildCompletionData(
     insertion_text = completion_data.TextToInsertInBuffer(),
+    insertion_snippet = completion_data.SnippetToInsertInBuffer(),
     menu_text = completion_data.MainCompletionText(),
     extra_menu_info = completion_data.ExtraMenuInfo(),
     kind = completion_data.kind_.name,

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -113,6 +113,7 @@ class CsharpCompleter( Completer ):
     completion_type = self.CompletionType( request_data )
     return [ responses.BuildCompletionData(
                 completion[ 'CompletionText' ],
+                None,
                 completion[ 'DisplayText' ],
                 completion[ 'Description' ],
                 None,

--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -224,6 +224,7 @@ def _GenerateCandidatesForPaths( absolute_paths ):
     completion_dicts.append(
       responses.BuildCompletionData(
         basename,
+        None,
         EXTRA_INFO_MAP[ extra_info[ basename ] ] ) )
 
   return completion_dicts

--- a/ycmd/completers/general/ultisnips_completer.py
+++ b/ycmd/completers/general/ultisnips_completer.py
@@ -54,5 +54,6 @@ class UltiSnipsCompleter( GeneralCompleter ):
     raw_candidates = request_data.get( 'ultisnips_snippets', [] )
     self._candidates = [
       responses.BuildCompletionData( snip[ 'trigger' ],
+                                     None,
                                      '<snip> ' + snip[ 'description' ] )
       for snip in raw_candidates ]

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -210,6 +210,7 @@ class TernCompleter( Completer ):
       return doc
 
     return [ responses.BuildCompletionData( completion[ 'name' ],
+                                            None,
                                             completion.get( 'type', '?' ),
                                             BuildDoc( completion ) )
              for completion in completions ]

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -265,6 +265,7 @@ class JediCompleter( Completer ):
   def ComputeCandidatesInner( self, request_data ):
     return [ responses.BuildCompletionData(
                 completion[ 'name' ],
+                None,
                 completion[ 'description' ],
                 completion[ 'docstring' ],
                 extra_data = self._GetExtraData( completion ) )

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -99,6 +99,7 @@ def BuildDetailedInfoResponse( text ):
 
 
 def BuildCompletionData( insertion_text,
+                         insertion_snippet = None,
                          extra_menu_info = None,
                          detailed_info = None,
                          menu_text = None,
@@ -108,6 +109,8 @@ def BuildCompletionData( insertion_text,
     'insertion_text': insertion_text
   }
 
+  if insertion_snippet:
+    completion_data[ 'insertion_snippet' ] = insertion_snippet
   if extra_menu_info:
     completion_data[ 'extra_menu_info' ] = extra_menu_info
   if menu_text:

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -121,8 +121,10 @@ def GetCompletions_ForcedWithNoTrigger_test( app ):
       'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains(
-          CompletionEntryMatcher( 'DO_SOMETHING_TO', 'void' ),
-          CompletionEntryMatcher( 'DO_SOMETHING_WITH', 'void' ),
+          CompletionEntryMatcher( 'DO_SOMETHING_TO', 'void', extra_params = {
+            'insertion_snippet': 'DO_SOMETHING_TO(${1:T &t})' } ),
+          CompletionEntryMatcher( 'DO_SOMETHING_WITH', 'void', extra_params = {
+            'insertion_snippet': 'DO_SOMETHING_WITH(${1:T *t})' } ),
         ),
         'errors': empty(),
       } )


### PR DESCRIPTION
Some context
* https://github.com/Valloric/ycmd/issues/121
* https://github.com/Valloric/ycmd/pull/137

---

It turned out that a breaking refactor is not suitable for this project and this time I try to implement parameter placeholders in completions in a much less intrusive way.

Basically a field named `insertion_snippet` is added to completion candidate object as an alternative to `insertion_text`.
Take a function completion for `fun(int x)` as an example, we can have:
```
insertion_text: 'fun',
insertion_snippet: 'fun(${1:int x})'
```

## TextMate Snippet Format
This field is only adopted in clang completer and all snippet placeholders will be parameters of functions or templates, numbered from 1. Yet this [snippet format](https://manual.macromates.com/en/snippets) is much more capable and also widespread.
Though it may not be fully supported by all editors, the simple usage above works indeed in UltiSnips, Atom and VSCode without parsing and reconstructing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/661)
<!-- Reviewable:end -->
