### PR TITLE
[ACTUALLY READY] Allow compilation for iOS projects

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -295,11 +295,22 @@ def _CallExtraConfFlagsForFile( module, filename, client_data ):
     return module.FlagsForFile( filename )
 
 
+def _SysRootSpecifedIn( flags ):
+  for flag in flags:
+    if flag == '-isysroot' or flag.startswith( '--sysroot' ):
+      return True
+
+  return False
+
+
 def PrepareFlagsForClang( flags, filename, add_extra_clang_flags = True ):
   flags = _AddLanguageFlagWhenAppropriate( flags )
   flags = _RemoveXclangFlags( flags )
   flags = _RemoveUnusedFlags( flags, filename )
   if add_extra_clang_flags:
+    if OnMac() and not _SysRootSpecifedIn( flags ):
+      for path in _MacIncludePaths():
+        flags.extend( [ '-isystem', path ] )
     flags = _EnableTypoCorrection( flags )
 
   vector = ycm_core.StringVector()
@@ -496,11 +507,13 @@ if OnMac():
   )
 
 
+def _MacIncludePaths():
+  # This method exists for testing only
+  return MAC_INCLUDE_PATHS
+
+
 def _ExtraClangFlags():
   flags = _SpecialClangIncludes()
-  if OnMac():
-    for path in MAC_INCLUDE_PATHS:
-      flags.extend( [ '-isystem', path ] )
   # On Windows, parsing of templates is delayed until instantiation time.
   # This makes GetType and GetParent commands fail to return the expected
   # result when the cursor is in a template.


### PR DESCRIPTION
Historically it hasn't been possible to use ycmd with iOS projects for 2 reasons:

1. Opensource libclang seems to be unable to build the system headers for th iOS platform. It's not known _why_ this is, but it is known that Apple patch clang in Xcode
2. ycmd's flag handling hasn't played well with the myriad switches that are needed to build using iOS system headers

The advice has always been to use `--system-libclang` in such environments. However, this only solves point 1.

For a completely unrelated reason I was today testing something which required using the iOS system headers (from `/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk`) and found that even with Apple's libclang I wasn't able to compile even a simple c program.

The issue is that we scribble flags to point to the MacOS platform on OS X to make "normal" things work. In order to compile for iOS, you need to add `-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk` to your flags. However, we then go and stick `-isystem /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/blah/blah` in the flags which causes problems.

The solution is to only add the additional mac paths if user doesn't specify a `-isysroot`.

This requires doing it for every flags for file request (rather than once at the start), but this is not a performance critical code path.

Fixes https://github.com/Valloric/ycmd/issues/534

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/710)
<!-- Reviewable:end -->
