### PR TITLE
[READY] Automatically load a compilation database if found

### DIFF
--- a/cpp/ycm/ClangCompleter/CompilationDatabase.cpp
+++ b/cpp/ycm/ClangCompleter/CompilationDatabase.cpp
@@ -41,11 +41,11 @@ remove_pointer< CXCompileCommands >::type > CompileCommandsWrap;
 
 CompilationDatabase::CompilationDatabase(
   const boost::python::object &path_to_directory )
-  : is_loaded_( false ) {
+  : is_loaded_( false )
+  , path_to_directory_( GetUtf8String( path_to_directory ) ) {
   CXCompilationDatabase_Error status;
-  std::string path_to_directory_string = GetUtf8String( path_to_directory );
   compilation_database_ = clang_CompilationDatabase_fromDirectory(
-                            path_to_directory_string.c_str(),
+                            path_to_directory_.c_str(),
                             &status );
   is_loaded_ = status == CXCompilationDatabase_NoError;
 }

--- a/cpp/ycm/ClangCompleter/CompilationDatabase.h
+++ b/cpp/ycm/ClangCompleter/CompilationDatabase.h
@@ -54,9 +54,14 @@ public:
   CompilationInfoForFile GetCompilationInfoForFile(
     const boost::python::object &path_to_file );
 
+  std::string GetDatabaseDirectory() {
+    return path_to_directory_;
+  }
+
 private:
 
   bool is_loaded_;
+  std::string path_to_directory_;
   CXCompilationDatabase compilation_database_;
   boost::mutex compilation_database_mutex_;
 };

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -197,7 +197,9 @@ BOOST_PYTHON_MODULE(ycm_core)
     .def( "AlreadyGettingFlags",
           &CompilationDatabase::AlreadyGettingFlags )
     .def( "GetCompilationInfoForFile",
-          &CompilationDatabase::GetCompilationInfoForFile );
+          &CompilationDatabase::GetCompilationInfoForFile )
+    .def_readonly( "database_directory",
+                   &CompilationDatabase::GetDatabaseDirectory );
 
   class_< CompilationInfoForFile,
       boost::shared_ptr< CompilationInfoForFile > >(


### PR DESCRIPTION
Alternative implementation to : https://github.com/Valloric/ycmd/pull/679

See #679 for explanation and rationale.

Fixes: https://github.com/Valloric/ycmd/issues/489
Fixes: https://github.com/Valloric/YouCompleteMe/issues/2310 (sort of)
Fixes: https://github.com/Valloric/ycmd/issues/26
Fixes: https://github.com/Valloric/YouCompleteMe/issues/1981
Fixes: https://github.com/Valloric/YouCompleteMe/issues/1623 (sort of)
Fixes: https://github.com/Valloric/YouCompleteMe/issues/1622
Partly implements: https://github.com/Valloric/YouCompleteMe/issues/927
Fixes: https://github.com/Valloric/YouCompleteMe/issues/664
Fixes: https://github.com/Valloric/YouCompleteMe/issues/487
Fixes (discussion on): https://github.com/Valloric/YouCompleteMe/issues/174

This implementation is almost identical to the default-extra-conf version, except:

- the code lives in `flags.py`
- it re-uses `INCLUDE_FLAGS` from `flags.py`
- it provides the directory of the compilation database in the `clang_completer` debug info instead of the name of the default extra conf module.

On reflection, I think I might prefer this implementation.

For now, the tests are identical to the other PR (you can now see why I added that set of tests!)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/680)
<!-- Reviewable:end -->
