### PR TITLE
[WIP] Minimise boost library usage by using C++11 feautres

### DIFF
--- a/cpp/ycm/Candidate.cpp
+++ b/cpp/ycm/Candidate.cpp
@@ -19,18 +19,21 @@
 #include "Candidate.h"
 #include "Result.h"
 
-#include <boost/algorithm/string.hpp>
+#include <algorithm>
 #include <cctype>
 #include <locale>
 
-using boost::algorithm::all;
-using boost::algorithm::is_lower;
-using boost::algorithm::is_print;
+using std::all_of;
+using std::islower;
+using std::isprint;
 
 namespace YouCompleteMe {
 
 bool IsPrintable( const std::string &text ) {
-  return all( text, is_print( std::locale::classic() ) );
+  for ( auto character : text )
+    if ( !isprint( character ) )
+      return false;
+  return true;
 }
 
 
@@ -75,9 +78,17 @@ Candidate::Candidate( const std::string &text )
   :
   text_( text ),
   word_boundary_chars_( GetWordBoundaryChars( text ) ),
-  text_is_lowercase_( all( text, is_lower() ) ),
   letters_present_( LetterBitsetFromString( text ) ),
   root_node_( new LetterNode( text ) ) {
+    text_is_lowercase_ = true;
+    for ( auto character : text )
+    {
+      if ( islower( character ) )
+      {
+        text_is_lowercase_ = false;
+	break;
+      }
+    }
 }
 
 

--- a/cpp/ycm/Candidate.cpp
+++ b/cpp/ycm/Candidate.cpp
@@ -63,7 +63,7 @@ std::string GetWordBoundaryChars( const std::string &text ) {
 Bitset LetterBitsetFromString( const std::string &text ) {
   Bitset letter_bitset;
 
-  foreach ( char letter, text ) {
+  for ( char letter : text ) {
     int letter_index = IndexForLetter( letter );
 
     if ( IsInAsciiRange( letter_index ) )
@@ -97,7 +97,7 @@ Result Candidate::QueryMatchResult( const std::string &query,
   LetterNode *node = root_node_.get();
   int index_sum = 0;
 
-  foreach ( char letter, query ) {
+  for ( char letter : query ) {
     const NearestLetterNodeIndices *nearest =
       node->NearestLetterNodesForLetter( letter );
 

--- a/cpp/ycm/Candidate.h
+++ b/cpp/ycm/Candidate.h
@@ -21,9 +21,9 @@
 #include "DLLDefines.h"
 #include "LetterNode.h"
 
-#include <boost/scoped_ptr.hpp>
 #include <boost/utility.hpp>
 
+#include <memory>
 #include <string>
 #include <bitset>
 
@@ -65,7 +65,7 @@ private:
   std::string word_boundary_chars_;
   bool text_is_lowercase_;
   Bitset letters_present_;
-  boost::scoped_ptr< LetterNode > root_node_;
+  const std::unique_ptr< LetterNode > root_node_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/CandidateRepository.cpp
+++ b/cpp/ycm/CandidateRepository.cpp
@@ -66,7 +66,7 @@ std::vector< const Candidate * > CandidateRepository::GetCandidatesForStrings(
   {
     boost::lock_guard< boost::mutex > locker( holder_mutex_ );
 
-    foreach ( const std::string & candidate_text, strings ) {
+    for ( const std::string & candidate_text : strings ) {
       const std::string &validated_candidate_text =
         ValidatedCandidateText( candidate_text );
 
@@ -95,7 +95,7 @@ std::vector< const Candidate * > CandidateRepository::GetCandidatesForStrings(
   {
     boost::lock_guard< boost::mutex > locker( holder_mutex_ );
 
-    foreach ( const CompletionData & data, datas ) {
+    for ( const CompletionData & data : datas ) {
       const std::string &validated_candidate_text =
         ValidatedCandidateText( data.original_string_ );
 
@@ -117,7 +117,7 @@ std::vector< const Candidate * > CandidateRepository::GetCandidatesForStrings(
 #endif // USE_CLANG_COMPLETER
 
 CandidateRepository::~CandidateRepository() {
-  foreach ( const CandidateHolder::value_type & pair,
+  for ( const CandidateHolder::value_type & pair :
             candidate_holder_ ) {
     delete pair.second;
   }

--- a/cpp/ycm/CandidateRepository.cpp
+++ b/cpp/ycm/CandidateRepository.cpp
@@ -21,7 +21,6 @@
 #include "Utils.h"
 
 #include <boost/thread/locks.hpp>
-#include <boost/algorithm/string.hpp>
 
 #ifdef USE_CLANG_COMPLETER
 #  include "ClangCompleter/CompletionData.h"

--- a/cpp/ycm/CandidateRepository.cpp
+++ b/cpp/ycm/CandidateRepository.cpp
@@ -20,8 +20,6 @@
 #include "standard.h"
 #include "Utils.h"
 
-#include <boost/thread/locks.hpp>
-
 #ifdef USE_CLANG_COMPLETER
 #  include "ClangCompleter/CompletionData.h"
 #endif // USE_CLANG_COMPLETER
@@ -37,11 +35,11 @@ const int MAX_CANDIDATE_SIZE = 80;
 }  // unnamed namespace
 
 
-boost::mutex CandidateRepository::singleton_mutex_;
+std::mutex CandidateRepository::singleton_mutex_;
 CandidateRepository *CandidateRepository::instance_ = NULL;
 
 CandidateRepository &CandidateRepository::Instance() {
-  boost::lock_guard< boost::mutex > locker( singleton_mutex_ );
+  std::lock_guard< std::mutex > locker( singleton_mutex_ );
 
   if ( !instance_ ) {
     static CandidateRepository repo;
@@ -53,7 +51,7 @@ CandidateRepository &CandidateRepository::Instance() {
 
 
 int CandidateRepository::NumStoredCandidates() {
-  boost::lock_guard< boost::mutex > locker( holder_mutex_ );
+  std::lock_guard< std::mutex > locker( holder_mutex_ );
   return candidate_holder_.size();
 }
 
@@ -64,7 +62,7 @@ std::vector< const Candidate * > CandidateRepository::GetCandidatesForStrings(
   candidates.reserve( strings.size() );
 
   {
-    boost::lock_guard< boost::mutex > locker( holder_mutex_ );
+    std::lock_guard< std::mutex > locker( holder_mutex_ );
 
     for ( const std::string & candidate_text : strings ) {
       const std::string &validated_candidate_text =
@@ -93,7 +91,7 @@ std::vector< const Candidate * > CandidateRepository::GetCandidatesForStrings(
   candidates.reserve( datas.size() );
 
   {
-    boost::lock_guard< boost::mutex > locker( holder_mutex_ );
+    std::lock_guard< std::mutex > locker( holder_mutex_ );
 
     for ( const CompletionData & data : datas ) {
       const std::string &validated_candidate_text =

--- a/cpp/ycm/CandidateRepository.h
+++ b/cpp/ycm/CandidateRepository.h
@@ -21,7 +21,7 @@
 #include "DLLDefines.h"
 
 #include <boost/utility.hpp>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 #include <mutex>
 #include <vector>
@@ -32,7 +32,7 @@ namespace YouCompleteMe {
 class Candidate;
 struct CompletionData;
 
-typedef boost::unordered_map< std::string, const Candidate * >
+typedef std::unordered_map< std::string, const Candidate * >
 CandidateHolder;
 
 

--- a/cpp/ycm/CandidateRepository.h
+++ b/cpp/ycm/CandidateRepository.h
@@ -22,8 +22,8 @@
 
 #include <boost/utility.hpp>
 #include <boost/unordered_map.hpp>
-#include <boost/thread/mutex.hpp>
 
+#include <mutex>
 #include <vector>
 #include <string>
 
@@ -64,9 +64,9 @@ private:
 
   const std::string &ValidatedCandidateText( const std::string &text );
 
-  boost::mutex holder_mutex_;
+  std::mutex holder_mutex_;
 
-  static boost::mutex singleton_mutex_;
+  static std::mutex singleton_mutex_;
   static CandidateRepository *instance_;
 
   const std::string empty_;

--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -28,10 +28,9 @@
 #include "ReleaseGil.h"
 
 #include <clang-c/Index.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
-
-using boost::shared_ptr;
+using std::shared_ptr;
 using boost::unordered_map;
 
 namespace YouCompleteMe {

--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -31,7 +31,7 @@
 #include <memory>
 
 using std::shared_ptr;
-using boost::unordered_map;
+using std::unordered_map;
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -24,10 +24,10 @@
 #include "Range.h"
 #include "PythonSupport.h"
 
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #include <iostream>
 
-using boost::unordered_map;
+using std::unordered_map;
 
 namespace YouCompleteMe {
 namespace {
@@ -227,7 +227,7 @@ std::vector< CompletionData > ToCompletionDataVector(
                                      completions.size() );
 
     if ( index == completions.size() ) {
-      completions.push_back( boost::move( data ) );
+      completions.push_back( std::move( data ) );
     }
 
     else {

--- a/cpp/ycm/ClangCompleter/ClangHelpers.h
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.h
@@ -23,14 +23,14 @@
 #include "UnsavedFile.h"
 
 #include <vector>
+#include <memory>
 #include <clang-c/Index.h>
-#include <boost/shared_ptr.hpp>
-#include <boost/type_traits/remove_pointer.hpp>
+#include <type_traits>
 
 namespace YouCompleteMe {
 
-typedef boost::shared_ptr <
-boost::remove_pointer< CXDiagnostic >::type > DiagnosticWrap;
+typedef std::shared_ptr <
+std::remove_pointer< CXDiagnostic >::type > DiagnosticWrap;
 
 std::vector< CompletionData > ToCompletionDataVector(
   CXCodeCompleteResults *results );

--- a/cpp/ycm/ClangCompleter/CompilationDatabase.cpp
+++ b/cpp/ycm/ClangCompleter/CompilationDatabase.cpp
@@ -21,16 +21,15 @@
 #include "ReleaseGil.h"
 #include "PythonSupport.h"
 
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/type_traits/remove_pointer.hpp>
+#include <memory>
+#include <type_traits>
 #include <boost/thread/locks.hpp>
 
 using boost::lock_guard;
 using boost::unique_lock;
 using boost::try_to_lock_t;
-using boost::remove_pointer;
-using boost::shared_ptr;
+using std::remove_pointer;
+using std::shared_ptr;
 using boost::mutex;
 
 namespace YouCompleteMe {

--- a/cpp/ycm/ClangCompleter/CompilationDatabase.cpp
+++ b/cpp/ycm/ClangCompleter/CompilationDatabase.cpp
@@ -23,14 +23,13 @@
 
 #include <memory>
 #include <type_traits>
-#include <boost/thread/locks.hpp>
 
-using boost::lock_guard;
-using boost::unique_lock;
-using boost::try_to_lock_t;
+using std::lock_guard;
+using std::unique_lock;
+using std::try_to_lock_t;
 using std::remove_pointer;
 using std::shared_ptr;
-using boost::mutex;
+using std::mutex;
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/ClangCompleter/CompilationDatabase.h
+++ b/cpp/ycm/ClangCompleter/CompilationDatabase.h
@@ -22,9 +22,9 @@
 #include <string>
 #include <memory>
 #include <boost/utility.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/python.hpp>
 #include <clang-c/CXCompilationDatabase.h>
+#include <mutex>
 
 
 namespace YouCompleteMe {
@@ -63,7 +63,7 @@ private:
   bool is_loaded_;
   std::string path_to_directory_;
   CXCompilationDatabase compilation_database_;
-  boost::mutex compilation_database_mutex_;
+  std::mutex compilation_database_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/ClangCompleter/CompilationDatabase.h
+++ b/cpp/ycm/ClangCompleter/CompilationDatabase.h
@@ -20,8 +20,8 @@
 
 #include <vector>
 #include <string>
+#include <memory>
 #include <boost/utility.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/python.hpp>
 #include <clang-c/CXCompilationDatabase.h>

--- a/cpp/ycm/ClangCompleter/CompletionData.cpp
+++ b/cpp/ycm/ClangCompleter/CompletionData.cpp
@@ -18,8 +18,6 @@
 #include "CompletionData.h"
 #include "ClangUtils.h"
 
-#include <boost/algorithm/string/erase.hpp>
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/move/move.hpp>
 
 namespace YouCompleteMe {
@@ -147,14 +145,19 @@ std::string OptionalChunkToString( CXCompletionString completion_string,
   return final_string;
 }
 
+bool ends_with(const std::string &str, const std::string &suffix)
+{
+  return str.size() >= suffix.size() &&
+         str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
 
 // foo( -> foo
 // foo() -> foo
 std::string RemoveTrailingParens( std::string text ) {
-  if ( boost::ends_with( text, "(" ) ) {
-    boost::erase_tail( text, 1 );
-  } else if ( boost::ends_with( text, "()" ) ) {
-    boost::erase_tail( text, 2 );
+  if ( ends_with( text, "(" ) ) {
+    text.substr( 0, text.length() - 1 );
+  } else if ( ends_with( text, "()" ) ) {
+    text.substr( 0, text.length() - 2 );
   }
 
   return text;

--- a/cpp/ycm/ClangCompleter/CompletionData.cpp
+++ b/cpp/ycm/ClangCompleter/CompletionData.cpp
@@ -155,9 +155,9 @@ bool ends_with(const std::string &str, const std::string &suffix)
 // foo() -> foo
 std::string RemoveTrailingParens( std::string text ) {
   if ( ends_with( text, "(" ) ) {
-    text.substr( 0, text.length() - 1 );
+    text = text.substr( 0, text.length() - 1 );
   } else if ( ends_with( text, "()" ) ) {
-    text.substr( 0, text.length() - 2 );
+    text = text.substr( 0, text.length() - 2 );
   }
 
   return text;

--- a/cpp/ycm/ClangCompleter/CompletionData.cpp
+++ b/cpp/ycm/ClangCompleter/CompletionData.cpp
@@ -18,7 +18,7 @@
 #include "CompletionData.h"
 #include "ClangUtils.h"
 
-#include <boost/move/move.hpp>
+#include <utility>
 
 namespace YouCompleteMe {
 
@@ -185,7 +185,7 @@ CompletionData::CompletionData( const CXCompletionResult &completion_result ) {
                           saw_placeholder );
   }
 
-  original_string_ = RemoveTrailingParens( boost::move( original_string_ ) );
+  original_string_ = RemoveTrailingParens( std::move( original_string_ ) );
   kind_ = CursorKindToCompletionKind( completion_result.CursorKind );
 
   detailed_info_.append( return_type_ )

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -82,7 +82,7 @@ TranslationUnit::TranslationUnit(
   std::vector< const char * > pointer_flags;
   pointer_flags.reserve( flags.size() );
 
-  foreach ( const std::string & flag, flags ) {
+  for ( const std::string & flag : flags ) {
     pointer_flags.push_back( flag.c_str() );
   }
 
@@ -425,7 +425,7 @@ std::vector< FixIt > TranslationUnit::GetFixItsForLocationInFile(
   {
     unique_lock< mutex > lock( diagnostics_mutex_ );
 
-    foreach( const Diagnostic& diagnostic, latest_diagnostics_ ) {
+    for( const Diagnostic& diagnostic : latest_diagnostics_ ) {
       // Find all diagnostics for the supplied line which have FixIts attached
       if ( diagnostic.location_.line_number_ == static_cast< uint >( line ) ) {
         fixits.insert( fixits.end(),

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -22,14 +22,14 @@
 #include "ClangUtils.h"
 #include "ClangHelpers.h"
 
-#include <boost/shared_ptr.hpp>
-#include <boost/type_traits/remove_pointer.hpp>
+#include <memory>
+#include <type_traits>
 
 using boost::unique_lock;
 using boost::mutex;
 using boost::try_to_lock_t;
-using boost::shared_ptr;
-using boost::remove_pointer;
+using std::shared_ptr;
+using std::remove_pointer;
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -23,6 +23,7 @@
 #include "ClangHelpers.h"
 
 #include <type_traits>
+#include <algorithm>
 
 using std::unique_lock;
 using std::mutex;
@@ -104,7 +105,7 @@ TranslationUnit::TranslationUnit(
                          &clang_translation_unit_ );
 
   if ( result != CXError_Success )
-    boost_throw( ClangParseError() );
+    throw( ClangParseError() );
 }
 
 
@@ -364,7 +365,7 @@ void TranslationUnit::Reparse( std::vector< CXUnsavedFile > &unsaved_files,
 
   if ( failure ) {
     Destroy();
-    boost_throw( ClangParseError() );
+    throw( ClangParseError() );
   }
 
   UpdateLatestDiagnostics();

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -22,12 +22,11 @@
 #include "ClangUtils.h"
 #include "ClangHelpers.h"
 
-#include <memory>
 #include <type_traits>
 
-using boost::unique_lock;
-using boost::mutex;
-using boost::try_to_lock_t;
+using std::unique_lock;
+using std::mutex;
+using std::try_to_lock_t;
 using std::shared_ptr;
 using std::remove_pointer;
 

--- a/cpp/ycm/ClangCompleter/TranslationUnit.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.h
@@ -26,8 +26,9 @@
 
 #include <clang-c/Index.h>
 #include <boost/utility.hpp>
-#include <boost/thread/mutex.hpp>
 
+#include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -116,10 +117,10 @@ private:
 
   std::string filename_;
 
-  boost::mutex diagnostics_mutex_;
+  std::mutex diagnostics_mutex_;
   std::vector< Diagnostic > latest_diagnostics_;
 
-  mutable boost::mutex clang_access_mutex_;
+  mutable std::mutex clang_access_mutex_;
   CXTranslationUnit clang_translation_unit_;
 };
 

--- a/cpp/ycm/ClangCompleter/TranslationUnit.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.h
@@ -34,7 +34,7 @@
 namespace YouCompleteMe {
 
 struct CompletionData;
-typedef boost::shared_ptr< std::vector< CompletionData > > AsyncCompletions;
+typedef std::shared_ptr< std::vector< CompletionData > > AsyncCompletions;
 
 class TranslationUnit : boost::noncopyable {
 public:

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
@@ -20,14 +20,12 @@
 #include "Utils.h"
 #include "exceptions.h"
 
-#include <boost/thread/locks.hpp>
-#include <memory>
 #include <boost/functional/hash.hpp>
 
-using boost::lock_guard;
+using std::lock_guard;
 using std::shared_ptr;
 using std::make_shared;
-using boost::mutex;
+using std::mutex;
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
@@ -21,12 +21,12 @@
 #include "exceptions.h"
 
 #include <boost/thread/locks.hpp>
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <boost/functional/hash.hpp>
 
 using boost::lock_guard;
-using boost::shared_ptr;
-using boost::make_shared;
+using std::shared_ptr;
+using std::make_shared;
 using boost::mutex;
 
 namespace YouCompleteMe {
@@ -86,10 +86,10 @@ shared_ptr< TranslationUnit > TranslationUnitStore::GetOrCreate(
     filename_to_flags_hash_[ filename ] = HashForFlags( flags );
   }
 
-  boost::shared_ptr< TranslationUnit > unit;
+  std::shared_ptr< TranslationUnit > unit;
 
   try {
-    unit = boost::make_shared< TranslationUnit >( filename,
+    unit = make_shared< TranslationUnit >( filename,
                                                   unsaved_files,
                                                   flags,
                                                   clang_index_ );

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.h
@@ -23,9 +23,9 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 #include <boost/utility.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/unordered_map.hpp>
 
@@ -40,12 +40,12 @@ public:
 
   // You can even call this function for the same filename from multiple
   // threads; the TU store will ensure only one TU is created.
-  boost::shared_ptr< TranslationUnit > GetOrCreate(
+  std::shared_ptr< TranslationUnit > GetOrCreate(
     const std::string &filename,
     const std::vector< UnsavedFile > &unsaved_files,
     const std::vector< std::string > &flags );
 
-  boost::shared_ptr< TranslationUnit > GetOrCreate(
+  std::shared_ptr< TranslationUnit > GetOrCreate(
     const std::string &filename,
     const std::vector< UnsavedFile > &unsaved_files,
     const std::vector< std::string > &flags,
@@ -55,7 +55,7 @@ public:
   // for the file before returning a stored TU (if the flags changed, the TU is
   // not really valid anymore and a new one should be built), this function does
   // not. You might end up getting a stale TU.
-  boost::shared_ptr< TranslationUnit > Get( const std::string &filename );
+  std::shared_ptr< TranslationUnit > Get( const std::string &filename );
 
   bool Remove( const std::string &filename );
 
@@ -64,11 +64,11 @@ public:
 private:
 
   // WARNING: This accesses filename_to_translation_unit_ without a lock!
-  boost::shared_ptr< TranslationUnit > GetNoLock( const std::string &filename );
+  std::shared_ptr< TranslationUnit > GetNoLock( const std::string &filename );
 
 
   typedef boost::unordered_map < std::string,
-          boost::shared_ptr< TranslationUnit > > TranslationUnitForFilename;
+          std::shared_ptr< TranslationUnit > > TranslationUnitForFilename;
 
   typedef boost::unordered_map < std::string,
           std::size_t > FlagsHashForFilename;

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.h
@@ -27,7 +27,7 @@
 
 #include <boost/utility.hpp>
 #include <mutex>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 typedef void *CXIndex;
 
@@ -67,10 +67,10 @@ private:
   std::shared_ptr< TranslationUnit > GetNoLock( const std::string &filename );
 
 
-  typedef boost::unordered_map < std::string,
+  typedef std::unordered_map < std::string,
           std::shared_ptr< TranslationUnit > > TranslationUnitForFilename;
 
-  typedef boost::unordered_map < std::string,
+  typedef std::unordered_map < std::string,
           std::size_t > FlagsHashForFilename;
 
   CXIndex clang_index_;

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.h
@@ -26,7 +26,7 @@
 #include <memory>
 
 #include <boost/utility.hpp>
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 #include <boost/unordered_map.hpp>
 
 typedef void *CXIndex;
@@ -76,7 +76,7 @@ private:
   CXIndex clang_index_;
   TranslationUnitForFilename filename_to_translation_unit_;
   FlagsHashForFilename filename_to_flags_hash_;
-  boost::mutex filename_to_translation_unit_and_flags_mutex_;
+  std::mutex filename_to_translation_unit_and_flags_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/IdentifierCompleter.cpp
+++ b/cpp/ycm/IdentifierCompleter.cpp
@@ -69,7 +69,7 @@ void IdentifierCompleter::ClearForFileAndAddIdentifiersToDatabase(
 void IdentifierCompleter::AddIdentifiersToDatabaseFromTagFiles(
   const std::vector< std::string > &absolute_paths_to_tag_files ) {
   ReleaseGil unlock;
-  foreach( const std::string & path, absolute_paths_to_tag_files ) {
+  for( const std::string & path : absolute_paths_to_tag_files ) {
     identifier_database_.AddIdentifiers(
       ExtractIdentifiersFromTagsFile( path ) );
   }
@@ -96,7 +96,7 @@ std::vector< std::string > IdentifierCompleter::CandidatesForQueryAndType(
   std::vector< std::string > candidates;
   candidates.reserve( results.size() );
 
-  foreach ( const Result & result, results ) {
+  for ( const Result & result : results ) {
     candidates.push_back( *result.Text() );
   }
   return candidates;

--- a/cpp/ycm/IdentifierCompleter.h
+++ b/cpp/ycm/IdentifierCompleter.h
@@ -23,7 +23,6 @@
 
 #include <boost/utility.hpp>
 #include <boost/unordered_map.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include <memory>
 #include <vector>

--- a/cpp/ycm/IdentifierCompleter.h
+++ b/cpp/ycm/IdentifierCompleter.h
@@ -23,9 +23,9 @@
 
 #include <boost/utility.hpp>
 #include <boost/unordered_map.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
 
+#include <memory>
 #include <vector>
 #include <string>
 

--- a/cpp/ycm/IdentifierCompleter.h
+++ b/cpp/ycm/IdentifierCompleter.h
@@ -22,7 +22,6 @@
 #include "IdentifierDatabase.h"
 
 #include <boost/utility.hpp>
-#include <boost/unordered_map.hpp>
 
 #include <memory>
 #include <vector>

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -24,7 +24,6 @@
 #include "Result.h"
 #include "Utils.h"
 
-#include <boost/thread/locks.hpp>
 #include <boost/unordered_set.hpp>
 
 #include <algorithm>
@@ -43,7 +42,7 @@ IdentifierDatabase::IdentifierDatabase()
 
 void IdentifierDatabase::AddIdentifiers(
   const FiletypeIdentifierMap &filetype_identifier_map ) {
-  boost::lock_guard< boost::mutex > locker( filetype_candidate_map_mutex_ );
+  std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
 
   for ( const FiletypeIdentifierMap::value_type & filetype_and_map :
             filetype_identifier_map ) {
@@ -61,7 +60,7 @@ void IdentifierDatabase::AddIdentifiers(
   const std::vector< std::string > &new_candidates,
   const std::string &filetype,
   const std::string &filepath ) {
-  boost::lock_guard< boost::mutex > locker( filetype_candidate_map_mutex_ );
+  std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
   AddIdentifiersNoLock( new_candidates, filetype, filepath );
 }
 
@@ -69,7 +68,7 @@ void IdentifierDatabase::AddIdentifiers(
 void IdentifierDatabase::ClearCandidatesStoredForFile(
   const std::string &filetype,
   const std::string &filepath ) {
-  boost::lock_guard< boost::mutex > locker( filetype_candidate_map_mutex_ );
+  std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
   GetCandidateSet( filetype, filepath ).clear();
 }
 
@@ -80,7 +79,7 @@ void IdentifierDatabase::ResultsForQueryAndType(
   std::vector< Result > &results ) const {
   FiletypeCandidateMap::const_iterator it;
   {
-    boost::lock_guard< boost::mutex > locker( filetype_candidate_map_mutex_ );
+    std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
     it = filetype_candidate_map_.find( filetype );
 
     if ( it == filetype_candidate_map_.end() || query.empty() )
@@ -101,7 +100,7 @@ void IdentifierDatabase::ResultsForQueryAndType(
   seen_candidates.reserve( candidate_repository_.NumStoredCandidates() );
 
   {
-    boost::lock_guard< boost::mutex > locker( filetype_candidate_map_mutex_ );
+    std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
     for ( const FilepathToCandidates::value_type & path_and_candidates :
               *it->second ) {
       for ( const Candidate * candidate : *path_and_candidates.second ) {

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -45,9 +45,9 @@ void IdentifierDatabase::AddIdentifiers(
   const FiletypeIdentifierMap &filetype_identifier_map ) {
   boost::lock_guard< boost::mutex > locker( filetype_candidate_map_mutex_ );
 
-  foreach ( const FiletypeIdentifierMap::value_type & filetype_and_map,
+  for ( const FiletypeIdentifierMap::value_type & filetype_and_map :
             filetype_identifier_map ) {
-    foreach( const FilepathToIdentifiers::value_type & filepath_and_identifiers,
+    for( const FilepathToIdentifiers::value_type & filepath_and_identifiers :
              filetype_and_map.second ) {
       AddIdentifiersNoLock( filepath_and_identifiers.second,
                             filetype_and_map.first,
@@ -102,9 +102,9 @@ void IdentifierDatabase::ResultsForQueryAndType(
 
   {
     boost::lock_guard< boost::mutex > locker( filetype_candidate_map_mutex_ );
-    foreach ( const FilepathToCandidates::value_type & path_and_candidates,
+    for ( const FilepathToCandidates::value_type & path_and_candidates :
               *it->second ) {
-      foreach ( const Candidate * candidate, *path_and_candidates.second ) {
+      for ( const Candidate * candidate : *path_and_candidates.second ) {
         if ( ContainsKey( seen_candidates, candidate ) )
           continue;
         else

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -24,7 +24,7 @@
 #include "Result.h"
 #include "Utils.h"
 
-#include <boost/unordered_set.hpp>
+#include <unordered_set>
 
 #include <algorithm>
 #include <cctype>
@@ -96,7 +96,7 @@ void IdentifierDatabase::ResultsForQueryAndType(
     }
   }
 
-  boost::unordered_set< const Candidate * > seen_candidates;
+  std::unordered_set< const Candidate * > seen_candidates;
   seen_candidates.reserve( candidate_repository_.NumStoredCandidates() );
 
   {

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -26,11 +26,12 @@
 
 #include <boost/thread/locks.hpp>
 #include <boost/unordered_set.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
 
-using boost::algorithm::any_of;
-using boost::algorithm::is_upper;
+#include <algorithm>
+#include <cctype>
+
+using std::any_of;
+using std::isupper;
 
 
 namespace YouCompleteMe {
@@ -86,7 +87,15 @@ void IdentifierDatabase::ResultsForQueryAndType(
       return;
   }
   Bitset query_bitset = LetterBitsetFromString( query );
-  bool query_has_uppercase_letters = any_of( query, is_upper() );
+  bool query_has_uppercase_letters = false;
+  for ( auto characters : query )
+  {
+    if ( isupper( characters ) )
+    {
+      query_has_uppercase_letters = true;
+      break;
+    }
+  }
 
   boost::unordered_set< const Candidate * > seen_candidates;
   seen_candidates.reserve( candidate_repository_.NumStoredCandidates() );

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -131,13 +131,13 @@ void IdentifierDatabase::ResultsForQueryAndType(
 std::set< const Candidate * > &IdentifierDatabase::GetCandidateSet(
   const std::string &filetype,
   const std::string &filepath ) {
-  boost::shared_ptr< FilepathToCandidates > &path_to_candidates =
+  std::shared_ptr< FilepathToCandidates > &path_to_candidates =
     filetype_candidate_map_[ filetype ];
 
   if ( !path_to_candidates )
     path_to_candidates.reset( new FilepathToCandidates() );
 
-  boost::shared_ptr< std::set< const Candidate * > > &candidates =
+  std::shared_ptr< std::set< const Candidate * > > &candidates =
     ( *path_to_candidates )[ filepath ];
 
   if ( !candidates )

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -19,7 +19,7 @@
 #define IDENTIFIERDATABASE_H_ZESX3CVR
 
 #include <boost/utility.hpp>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #include <mutex>
 
 #include <vector>
@@ -83,12 +83,12 @@ private:
 
 
   // filepath -> *( *candidate )
-  typedef boost::unordered_map < std::string,
+  typedef std::unordered_map < std::string,
           std::shared_ptr< std::set< const Candidate * > > >
           FilepathToCandidates;
 
   // filetype -> *( filepath -> *( *candidate ) )
-  typedef boost::unordered_map < std::string,
+  typedef std::unordered_map < std::string,
           std::shared_ptr< FilepathToCandidates > > FiletypeCandidateMap;
 
 

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -21,11 +21,11 @@
 #include <boost/utility.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <vector>
 #include <string>
 #include <map>
+#include <memory>
 #include <set>
 
 namespace YouCompleteMe {
@@ -84,12 +84,12 @@ private:
 
   // filepath -> *( *candidate )
   typedef boost::unordered_map < std::string,
-          boost::shared_ptr< std::set< const Candidate * > > >
+          std::shared_ptr< std::set< const Candidate * > > >
           FilepathToCandidates;
 
   // filetype -> *( filepath -> *( *candidate ) )
   typedef boost::unordered_map < std::string,
-          boost::shared_ptr< FilepathToCandidates > > FiletypeCandidateMap;
+          std::shared_ptr< FilepathToCandidates > > FiletypeCandidateMap;
 
 
   CandidateRepository &candidate_repository_;

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -20,7 +20,7 @@
 
 #include <boost/utility.hpp>
 #include <boost/unordered_map.hpp>
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 
 #include <vector>
 #include <string>
@@ -95,7 +95,7 @@ private:
   CandidateRepository &candidate_repository_;
 
   FiletypeCandidateMap filetype_candidate_map_;
-  mutable boost::mutex filetype_candidate_map_mutex_;
+  mutable std::mutex filetype_candidate_map_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -20,7 +20,6 @@
 #include "standard.h"
 
 #include <boost/unordered_map.hpp>
-#include <boost/assign/list_of.hpp>
 #include <regex>
 
 namespace YouCompleteMe {
@@ -63,49 +62,48 @@ struct StringEqualityComparer :
 const boost::unordered_map < const char *,
       const char *,
       boost::hash< std::string >,
-      StringEqualityComparer > LANG_TO_FILETYPE =
-        boost::assign::map_list_of
-        ( "Ant"        , "ant"        )
-        ( "Asm"        , "asm"        )
-        ( "Awk"        , "awk"        )
-        ( "Basic"      , "basic"      )
-        ( "C++"        , "cpp"        )
-        ( "C#"         , "cs"         )
-        ( "C"          , "c"          )
-        ( "COBOL"      , "cobol"      )
-        ( "DosBatch"   , "dosbatch"   )
-        ( "Eiffel"     , "eiffel"     )
-        ( "Elixir"     , "elixir"     )
-        ( "Erlang"     , "erlang"     )
-        ( "Fortran"    , "fortran"    )
-        ( "Go"         , "go"         )
-        ( "Haskell"    , "haskell"    )
-        ( "HTML"       , "html"       )
-        ( "Java"       , "java"       )
-        ( "JavaScript" , "javascript" )
-        ( "Lisp"       , "lisp"       )
-        ( "Lua"        , "lua"        )
-        ( "Make"       , "make"       )
-        ( "MatLab"     , "matlab"     )
-        ( "OCaml"      , "ocaml"      )
-        ( "Pascal"     , "pascal"     )
-        ( "Perl"       , "perl"       )
-        ( "PHP"        , "php"        )
-        ( "Python"     , "python"     )
-        ( "REXX"       , "rexx"       )
-        ( "Ruby"       , "ruby"       )
-        ( "Scheme"     , "scheme"     )
-        ( "Sh"         , "sh"         )
-        ( "SLang"      , "slang"      )
-        ( "SML"        , "sml"        )
-        ( "SQL"        , "sql"        )
-        ( "Tcl"        , "tcl"        )
-        ( "Tex"        , "tex"        )
-        ( "Vera"       , "vera"       )
-        ( "Verilog"    , "verilog"    )
-        ( "VHDL"       , "vhdl"       )
-        ( "Vim"        , "vim"        )
-        ( "YACC"       , "yacc"       );
+      StringEqualityComparer > LANG_TO_FILETYPE = {
+        { "Ant"        , "ant"        },
+        { "Asm"        , "asm"        },
+        { "Awk"        , "awk"        },
+        { "Basic"      , "basic"      },
+        { "C++"        , "cpp"        },
+        { "C#"         , "cs"         },
+        { "C"          , "c"          },
+        { "COBOL"      , "cobol"      },
+        { "DosBatch"   , "dosbatch"   },
+        { "Eiffel"     , "eiffel"     },
+        { "Elixir"     , "elixir"     },
+        { "Erlang"     , "erlang"     },
+        { "Fortran"    , "fortran"    },
+        { "Go"         , "go"         },
+        { "Haskell"    , "haskell"    },
+        { "HTML"       , "html"       },
+        { "Java"       , "java"       },
+        { "JavaScript" , "javascript" },
+        { "Lisp"       , "lisp"       },
+        { "Lua"        , "lua"        },
+        { "Make"       , "make"       },
+        { "MatLab"     , "matlab"     },
+        { "OCaml"      , "ocaml"      },
+        { "Pascal"     , "pascal"     },
+        { "Perl"       , "perl"       },
+        { "PHP"        , "php"        },
+        { "Python"     , "python"     },
+        { "REXX"       , "rexx"       },
+        { "Ruby"       , "ruby"       },
+        { "Scheme"     , "scheme"     },
+        { "Sh"         , "sh"         },
+        { "SLang"      , "slang"      },
+        { "SML"        , "sml"        },
+        { "SQL"        , "sql"        },
+        { "Tcl"        , "tcl"        },
+        { "Tex"        , "tex"        },
+        { "Vera"       , "vera"       },
+        { "Verilog"    , "verilog"    },
+        { "VHDL"       , "vhdl"       },
+        { "Vim"        , "vim"        },
+        { "YACC"       , "yacc"       },};
 
 const char *const NOT_FOUND = "YCMFOOBAR_NOT_FOUND";
 

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -21,8 +21,7 @@
 
 #include <boost/unordered_map.hpp>
 #include <boost/assign/list_of.hpp>
-#include <boost/regex.hpp>
-#include <boost/algorithm/string/regex.hpp>
+#include <regex>
 
 namespace YouCompleteMe {
 
@@ -127,11 +126,10 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
   std::string::const_iterator start = tags_file_contents.begin();
   std::string::const_iterator end   = tags_file_contents.end();
 
-  boost::smatch matches;
-  const boost::regex expression( TAG_REGEX );
-  const boost::match_flag_type options = boost::match_not_dot_newline;
+  std::smatch matches;
+  const std::regex expression( TAG_REGEX );
 
-  while ( boost::regex_search( start, end, matches, expression, options ) ) {
+  while ( std::regex_search( start, end, matches, expression ) ) {
     start = matches[ 0 ].second;
 
     std::string language( matches[ 3 ] );

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -19,7 +19,7 @@
 #include "Utils.h"
 #include "standard.h"
 
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #include <regex>
 
 namespace YouCompleteMe {
@@ -59,9 +59,9 @@ struct StringEqualityComparer :
 //   :e $VIMRUNTIME/filetype.vim
 // This is a map of const char* and not std::string to prevent issues with
 // static initialization.
-const boost::unordered_map < const char *,
+const std::unordered_map < const char *,
       const char *,
-      boost::hash< std::string >,
+      std::hash< std::string >,
       StringEqualityComparer > LANG_TO_FILETYPE = {
         { "Ant"        , "ant"        },
         { "Asm"        , "asm"        },

--- a/cpp/ycm/LetterNode.h
+++ b/cpp/ycm/LetterNode.h
@@ -22,7 +22,7 @@
 #include "LetterNodeListMap.h"
 
 #include <boost/utility.hpp>
-#include <boost/type_traits.hpp>
+//#include <type_traits>
 
 #include <memory>
 #include <vector>

--- a/cpp/ycm/LetterNode.h
+++ b/cpp/ycm/LetterNode.h
@@ -22,9 +22,9 @@
 #include "LetterNodeListMap.h"
 
 #include <boost/utility.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/type_traits.hpp>
 
+#include <memory>
 #include <vector>
 #include <list>
 #include <string>

--- a/cpp/ycm/LetterNodeListMap.h
+++ b/cpp/ycm/LetterNodeListMap.h
@@ -21,7 +21,7 @@
 #include "DLLDefines.h"
 
 #include <vector>
-#include <boost/move/unique_ptr.hpp>
+#include <memory>
 #include <boost/utility.hpp>
 #include <array>
 
@@ -75,7 +75,7 @@ private:
   typedef std::array<NearestLetterNodeIndices , NUM_LETTERS>
     NearestLetterNodeArray;
 
-  boost::movelib::unique_ptr< NearestLetterNodeArray > letters_;
+  std::unique_ptr< NearestLetterNodeArray > letters_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/LetterNodeListMap.h
+++ b/cpp/ycm/LetterNodeListMap.h
@@ -23,7 +23,7 @@
 #include <vector>
 #include <boost/move/unique_ptr.hpp>
 #include <boost/utility.hpp>
-#include <boost/array.hpp>
+#include <array>
 
 #define NUM_LETTERS 128
 
@@ -49,7 +49,7 @@ YCM_DLL_EXPORT int IndexForLetter( char letter );
  * doesn't occur, it records -1, indicating it isn't present.
  *
  * The indices can be used to retrieve the corresponding LetterNode from
- * the root LetterNode, as it contains a vector of LetterNodes, one per 
+ * the root LetterNode, as it contains a vector of LetterNodes, one per
  * position in the original string.
  */
 struct NearestLetterNodeIndices {
@@ -72,7 +72,7 @@ public:
   YCM_DLL_EXPORT NearestLetterNodeIndices *ListPointerAt( char letter );
 
 private:
-  typedef boost::array<NearestLetterNodeIndices , NUM_LETTERS>
+  typedef std::array<NearestLetterNodeIndices , NUM_LETTERS>
     NearestLetterNodeArray;
 
   boost::movelib::unique_ptr< NearestLetterNodeArray > letters_;

--- a/cpp/ycm/PythonSupport.cpp
+++ b/cpp/ycm/PythonSupport.cpp
@@ -110,7 +110,7 @@ boost::python::list FilterAndSortCandidates(
     std::sort( result_and_objects.begin(), result_and_objects.end() );
   }
 
-  foreach ( const ResultAnd< int > &result_and_object,
+  for ( const ResultAnd< int > &result_and_object :
             result_and_objects ) {
     filtered_candidates.append( candidates[ result_and_object.extra_object_ ] );
   }

--- a/cpp/ycm/PythonSupport.cpp
+++ b/cpp/ycm/PythonSupport.cpp
@@ -22,12 +22,12 @@
 #include "CandidateRepository.h"
 #include "ReleaseGil.h"
 
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
+#include <algorithm>
 #include <vector>
+#include <cctype>
 
-using boost::algorithm::any_of;
-using boost::algorithm::is_upper;
+using std::any_of;
+using std::isupper;
 using boost::python::len;
 using boost::python::str;
 using boost::python::extract;
@@ -82,7 +82,15 @@ boost::python::list FilterAndSortCandidates(
   {
     ReleaseGil unlock;
     Bitset query_bitset = LetterBitsetFromString( query );
-    bool query_has_uppercase_letters = any_of( query, is_upper() );
+    bool query_has_uppercase_letters = false;
+    for ( auto character : query )
+    {
+      if ( isupper( character ) )
+      {
+        query_has_uppercase_letters = true;
+        break;
+      }
+    }
 
     for ( int i = 0; i < num_candidates; ++i ) {
       const Candidate *candidate = repository_candidates[ i ];

--- a/cpp/ycm/Result.cpp
+++ b/cpp/ycm/Result.cpp
@@ -203,7 +203,7 @@ bool istarts_with( std::string text, std::string query )
 {
   bool starts_with_ignore_case = true;
 
-  for ( auto i=0; i < query.length(); ++i )
+  for ( size_t i=0; i < query.length(); ++i )
   {
     if ( toupper( text[i] ) != toupper( query[i] ) )
     {

--- a/cpp/ycm/Result.cpp
+++ b/cpp/ycm/Result.cpp
@@ -18,9 +18,9 @@
 #include "Result.h"
 #include "standard.h"
 #include "Utils.h"
-#include <boost/function.hpp>
 #include <algorithm>
 #include <locale>
+#include <functional>
 
 namespace YouCompleteMe {
 
@@ -47,7 +47,7 @@ bool StringLessThanWithLowercasePriority( const std::string &first,
   return std::lexicographical_compare(
            first.begin(), first.end(),
            second.begin(), second.end(),
-           boost::function< bool( const char &, const char & ) >(
+           std::function< bool( const char &, const char & ) >(
              &CharLessThanWithLowercasePriority ) );
 }
 

--- a/cpp/ycm/Result.cpp
+++ b/cpp/ycm/Result.cpp
@@ -18,12 +18,9 @@
 #include "Result.h"
 #include "standard.h"
 #include "Utils.h"
-#include <boost/algorithm/string.hpp>
 #include <boost/function.hpp>
 #include <algorithm>
 #include <locale>
-
-using boost::algorithm::istarts_with;
 
 namespace YouCompleteMe {
 
@@ -201,6 +198,22 @@ bool Result::operator< ( const Result &other ) const {
   return StringLessThanWithLowercasePriority( *text_, *other.text_ );
 }
 
+
+bool istarts_with( std::string text, std::string query )
+{
+  bool starts_with_ignore_case = true;
+
+  for ( auto i=0; i < query.length(); ++i )
+  {
+    if ( toupper( text[i] ) != toupper( query[i] ) )
+    {
+      starts_with_ignore_case = false;
+      break;
+    }
+  }
+
+  return starts_with_ignore_case;
+}
 
 void Result::SetResultFeaturesFromQuery(
   const std::string &word_boundary_chars,

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -19,7 +19,6 @@
 #include <cmath>
 #include <limits>
 #include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 namespace fs = boost::filesystem;
 
@@ -32,15 +31,15 @@ bool AlmostEqual( double a, double b ) {
 }
 
 
-std::string ReadUtf8File( const fs::path &filepath ) {
-  fs::ifstream file( filepath, std::ios::in | std::ios::binary );
-  std::vector< char > contents( ( std::istreambuf_iterator< char >( file ) ),
-                                std::istreambuf_iterator< char >() );
-
-  if ( contents.size() == 0 )
-    return std::string();
-
-  return std::string( contents.begin(), contents.end() );
+std::vector< std::string > ReadUtf8File( const fs::path &filepath ) {
+  std::ifstream file;
+  file.open(filepath.string());
+  std::vector<std::string> lines;
+  std::string temp_line;
+  while (std::getline(file,temp_line))
+    lines.push_back(temp_line);
+  file.close();
+  return lines;
 }
 
 

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -32,7 +32,7 @@ bool AlmostEqual( double a, double b );
 
 // Reads the entire contents of the specified file. If the file does not exist,
 // an exception is thrown.
-std::string ReadUtf8File( const fs::path &filepath );
+std::vector< std::string > ReadUtf8File( const fs::path &filepath );
 
 // Writes the entire contents of the specified file. If the file does not exist,
 // an exception is thrown.

--- a/cpp/ycm/exceptions.h
+++ b/cpp/ycm/exceptions.h
@@ -18,11 +18,7 @@
 #ifndef EXCEPTIONS_H_3PHJ9YOB
 #define EXCEPTIONS_H_3PHJ9YOB
 
-#include <boost/exception/all.hpp>
-
 namespace YouCompleteMe {
-
-#define boost_throw(x) BOOST_THROW_EXCEPTION(x)
 
 // YouCompleteMe uses the "Exception types as semantic tags" idiom.
 // For more information, see this link:
@@ -31,7 +27,7 @@ namespace YouCompleteMe {
 /**
  * The common base for all exceptions.
  */
-struct ExceptionBase: virtual std::exception, virtual boost::exception {};
+struct ExceptionBase: virtual std::exception {};
 
 /**
  * Thrown when a file does not exist.

--- a/cpp/ycm/standard.h
+++ b/cpp/ycm/standard.h
@@ -15,10 +15,4 @@
 // You should have received a copy of the GNU General Public License
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <boost/foreach.hpp>
-
-// We're most definitely not going to use
-// it as BOOST_FOREACH.
-#define foreach BOOST_FOREACH
-
 typedef unsigned int uint;

--- a/cpp/ycm/tests/gmock/gtest/src/gtest-internal-inl.h
+++ b/cpp/ycm/tests/gmock/gtest/src/gtest-internal-inl.h
@@ -292,7 +292,7 @@ inline int CountIf(const Container& c, Predicate predicate) {
 
 // Applies a function/functor to each element in the container.
 template <class Container, typename Functor>
-void for(const Container& c : Functor functor) {
+void ForEach(const Container& c, Functor functor) {
   std::for_each(c.begin(), c.end(), functor);
 }
 
@@ -709,7 +709,7 @@ class GTEST_API_ UnitTestImpl {
 
   // Clears the results of all tests, except the ad hoc tests.
   void ClearNonAdHocTestResult() {
-    for(test_cases_ : TestCase::ClearTestCaseResult);
+    ForEach(test_cases_, TestCase::ClearTestCaseResult);
   }
 
   // Clears the results of ad-hoc test assertions.

--- a/cpp/ycm/tests/gmock/gtest/src/gtest-internal-inl.h
+++ b/cpp/ycm/tests/gmock/gtest/src/gtest-internal-inl.h
@@ -292,7 +292,7 @@ inline int CountIf(const Container& c, Predicate predicate) {
 
 // Applies a function/functor to each element in the container.
 template <class Container, typename Functor>
-void ForEach(const Container& c, Functor functor) {
+void for(const Container& c : Functor functor) {
   std::for_each(c.begin(), c.end(), functor);
 }
 
@@ -709,7 +709,7 @@ class GTEST_API_ UnitTestImpl {
 
   // Clears the results of all tests, except the ad hoc tests.
   void ClearNonAdHocTestResult() {
-    ForEach(test_cases_, TestCase::ClearTestCaseResult);
+    for(test_cases_ : TestCase::ClearTestCaseResult);
   }
 
   // Clears the results of ad-hoc test assertions.

--- a/cpp/ycm/tests/gmock/gtest/src/gtest.cc
+++ b/cpp/ycm/tests/gmock/gtest/src/gtest.cc
@@ -146,7 +146,7 @@
 namespace testing {
 
 using internal::CountIf;
-using internal::for;
+using internal::ForEach;
 using internal::GetElementOr;
 using internal::Shuffle;
 
@@ -2685,7 +2685,7 @@ TestCase::TestCase(const char* a_name, const char* a_type_param,
 // Destructor of TestCase.
 TestCase::~TestCase() {
   // Deletes every Test in the collection.
-  for(test_info_list_ : internal::Delete<TestInfo>);
+  ForEach(test_info_list_, internal::Delete<TestInfo>);
 }
 
 // Returns the i-th test among all the tests. i can range from 0 to
@@ -2740,7 +2740,7 @@ void TestCase::Run() {
 // Clears the results of all tests in this test case.
 void TestCase::ClearResult() {
   ad_hoc_test_result_.Clear();
-  for(test_info_list_ : TestInfo::ClearTestResult);
+  ForEach(test_info_list_, TestInfo::ClearTestResult);
 }
 
 // Shuffles the tests in this test case.
@@ -3220,7 +3220,7 @@ class TestEventRepeater : public TestEventListener {
 };
 
 TestEventRepeater::~TestEventRepeater() {
-  for(listeners_ : Delete<TestEventListener>);
+  ForEach(listeners_, Delete<TestEventListener>);
 }
 
 void TestEventRepeater::Append(TestEventListener *listener) {
@@ -4308,10 +4308,10 @@ UnitTestImpl::UnitTestImpl(UnitTest* parent)
 
 UnitTestImpl::~UnitTestImpl() {
   // Deletes every TestCase.
-  for(test_cases_ : internal::Delete<TestCase>);
+  ForEach(test_cases_, internal::Delete<TestCase>);
 
   // Deletes every Environment.
-  for(environments_ : internal::Delete<Environment>);
+  ForEach(environments_, internal::Delete<Environment>);
 
   delete os_stack_trace_getter_;
 }
@@ -4580,7 +4580,7 @@ bool UnitTestImpl::RunAllTests() {
     if (has_tests_to_run) {
       // Sets up all environments beforehand.
       repeater->OnEnvironmentsSetUpStart(*parent_);
-      for(environments_ : SetUpEnvironment);
+      ForEach(environments_, SetUpEnvironment);
       repeater->OnEnvironmentsSetUpEnd(*parent_);
 
       // Runs the tests only if there was no fatal failure during global

--- a/cpp/ycm/tests/gmock/gtest/src/gtest.cc
+++ b/cpp/ycm/tests/gmock/gtest/src/gtest.cc
@@ -146,7 +146,7 @@
 namespace testing {
 
 using internal::CountIf;
-using internal::ForEach;
+using internal::for;
 using internal::GetElementOr;
 using internal::Shuffle;
 
@@ -2685,7 +2685,7 @@ TestCase::TestCase(const char* a_name, const char* a_type_param,
 // Destructor of TestCase.
 TestCase::~TestCase() {
   // Deletes every Test in the collection.
-  ForEach(test_info_list_, internal::Delete<TestInfo>);
+  for(test_info_list_ : internal::Delete<TestInfo>);
 }
 
 // Returns the i-th test among all the tests. i can range from 0 to
@@ -2740,7 +2740,7 @@ void TestCase::Run() {
 // Clears the results of all tests in this test case.
 void TestCase::ClearResult() {
   ad_hoc_test_result_.Clear();
-  ForEach(test_info_list_, TestInfo::ClearTestResult);
+  for(test_info_list_ : TestInfo::ClearTestResult);
 }
 
 // Shuffles the tests in this test case.
@@ -3220,7 +3220,7 @@ class TestEventRepeater : public TestEventListener {
 };
 
 TestEventRepeater::~TestEventRepeater() {
-  ForEach(listeners_, Delete<TestEventListener>);
+  for(listeners_ : Delete<TestEventListener>);
 }
 
 void TestEventRepeater::Append(TestEventListener *listener) {
@@ -4308,10 +4308,10 @@ UnitTestImpl::UnitTestImpl(UnitTest* parent)
 
 UnitTestImpl::~UnitTestImpl() {
   // Deletes every TestCase.
-  ForEach(test_cases_, internal::Delete<TestCase>);
+  for(test_cases_ : internal::Delete<TestCase>);
 
   // Deletes every Environment.
-  ForEach(environments_, internal::Delete<Environment>);
+  for(environments_ : internal::Delete<Environment>);
 
   delete os_stack_trace_getter_;
 }
@@ -4482,7 +4482,7 @@ TestCase* UnitTestImpl::GetTestCase(const char* test_case_name,
 }
 
 // Helpers for setting up / tearing down the given environment.  They
-// are for use in the ForEach() function.
+// are for use in the for() function.
 static void SetUpEnvironment(Environment* env) { env->SetUp(); }
 static void TearDownEnvironment(Environment* env) { env->TearDown(); }
 
@@ -4580,7 +4580,7 @@ bool UnitTestImpl::RunAllTests() {
     if (has_tests_to_run) {
       // Sets up all environments beforehand.
       repeater->OnEnvironmentsSetUpStart(*parent_);
-      ForEach(environments_, SetUpEnvironment);
+      for(environments_ : SetUpEnvironment);
       repeater->OnEnvironmentsSetUpEnd(*parent_);
 
       // Runs the tests only if there was no fatal failure during global

--- a/cpp/ycm/tests/gmock/gtest/test/gtest_unittest.cc
+++ b/cpp/ycm/tests/gmock/gtest/test/gtest_unittest.cc
@@ -245,7 +245,7 @@ using testing::internal::CopyArray;
 using testing::internal::CountIf;
 using testing::internal::EqFailure;
 using testing::internal::FloatingPoint;
-using testing::internal::ForEach;
+using testing::internal::for;
 using testing::internal::FormatEpochTimeInMillisAsIso8601;
 using testing::internal::FormatTimeInMillisAsSeconds;
 using testing::internal::GTestFlagSaver;
@@ -770,26 +770,26 @@ TEST(ContainerUtilityTest, CountIf) {
   EXPECT_EQ(2, CountIf(v, IsPositive));
 }
 
-// Tests ForEach().
+// Tests for().
 
 static int g_sum = 0;
 static void Accumulate(int n) { g_sum += n; }
 
-TEST(ContainerUtilityTest, ForEach) {
+TEST(ContainerUtilityTest : for) {
   std::vector<int> v;
   g_sum = 0;
-  ForEach(v, Accumulate);
+  for(v : Accumulate);
   EXPECT_EQ(0, g_sum);  // Works for an empty container;
 
   g_sum = 0;
   v.push_back(1);
-  ForEach(v, Accumulate);
+  for(v : Accumulate);
   EXPECT_EQ(1, g_sum);  // Works for a container with one element.
 
   g_sum = 0;
   v.push_back(20);
   v.push_back(300);
-  ForEach(v, Accumulate);
+  for(v : Accumulate);
   EXPECT_EQ(321, g_sum);
 }
 

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -70,7 +70,7 @@ BOOST_PYTHON_MODULE(ycm_core)
           &IdentifierCompleter::CandidatesForQueryAndType );
 
   class_< std::vector< std::string >,
-      boost::shared_ptr< std::vector< std::string > > >( "StringVector" )
+      std::shared_ptr< std::vector< std::string > > >( "StringVector" )
     .def( vector_indexing_suite< std::vector< std::string > >() );
 
 #ifdef USE_CLANG_COMPLETER
@@ -134,7 +134,7 @@ BOOST_PYTHON_MODULE(ycm_core)
     .def_readonly( "kind_", &CompletionData::kind_ );
 
   class_< std::vector< CompletionData >,
-      boost::shared_ptr< std::vector< CompletionData > > >( "CompletionVector" )
+      std::shared_ptr< std::vector< CompletionData > > >( "CompletionVector" )
     .def( vector_indexing_suite< std::vector< CompletionData > >() );
 
   class_< Location >( "Location" )
@@ -202,7 +202,7 @@ BOOST_PYTHON_MODULE(ycm_core)
                    &CompilationDatabase::GetDatabaseDirectory );
 
   class_< CompilationInfoForFile,
-      boost::shared_ptr< CompilationInfoForFile > >(
+      std::shared_ptr< CompilationInfoForFile > >(
           "CompilationInfoForFile", no_init )
     .def_readonly( "compiler_working_dir_",
                    &CompilationInfoForFile::compiler_working_dir_ )


### PR DESCRIPTION
This pull request makes use of C++11 featuure, by mostly switching from `boost::` to `std::`. In some parts of the code some non-trivial refactoring needed to be done as well.

Changes planned:

- [x] Change `boost::regex` to its `std` counterpart
- [x] Change `boost::function` to its `std` counterpart
- [x] Remove `boost::assign::list_of`
- [x] Change `boost::shared_ptr`, `boost::make_shared` and `boost::remove_ptr` to its `std` counterparts
- [x] Change `boost::mutex`, `boost::unique_lock` and `boost::try_to_lock_t` to its `std` counterpart
- [x] Change `boost::unique_ptr` to its `std` counterpart
- [x] Change `boost::unordered_set` to its `std` counterpart
- [x] Change `boost::scoped_ptr` to `std::unique_ptr` - [Reference](https://stackoverflow.com/questions/21852612/alternatives-to-boostscoped-ptr-in-c-11/21852657#21852657)
- [x] Change `boost::alogrithm` to its `std` counterpart
- [x] Change `boost::unordered_map` to its `std` counterpart
- [x] Remove `boost::exception`
- [x] Use range based for instead of BOOST_FOREACH
- [ ] Change `boost::hash` to `std::hash`
- [ ] Don't depend on boost for noncopyable classes
- [ ] Change `CMakeLists.txt` to reflect the new changes
- [ ] Bump ycmd version

Boost headers left in the code:

- `boost/python.hpp`
- `boost/filesystem.hpp`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/696)
<!-- Reviewable:end -->
