### PR TITLE
Support objc import module

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -407,7 +407,7 @@ endif()
 # present in the same directory as our ycm_core.so is used.
 # And the extra `rpath` is helpful to find libclang.dylib's dependencies
 # if it is built with `--enable-shared` flag.
-if ( EXTERNAL_LIBCLANG_PATH AND APPLE )
+if ( EXTERNAL_LIBCLANG_PATH AND APPLE AND NOT USE_SYSTEM_LIBCLANG)
   get_filename_component(EXTRA_LIB_PATH ${EXTERNAL_LIBCLANG_PATH} DIRECTORY)
 
   set_target_properties(${PROJECT_NAME}

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -181,8 +181,11 @@ def PrepareFlagsForClang( flags, filename, add_extra_clang_flags = True ):
   flags = _RemoveUnusedFlags( flags, filename )
   if add_extra_clang_flags:
     flags = _EnableTypoCorrection( flags )
-  flags = _SanitizeFlags( flags )
-  return flags
+
+  vector = ycm_core.StringVector()
+  for flag in flags:
+    vector.append( ToCppStringCompatible( flag ) )
+  return vector
 
 
 def _RemoveXclangFlags( flags ):
@@ -203,16 +206,6 @@ def _RemoveXclangFlags( flags ):
     sanitized_flags.append( flag )
 
   return sanitized_flags
-
-
-def _SanitizeFlags( flags ):
-  """Drops unsafe flags. Currently these are only -arch flags; they tend to
-  crash libclang."""
-
-  vector = ycm_core.StringVector()
-  for flag in flags:
-    vector.append( ToCppStringCompatible( flag ) )
-  return vector
 
 
 def _RemoveFlagsPrecedingCompiler( flags ):

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -209,22 +209,8 @@ def _SanitizeFlags( flags ):
   """Drops unsafe flags. Currently these are only -arch flags; they tend to
   crash libclang."""
 
-  sanitized_flags = []
-  saw_arch = False
-  for i, flag in enumerate( flags ):
-    if flag == '-arch':
-      saw_arch = True
-      continue
-    elif flag.startswith( '-arch' ):
-      continue
-    elif saw_arch:
-      saw_arch = False
-      continue
-
-    sanitized_flags.append( flag )
-
   vector = ycm_core.StringVector()
-  for flag in sanitized_flags:
+  for flag in flags:
     vector.append( ToCppStringCompatible( flag ) )
   return vector
 

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -113,10 +113,10 @@ def SanitizeFlags_ArchNotRemoved_test():
   eq_( expected + not_to_remove,
        list( flags._SanitizeFlags( expected + not_to_remove ) ) )
 
-  eq_( expected + not_to_remove,
+  eq_( not_to_remove + expected,
        list( flags._SanitizeFlags( not_to_remove + expected ) ) )
 
-  eq_( expected + not_to_remove,
+  eq_( expected[ :1 ] + not_to_remove + expected[ -1: ],
        list( flags._SanitizeFlags(
          expected[ :1 ] + not_to_remove + expected[ -1: ] ) ) )
 

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -101,26 +101,6 @@ def FlagsForFile_FlagsCachedWhenDoCacheIsTrue_test( *args ):
     assert_that( flags_list, contains( '-x', 'c' ) )
 
 
-def SanitizeFlags_Passthrough_test():
-  eq_( [ '-foo', '-bar' ],
-       list( flags._SanitizeFlags( [ '-foo', '-bar' ] ) ) )
-
-
-def SanitizeFlags_ArchNotRemoved_test():
-  expected = [ '-foo', '-bar' ]
-  not_to_remove = [ '-arch', 'arch_of_evil' ]
-
-  eq_( expected + not_to_remove,
-       list( flags._SanitizeFlags( expected + not_to_remove ) ) )
-
-  eq_( not_to_remove + expected,
-       list( flags._SanitizeFlags( not_to_remove + expected ) ) )
-
-  eq_( expected[ :1 ] + not_to_remove + expected[ -1: ],
-       list( flags._SanitizeFlags(
-         expected[ :1 ] + not_to_remove + expected[ -1: ] ) ) )
-
-
 def RemoveUnusedFlags_Passthrough_test():
   eq_( [ '-foo', '-bar' ],
        flags._RemoveUnusedFlags( [ '-foo', '-bar' ], 'file' ) )

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -106,19 +106,19 @@ def SanitizeFlags_Passthrough_test():
        list( flags._SanitizeFlags( [ '-foo', '-bar' ] ) ) )
 
 
-def SanitizeFlags_ArchRemoved_test():
+def SanitizeFlags_ArchNotRemoved_test():
   expected = [ '-foo', '-bar' ]
-  to_remove = [ '-arch', 'arch_of_evil' ]
+  not_to_remove = [ '-arch', 'arch_of_evil' ]
 
-  eq_( expected,
-       list( flags._SanitizeFlags( expected + to_remove ) ) )
+  eq_( expected + not_to_remove,
+       list( flags._SanitizeFlags( expected + not_to_remove ) ) )
 
-  eq_( expected,
-       list( flags._SanitizeFlags( to_remove + expected ) ) )
+  eq_( expected + not_to_remove,
+       list( flags._SanitizeFlags( not_to_remove + expected ) ) )
 
-  eq_( expected,
+  eq_( expected + not_to_remove,
        list( flags._SanitizeFlags(
-         expected[ :1 ] + to_remove + expected[ -1: ] ) ) )
+         expected[ :1 ] + not_to_remove + expected[ -1: ] ) ) )
 
 
 def RemoveUnusedFlags_Passthrough_test():


### PR DESCRIPTION
Fixes #659 

It turns out that only the libclang in Xcode 8 can handle the `@import Foundation;` syntax correctly.
It means the ycmd should be built  by `install.py --clang-completer --system-libclang`. 
Besides, I got to remove some tweaks in `CMakeLists.txt` and `flags.py` for the system's libclang to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/667)
<!-- Reviewable:end -->
