### PR TITLE
Make IdentifierAtIndex more accurate

### DIFF
--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -157,6 +157,9 @@ def IdentifierAtIndex( text, index, filetype = None ):
     return ''
 
   for match in IdentifierRegexForFiletype( filetype ).finditer( text ):
-    if match.end() > index:
+    if match.start() > index:
+      return ''
+    
+    if match.start() < index < match.end():
       return match.group()
   return ''


### PR DESCRIPTION
In the old implementation, IdentifierAtIndex function will return the next identifier right after the space character when cursor with specified index is on it. I add a restriction on the index so IdentifierAtIndex will handle that situation well.

There might be other problems I don't take into consideration, what's your opinions?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/668)
<!-- Reviewable:end -->
