### PR TITLE
Fix Type Error in Flags.FlagsForFile@completers/cpp/flags.py

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -131,14 +131,14 @@ class Flags( object ):
       if not self.no_extra_conf_file_warning_posted:
         self.no_extra_conf_file_warning_posted = True
         raise NoExtraConfDetected
-      return None
+      return []
 
     if not results or not results.get( 'flags_ready', True ):
-      return None
+      return []
 
     flags = _ExtractFlagsList( results )
     if not flags:
-      return None
+      return []
 
     if add_extra_clang_flags:
       flags += self.extra_clang_flags


### PR DESCRIPTION
In `completers/cpp/flags.py`, `UserIncludePaths` expect `self.FlagsForFile` to return a `list`. But it return `None` when there's no flags available, causing `TypeError` and flickering in vim.

This PR changes three `return None` to `return []` in `FlagsForFile`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/682)
<!-- Reviewable:end -->
