### PR TITLE
[READY] Update GoToType test for TypeScript completer

### DIFF
--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -382,7 +382,7 @@ def Subcommands_GoToType_test( app ):
                has_entries( {
                  'filepath': filepath,
                  'line_num': 2,
-                 'column_num': 1,
+                 'column_num': 7,
                } ) )
 
 


### PR DESCRIPTION
TypeScript 2.2 improved the behavior of the `GoToType` subcommand. It now jumps to the class name instead of the `Class` keyword when the cursor is on an object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/712)
<!-- Reviewable:end -->
