### PR TITLE
[READY] Fix finding node on Debian-based distributions

### DIFF
--- a/build.py
+++ b/build.py
@@ -450,13 +450,13 @@ def BuildRacerd():
 
 
 def SetUpTern():
-  paths = {}
-  for exe in [ 'node', 'npm' ]:
-    path = FindExecutable( exe )
-    if not path:
-      sys.exit( 'ERROR: {0} is required to set up ternjs.'.format( exe ) )
-    else:
-      paths[ exe ] = path
+  # On Debian-based distributions, node is by default installed as nodejs.
+  node = PathToFirstExistingExecutable( [ 'nodejs', 'node' ] )
+  if not node:
+    sys.exit( 'ERROR: node is required to set up Tern.' )
+  npm = FindExecutable( 'npm' )
+  if not npm:
+    sys.exit( 'ERROR: npm is required to set up Tern.' )
 
   # We install Tern into a runtime directory. This allows us to control
   # precisely the version (and/or git commit) that is used by ycmd.  We use a
@@ -477,7 +477,7 @@ def SetUpTern():
   # (third_party/tern_runtime) that defines the packages that we require,
   # including Tern and any plugins which we require as standard.
   os.chdir( p.join( DIR_OF_THIS_SCRIPT, 'third_party', 'tern_runtime' ) )
-  CheckCall( [ paths[ 'npm' ], 'install', '--production' ] )
+  CheckCall( [ npm, 'install', '--production' ] )
 
 
 def WritePythonUsedDuringBuild():

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -49,7 +49,8 @@ PATH_TO_TERN_BINARY = os.path.abspath(
     'bin',
     'tern' ) )
 
-PATH_TO_NODE = utils.PathToFirstExistingExecutable( [ 'node' ] )
+# On Debian-based distributions, node is by default installed as nodejs.
+PATH_TO_NODE = utils.PathToFirstExistingExecutable( [ 'node', 'nodejs' ] )
 
 # host name/address on which the tern server should listen
 # note: we use 127.0.0.1 rather than localhost because on some platforms

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -50,7 +50,7 @@ PATH_TO_TERN_BINARY = os.path.abspath(
     'tern' ) )
 
 # On Debian-based distributions, node is by default installed as nodejs.
-PATH_TO_NODE = utils.PathToFirstExistingExecutable( [ 'node', 'nodejs' ] )
+PATH_TO_NODE = utils.PathToFirstExistingExecutable( [ 'nodejs', 'node' ] )
 
 # host name/address on which the tern server should listen
 # note: we use 127.0.0.1 rather than localhost because on some platforms

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -45,7 +45,7 @@ MAX_DETAILED_COMPLETIONS = 100
 RESPONSE_TIMEOUT_SECONDS = 10
 
 # On Debian-based distributions, node is by default installed as nodejs.
-PATH_TO_NODE = utils.PathToFirstExistingExecutable( [ 'node', 'nodejs' ] )
+PATH_TO_NODE = utils.PathToFirstExistingExecutable( [ 'nodejs', 'node' ] )
 
 LOGFILE_FORMAT = 'tsserver_'
 
@@ -94,7 +94,7 @@ def FindTsserverBinary():
     'tsserver' ) )
 
 
-def ShouldEnableTypescriptCompleter():
+def ShouldEnableTypeScriptCompleter():
   if not PATH_TO_NODE:
     _logger.warning( 'Not using TypeScript completer: unable to find node' )
     return False

--- a/ycmd/tests/typescript/typescript_completer_test.py
+++ b/ycmd/tests/typescript/typescript_completer_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Google Inc.
+# Copyright (C) 2017 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -23,12 +23,23 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
+from mock import patch, DEFAULT
+from nose.tools import ok_
+
 from ycmd.completers.typescript.typescript_completer import (
-    ShouldEnableTypeScriptCompleter, TypeScriptCompleter )
+    ShouldEnableTypeScriptCompleter )
 
 
-def GetCompleter( user_options ):
-  if not ShouldEnableTypeScriptCompleter():
-    return None
+def ShouldEnableTypeScriptCompleter_NodeAndTsserverFound_test():
+  ok_( ShouldEnableTypeScriptCompleter() )
 
-  return TypeScriptCompleter( user_options )
+
+@patch( 'ycmd.completers.typescript.typescript_completer.PATH_TO_NODE', None )
+def ShouldEnableTypeScriptCompleter_NodeNotFound_test( *args ):
+  ok_( not ShouldEnableTypeScriptCompleter() )
+
+
+@patch( 'ycmd.utils.FindExecutable',
+        lambda exe: None if exe == 'tsserver' else DEFAULT )
+def ShouldEnableTypeScriptCompleter_TsserverNotFound_test( *args ):
+  ok_( not ShouldEnableTypeScriptCompleter() )


### PR DESCRIPTION
On Debian-based distributions, `node` is installed by default as `nodejs`. See issue https://github.com/Valloric/YouCompleteMe/issues/2532. We fix that by looking for `nodejs` before `node`. We also need to change how we start the `tsserver` script because it contains the line `#!/usr/bin/env node` at the top.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/711)
<!-- Reviewable:end -->
