### PR TITLE
Add haskell ctag support

### DIFF
--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -80,6 +80,7 @@ const boost::unordered_map < const char *,
         ( "Erlang"     , "erlang"     )
         ( "Fortran"    , "fortran"    )
         ( "Go"         , "go"         )
+        ( "Haskell"    , "haskell"    )
         ( "HTML"       , "html"       )
         ( "Java"       , "java"       )
         ( "JavaScript" , "javascript" )


### PR DESCRIPTION
This way I can have autocompletion in haskell using CTags.
This works with tools like ``hasktags`` that can generate the ``language:Haskell`` field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/693)
<!-- Reviewable:end -->
