### PR TITLE
[READY] Use non-capturing group in JavaScript identifier regex

### DIFF
--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -68,7 +68,7 @@ FILETYPE_TO_IDENTIFIER_REGEX = {
     # Spec:
     # http://www.ecma-international.org/ecma-262/6.0/#sec-names-and-keywords
     # Default identifier plus the dollar sign.
-    'javascript': re.compile( r"([^\W\d]|\$)[\w$]*", re.UNICODE ),
+    'javascript': re.compile( r"(?:[^\W\d]|\$)[\w$]*", re.UNICODE ),
 
     # Spec: http://www.w3.org/TR/CSS2/syndata.html#characters
     # Good summary: http://stackoverflow.com/a/449000/1672783

--- a/ycmd/tests/identifier_utils_test.py
+++ b/ycmd/tests/identifier_utils_test.py
@@ -137,6 +137,12 @@ def ExtractIdentifiersFromText_Html_TemplateChars_test():
                has_item( 'goo' ) )
 
 
+def ExtractIdentifiersFromText_JavaScript_test():
+  eq_( [ "var", "foo", "require", "bar" ],
+       iu.ExtractIdentifiersFromText( "var foo = require('bar');",
+                                      'javascript' ) )
+
+
 def IsIdentifier_Default_test():
   ok_( iu.IsIdentifier( 'foo' ) )
   ok_( iu.IsIdentifier( 'foo129' ) )


### PR DESCRIPTION
In PR https://github.com/Valloric/ycmd/issues/643, we added a regular expression with a capturing group for JavaScript (and TypeScript) identifiers. Unfortunately, this makes [`re.findall` returns matches of this group instead of the whole pattern](https://docs.python.org/2/library/re.html#re.findall). Since this function is used in `ExtractIdentifiersFromText`, it breaks the extraction of identifiers in JS and TS files. We fix the issue by replacing the `(...)` pattern with `(:?...)`.

Added a test that fails without the fix:
```
AssertionError: ['var', 'foo', 'require', 'bar'] != ['v', 'f', 'r', 'b']
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/684)
<!-- Reviewable:end -->
