### PR TITLE
[READY] Switch from boost to std for hashes, arrays and regexes

### DIFF
--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
@@ -32,17 +32,21 @@ namespace YouCompleteMe {
 namespace {
 
 std::size_t HashForFlags( const std::vector< std::string > &flags ) {
-  /* 
+  /*
    * The way boost::hash implements hash< std::vector<T> > goes after the
    * described way in "Library Extension Technical Report - Issue List"
-   * section 6.18. When (if) it ends up in the STL this whole function could br
+   * section 6.18. This function's body is taken straight (copy-pasted)
+   * from the TR to replicate boost's behaviour.
+   *
+   * When (if) it ends up in the STL this whole function could be
    * replaced with:
    *
-   * return std::hash< std::vecto< std::string > >()( flags );
+   * return std::hash< std::vector< std::string > >()( flags );
    */
   size_t seed = 0;
-  for ( auto flag : flags )
+  for ( auto flag : flags ) {
     seed ^= std::hash< std::string >()( flag ) + ( seed<<6 ) + ( seed>>2 );
+  }
   return seed;
 }
 

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
@@ -20,7 +20,7 @@
 #include "Utils.h"
 #include "exceptions.h"
 
-#include <boost/functional/hash.hpp>
+#include <functional>
 
 using std::lock_guard;
 using std::shared_ptr;
@@ -32,7 +32,18 @@ namespace YouCompleteMe {
 namespace {
 
 std::size_t HashForFlags( const std::vector< std::string > &flags ) {
-  return boost::hash< std::vector< std::string > >()( flags );
+  /* 
+   * The way boost::hash implements hash< std::vector<T> > goes after the
+   * described way in "Library Extension Technical Report - Issue List"
+   * section 6.18. When (if) it ends up in the STL this whole function could br
+   * replaced with:
+   *
+   * return std::hash< std::vecto< std::string > >()( flags );
+   */
+  size_t seed = 0;
+  for ( auto flag : flags )
+    seed ^= std::hash< std::string >()( flag ) + ( seed<<6 ) + ( seed>>2 );
+  return seed;
 }
 
 }  // unnamed namespace

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -61,7 +61,7 @@ struct StringEqualityComparer :
 // static initialization.
 const std::unordered_map < const char *,
       const char *,
-      boost::hash< std::string >,
+      std::hash< std::string >,
       StringEqualityComparer > LANG_TO_FILETYPE = {
         { "Ant"        , "ant"        },
         { "Asm"        , "asm"        },

--- a/cpp/ycm/LetterNodeListMap.h
+++ b/cpp/ycm/LetterNodeListMap.h
@@ -22,7 +22,7 @@
 
 #include <vector>
 #include <memory>
-#include <boost/array.hpp>
+#include <array>
 
 #define NUM_LETTERS 128
 
@@ -71,7 +71,7 @@ public:
   YCM_DLL_EXPORT NearestLetterNodeIndices *ListPointerAt( char letter );
 
 private:
-  typedef boost::array<NearestLetterNodeIndices , NUM_LETTERS>
+  typedef std::array<NearestLetterNodeIndices , NUM_LETTERS>
     NearestLetterNodeArray;
 
   std::unique_ptr< NearestLetterNodeArray > letters_;

--- a/cpp/ycm/PythonSupport.cpp
+++ b/cpp/ycm/PythonSupport.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <vector>
 #include <locale>
+#include <utility>
 
 using std::any_of;
 using boost::python::len;
@@ -96,7 +97,7 @@ boost::python::list FilterAndSortCandidates(
 
       if ( result.IsSubsequence() ) {
         ResultAnd< int > result_and_object( result, i );
-        result_and_objects.push_back( boost::move( result_and_object ) );
+        result_and_objects.push_back( std::move( result_and_object ) );
       }
     }
 

--- a/cpp/ycm/tests/LetterNode_test.cpp
+++ b/cpp/ycm/tests/LetterNode_test.cpp
@@ -72,23 +72,6 @@ TEST( LetterNodeTest, ThrowOnNonAsciiCharacters ) {
   //   €: \xe2\x82\xac
   //   𐍈: \xf0\x90\x8d\x88
   ASSERT_THROW( LetterNode root_node( "uni¢𐍈d€" ), std::out_of_range );
-
-  /*
-   * Since what() is not standardised for std::array
-   * we do not test against its string value.
-   *
-   * When it gets standardised this part of code can
-   * be uncommented to check against the what() part
-   * of the error. To make the test valid, once the
-   * string checking is re-enabled, the string literal
-   * that is the argument of StrEq will have to be
-   * changed as well
-   */
-  // try {
-  //   LetterNode root_node( "uni¢𐍈d€" );
-  // } catch ( std::out_of_range error ) {
-  //   EXPECT_THAT( error.what(), StrEq( "array<>: index out of range" ) );
-  // }
 }
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/tests/LetterNode_test.cpp
+++ b/cpp/ycm/tests/LetterNode_test.cpp
@@ -73,11 +73,22 @@ TEST( LetterNodeTest, ThrowOnNonAsciiCharacters ) {
   //   𐍈: \xf0\x90\x8d\x88
   ASSERT_THROW( LetterNode root_node( "uni¢𐍈d€" ), std::out_of_range );
 
-  try {
-    LetterNode root_node( "uni¢𐍈d€" );
-  } catch ( std::out_of_range error ) {
-    EXPECT_THAT( error.what(), StrEq( "array<>: index out of range" ) );
-  }
+  /*
+   * Since what() is not standardised for std::array
+   * we do not test against its string value.
+   *
+   * When it gets standardised this part of code can
+   * be uncommented to check against the what() part
+   * of the error. To make the test valid, once the
+   * string checking is re-enabled, the string literal
+   * that is the argument of StrEq will have to be
+   * changed as well
+   */
+  // try {
+  //   LetterNode root_node( "uni¢𐍈d€" );
+  // } catch ( std::out_of_range error ) {
+  //   EXPECT_THAT( error.what(), StrEq( "array<>: index out of range" ) );
+  // }
 }
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -78,7 +78,7 @@ BOOST_PYTHON_MODULE(ycm_core)
           &IdentifierCompleter::CandidatesForQueryAndType );
 
   class_< std::vector< std::string >,
-      boost::shared_ptr< std::vector< std::string > > >( "StringVector" )
+      std::shared_ptr< std::vector< std::string > > >( "StringVector" )
     .def( vector_indexing_suite< std::vector< std::string > >() );
 
 #ifdef USE_CLANG_COMPLETER
@@ -142,7 +142,7 @@ BOOST_PYTHON_MODULE(ycm_core)
     .def_readonly( "kind_", &CompletionData::kind_ );
 
   class_< std::vector< CompletionData >,
-      boost::shared_ptr< std::vector< CompletionData > > >( "CompletionVector" )
+      std::shared_ptr< std::vector< CompletionData > > >( "CompletionVector" )
     .def( vector_indexing_suite< std::vector< CompletionData > >() );
 
   class_< Location >( "Location" )
@@ -210,7 +210,7 @@ BOOST_PYTHON_MODULE(ycm_core)
                    &CompilationDatabase::GetDatabaseDirectory );
 
   class_< CompilationInfoForFile,
-      boost::shared_ptr< CompilationInfoForFile > >(
+      std::shared_ptr< CompilationInfoForFile > >(
           "CompilationInfoForFile", no_init )
     .def_readonly( "compiler_working_dir_",
                    &CompilationInfoForFile::compiler_working_dir_ )


### PR DESCRIPTION
This is a continuation of #701. These changes will not be trivial and will need to be discussed before proceeding. At this moment only `std::hash` is working. The other two boost components will be discussed after agreeing that this hash implementation is fine.


- [x] Use `std::hash` instead of `boost::hash`
- [x] Use `std::array` instead of `boost::array`
~~Use `regex_search` and related from `std` namespace.~~

### Regex component will be in another PR

As it stands for now the regex part is the hardest to replce, so, in order not to make this PR big and drag it out, regex component will be in a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/705)
<!-- Reviewable:end -->
