### PR TITLE
[READY] Exclude psutil 5.0.1 from test requirements

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,7 +8,8 @@ WebTest      >= 2.0.20
 ordereddict  >= 1.1
 nose-exclude >= 0.4.1
 unittest2    >= 1.1.0
-psutil       >= 3.3.0
+# psutil 5.0.1 is broken on Python 3.6 and Windows 64-bit
+psutil       >= 3.3.0, != 5.0.1
 # This needs to be kept in sync with submodule checkout in third_party
 future       == 0.15.2
 coverage     >= 4.2


### PR DESCRIPTION
Last version of psutil (5.0.1) is broken on Python 3.6 and Windows 64-bit. See issue https://github.com/giampaolo/psutil/issues/951. We exclude it from our test requirements. This fixes the builds with `arch=64` and `python=36` on AppVeyor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/695)
<!-- Reviewable:end -->
