### PR TITLE
Added yang

### DIFF
--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -104,6 +104,11 @@ FILETYPE_TO_IDENTIFIER_REGEX = {
 
     # Spec: http://doc.perl6.org/language/syntax
     'perl6': re.compile( r"[_a-zA-Z](?:\w|[-'](?=[_a-zA-Z]))*", re.UNICODE ),
+
+    # Spec: https://tools.ietf.org/html/rfc6020
+    # Section 6.2
+    # namespace + identifier
+    'yang': re.compile( r"[a-zA-Z][\w:.-]*", re.UNICODE ),
 }
 
 FILETYPE_TO_IDENTIFIER_REGEX[ 'typescript' ] = (


### PR DESCRIPTION
Added yang language to identifier utils, the regex includes namespace, e.g. 'inet:ipv4-address'. I've used this myself for quite some time now without any trouble.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/672)
<!-- Reviewable:end -->
