### PR TITLE
[RFC] Enable dev flags when --enable-debug is supplied

### DIFF
--- a/build.py
+++ b/build.py
@@ -305,6 +305,7 @@ def GetCmakeArgs( parsed_args ):
 
   if parsed_args.enable_debug:
     cmake_args.append( '-DCMAKE_BUILD_TYPE=Debug' )
+    cmake_args.append( '-DUSE_DEV_FLAGS=ON' )
 
   # coverage is not supported for c++ on MSVC
   if not OnWindows() and parsed_args.enable_coverage:


### PR DESCRIPTION
I was looking at the CMake config and noticed the `USE_DEV_FLAGS` option which i'd never seen before.

It seems a useful thing for devs (enables `-Wall -Wextra -Werror`), so enabling it with `--enable-debug` seems a solid move.

Tested by adding `int x;` in a random method and observing following build failure:

```
Bens-MBP:build ben$ ninja
[2/4] Building CXX object ycm/CMakeFiles/ycm_core.dir/Candidate.cpp.o
FAILED: ycm/CMakeFiles/ycm_core.dir/Candidate.cpp.o
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++   -DBOOST_THREAD_DONT_USE_CHRONO -DUSE_CLANG_COMPLETER -DYCMD_CORE_VERSION=25 -Dycm_core_EXPORTS -I/Users/ben/.vim/bundle/YouCompleteMe-Clean/third_party/ycmd/cpp/ycm -I/Users/ben/.vim/bundle/YouCompleteMe-Clean/third_party/ycmd/cpp/ycm/ClangCompleter -isystem /Users/ben/.vim/bundle/YouCompleteMe-Clean/third_party/ycmd/cpp/BoostParts -isystem /usr/local/Cellar/python/2.7.12_2/Frameworks/Python.framework/Versions/2.7/include/python2.7 -isystem ycm/../clang+llvm-3.9.0-x86_64-apple-darwin/include -stdlib=libc++ -fcolor-diagnostics -Wall -Wextra -Werror -Wc++98-compat -g -fPIC   -std=c++0x -MD -MT ycm/CMakeFiles/ycm_core.dir/Candidate.cpp.o -MF ycm/CMakeFiles/ycm_core.dir/Candidate.cpp.o.d -o ycm/CMakeFiles/ycm_core.dir/Candidate.cpp.o -c /Users/ben/.vim/bundle/YouCompleteMe-Clean/third_party/ycmd/cpp/ycm/Candidate.cpp
/Users/ben/.vim/bundle/YouCompleteMe-Clean/third_party/ycmd/cpp/ycm/Candidate.cpp:56:7: error: unused variable 'x' [-Werror,-Wunused-variable]
  int x;
      ^
1 error generated.
ninja: build stopped: subcommand failed.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/677)
<!-- Reviewable:end -->
