### PR TITLE
Remove GetCandidatesForStrings taking CompletionData

### DIFF
--- a/cpp/ycm/CandidateRepository.cpp
+++ b/cpp/ycm/CandidateRepository.cpp
@@ -84,36 +84,6 @@ std::vector< const Candidate * > CandidateRepository::GetCandidatesForStrings(
   return candidates;
 }
 
-#ifdef USE_CLANG_COMPLETER
-
-std::vector< const Candidate * > CandidateRepository::GetCandidatesForStrings(
-  const std::vector< CompletionData > &datas ) {
-  std::vector< const Candidate * > candidates;
-  candidates.reserve( datas.size() );
-
-  {
-    std::lock_guard< std::mutex > locker( holder_mutex_ );
-
-    for ( const CompletionData & data : datas ) {
-      const std::string &validated_candidate_text =
-        ValidatedCandidateText( data.original_string_ );
-
-      const Candidate *&candidate = GetValueElseInsert(
-                                      candidate_holder_,
-                                      validated_candidate_text,
-                                      NULL );
-
-      if ( !candidate )
-        candidate = new Candidate( validated_candidate_text );
-
-      candidates.push_back( candidate );
-    }
-  }
-
-  return candidates;
-}
-
-#endif // USE_CLANG_COMPLETER
 
 CandidateRepository::~CandidateRepository() {
   for ( const CandidateHolder::value_type & pair : candidate_holder_ ) {

--- a/cpp/ycm/CandidateRepository.h
+++ b/cpp/ycm/CandidateRepository.h
@@ -28,7 +28,6 @@
 namespace YouCompleteMe {
 
 class Candidate;
-struct CompletionData;
 
 typedef std::unordered_map< std::string, const Candidate * >
 CandidateHolder;
@@ -53,11 +52,6 @@ public:
 
   YCM_DLL_EXPORT std::vector< const Candidate * > GetCandidatesForStrings(
     const std::vector< std::string > &strings );
-
-#ifdef USE_CLANG_COMPLETER
-  std::vector< const Candidate * > GetCandidatesForStrings(
-    const std::vector< CompletionData > &datas );
-#endif // USE_CLANG_COMPLETER
 
 private:
   CandidateRepository() {};


### PR DESCRIPTION
I was looking at the coverage data and saw that this member function was not covered, so I checked and I found out that we actually never use it, so why keep it?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/708)
<!-- Reviewable:end -->
