### PR TITLE
[READY] Suppress MSVC warnings from third-party libraries

### DIFF
--- a/cpp/BoostParts/CMakeLists.txt
+++ b/cpp/BoostParts/CMakeLists.txt
@@ -72,10 +72,12 @@ add_library( BoostParts ${SOURCES} )
 
 #############################################################################
 
+# No warnings. We just use Boost as is so warnings coming from it are just
+# noise.
 if( CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG )
-  # No warnings. We just use Boost as is so warnings coming from it are just
-  # noise.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w" )
+elseif( MSVC )
+  add_definitions( /W0 -D_SCL_SECURE_NO_WARNINGS )
 endif()
 
 #############################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -130,8 +130,8 @@ endif()
 
 # For MSVC enable UNICODE and compilation on multiple processors
 if ( MSVC )
-  add_definitions( /DUNICODE /D_UNICODE /Zc:wchar_t-  )
-	set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP" )
+  add_definitions( /DUNICODE /D_UNICODE /Zc:wchar_t- )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP" )
 endif()
 
 # Solves the conflict in names of hypot in python sources and boost::python
@@ -156,8 +156,9 @@ endif()
 if( WIN32 OR CYGWIN )
   # BOOST_PYTHON_SOURCE makes boost use the correct __declspec
   add_definitions( -DBOOST_PYTHON_SOURCE -DBOOST_THREAD_USE_LIB )
-  if ( 64_BIT_PLATFORM )
-    # Enables python compilation for 64-bit Windows
+  if ( NOT MSVC AND 64_BIT_PLATFORM )
+      # Enables Python compilation for 64-bit Windows. Already defined by Python
+      # headers when compiling with MSVC.
     add_definitions( -DMS_WIN64 )
   endif()
 endif()

--- a/cpp/ycm/tests/CMakeLists.txt
+++ b/cpp/ycm/tests/CMakeLists.txt
@@ -18,11 +18,13 @@
 project( ycm_core_tests )
 cmake_minimum_required( VERSION 2.8 )
 
-# The gtest library triggers these warnings, so we turn them off; it's not up to
-# us to fix gtest warnings, it's up to upstream.
+# The gtest library triggers warnings, so we turn them off; it's not up to us to
+# fix gtest warnings, it's up to upstream.
 if ( COMPILER_IS_CLANG )
   set( CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -Wno-long-long -Wno-variadic-macros -Wno-missing-field-initializers -Wno-unused-private-field -Wno-c++98-compat" )
+elseif( MSVC )
+  add_definitions( /W0 )
 endif()
 
 


### PR DESCRIPTION
This suppresses the warnings raised while compiling Boost and gtest with MSVC. It also fixes the `MS_WIN64` redefinition warnings on 64-bit (this macro is already defined in Python headers).

These changes reduce the number of warnings from 310 to 3 on 32-bit and from 403 to 23 on 64-bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/685)
<!-- Reviewable:end -->
