### PR TITLE
Fix decoding error

### DIFF
--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -414,6 +414,9 @@ def SplitLines( contents ):
   # ''.splitlines() returns [], but we want [ '' ]
   if contents == '':
     return [ '' ]
+  
+  # Fix decoding error
+  contents = contents.decode('utf-8')
 
   lines = contents.splitlines()
 


### PR DESCRIPTION
I encounter a decoding error when I'm testing YCMD with code from [https://github.com/7sDream/zhihu-py3/tree/master/zhihu](https://github.com/7sDream/zhihu-py3/tree/master/zhihu) which includes python 3 code with Chinese inside.

Adding decode('utf-8') to contents will fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/662)
<!-- Reviewable:end -->
