### PR TITLE
Use Xcode's libclang

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -292,7 +292,7 @@ if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
                   /usr/lib/llvm
                   ${SYS_LLVM_PATHS}
                   /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib
-                  /Library/Developer/CommandLineTools/usr/lib)
+                  /Library/Developer/CommandLineTools/usr/lib )
     set( EXTERNAL_LIBCLANG_PATH ${TEMP} )
   else()
     # For Macs, we do things differently; look further in this file.

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -291,8 +291,8 @@ if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
                   /usr/lib
                   /usr/lib/llvm
                   ${SYS_LLVM_PATHS}
-                  /Library/Developer/CommandLineTools/usr/lib
-                  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib )
+                  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib
+                  /Library/Developer/CommandLineTools/usr/lib)
     set( EXTERNAL_LIBCLANG_PATH ${TEMP} )
   else()
     # For Macs, we do things differently; look further in this file.


### PR DESCRIPTION
Use Xcode's libclang because it's always newer than Xcode command line tool's libclang
The current libclang in Xcode command line tool is too old.
Switch to libclang in Xcode 8 can fix this error.

**Actual**
```bash
./install.py --clang-completer --system-libclang
```
will output
```
Undefined symbols for architecture x86_64:
  "_clang_parseTranslationUnit2FullArgv", referenced from:
      YouCompleteMe::TranslationUnit::TranslationUnit(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::vector<UnsavedFile, std::__1::allocator<UnsavedFile> > const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, void*) in TranslationUnit.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
ERROR: the build failed.
```

**Expected**
```
[134/134] Linking CXX shared library /Users/.../YouCompleteMe/third_party/ycmd/ycm_core.so
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/666)
<!-- Reviewable:end -->
