### PR TITLE
[READY] Do not disable Flake8 on Python 2.6 Travis but restrict its version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ install:
   - source ci/travis/travis_install.sh
 compiler:
   - gcc
-script:
-  - ci/travis/travis_script.sh
+script: ./run_tests.py
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 env:
@@ -25,17 +24,16 @@ env:
     - YCM_CORES=3
     - COVERAGE=true
   matrix:
-    # Since 3.0.4, Flake8 is not working anymore on Python 2.6.
-    - USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6 YCMD_FLAKE8=false
-    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6 YCMD_FLAKE8=false
-    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7 YCMD_FLAKE8=true
-    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=3.3 YCMD_FLAKE8=true
+    - USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6
+    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6
+    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7
+    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=3.3
 matrix:
   exclude:
     - os: osx
-      env: USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6 YCMD_FLAKE8=false
+      env: USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6
     - os: osx
-      env: USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6 YCMD_FLAKE8=false
+      env: USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6
 addons:
   # If this doesn't make much sense to you, see the travis docs:
   #    https://docs.travis-ci.com/user/migrating-from-legacy/

--- a/ci/travis/travis_script.sh
+++ b/ci/travis/travis_script.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-if [ "${YCMD_FLAKE8}" = true ]; then
-  ./run_tests.py
-else
-  ./run_tests.py --no-flake8
-fi

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,12 +1,14 @@
-flake8>=2.6.0
-mock>=1.3.0
-nose>=1.3.7
-PyHamcrest>=1.8.5
-WebTest>=2.0.20
-ordereddict>=1.1
-nose-exclude>=0.4.1
-unittest2>=1.1.0
-psutil>=3.3.0
+# Flake8 3.x dropped support of Python 2.6 and 3.3
+flake8       <  3.0.0; python_version == '2.6' or python_version == '3.3'
+flake8       >= 3.0.0; python_version == '2.7' or python_version >  '3.3'
+mock         >= 1.3.0
+nose         >= 1.3.7
+PyHamcrest   >= 1.8.5
+WebTest      >= 2.0.20
+ordereddict  >= 1.1
+nose-exclude >= 0.4.1
+unittest2    >= 1.1.0
+psutil       >= 3.3.0
 # This needs to be kept in sync with submodule checkout in third_party
-future==0.15.2
-coverage>=4.2
+future       == 0.15.2
+coverage     >= 4.2


### PR DESCRIPTION
See issue https://github.com/Valloric/ycmd/issues/660. This reverts PR #570 and adds a version requirement to Flake8 for Python 2.6 and 3.3. Once this is merged, I'll prepare a similar PR for YCM repository.

Fixes #660.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/665)
<!-- Reviewable:end -->
