### PR TITLE
Update bottle to 0.12.13

### DIFF
--- a/ycmd/bottle_utils.py
+++ b/ycmd/bottle_utils.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 from future.utils import PY2
-from ycmd.utils import ToBytes, ToUnicode
+from ycmd.utils import ToCppStringCompatible, ToUnicode
 import bottle
 
 
@@ -38,5 +38,6 @@ import bottle
 # making life easier for codebases that work across versions, thus preventing
 # tracebacks in the depths of WSGI server frameworks.
 def SetResponseHeader( name, value ):
-  name = ToBytes( name ) if PY2 else ToUnicode( name )
-  bottle.response.set_header( name, ToUnicode( value ) )
+  name = ToCppStringCompatible( name ) if PY2 else ToUnicode( name )
+  value = ToCppStringCompatible( value ) if PY2 else ToUnicode( value )
+  bottle.response.set_header( name, value )


### PR DESCRIPTION
Fixes: #670

Currently ycmd is only working with bottle that comes with ycmd.
It is really an old version of bottle and ycmd is not compatible with
recent version.

A Debian package must use system-dependencies instead of third_party modules.

This patch is updating bottle and making ycmd to compatible with latest
bottle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/673)
<!-- Reviewable:end -->
