### PR TITLE
Update build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -66,7 +66,9 @@ DYNAMIC_PYTHON_LIBRARY_REGEX = """
   # OS X
   libpython{major}\.{minor}m?\.dylib|
   # Windows
-  python{major}{minor}\.lib
+  python{major}{minor}\.lib|
+  # Cygwin
+  libpython{major}\.{minor}\.dll\.a
   )$
 """
 


### PR DESCRIPTION
The name of libpython under cygwin is libpythonx.x.dll.a. So I add a line of regex to make the build.py able to find the libpython which makes the install.py work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/688)
<!-- Reviewable:end -->
