### PR TITLE
[READY] Migrate to Ubuntu 14.04 and set language to generic on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
-language: csharp
+language: generic
 os:
   - linux
   - osx
+dist: trusty
 osx_image: xcode8
 sudo: false
-mono:
-  - 4.2.3
 before_install:
   - git submodule update --init --recursive
 install:
@@ -18,8 +17,6 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 env:
   global:
-    - MONO_THREADS_PER_CPU=2000
-    - MONO_MANAGED_WATCHER=disabled
     # Travis can run out of RAM, so we need to be careful here.
     - YCM_CORES=3
     - COVERAGE=true
@@ -43,11 +40,14 @@ addons:
      #   https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
      - ubuntu-toolchain-r-test  # for new libstdc++
      - george-edison55-precise-backports # for a more recent version of cmake (3.2.3)
+     - mono # for installing Mono
     packages:
      - cmake-data
      - cmake
      # 4.8.1 is the first version of GCC with full C++11 support.
      - g++-4.8
+     # Required to build the OmniSharp server.
+     - mono-devel
      - ninja-build
      # Everything below is a Python build dep (though it depends on Python
      # version). We need them because pyenv builds Python.

--- a/ci/travis/travis_install.osx.sh
+++ b/ci/travis/travis_install.osx.sh
@@ -5,17 +5,18 @@
 brew update || brew update
 
 # List of homebrew formulae to install in the order they appear.
-# We require node, go and ninja for our build and tests, and all the others are
-# dependencies of pyenv.
+# We require Node, Go, Mono and Ninja for our build and tests, and all the
+# others are dependencies of pyenv.
 REQUIREMENTS="node.js
               go
+              mono
               ninja
               readline
               autoconf
               pkg-config
               openssl"
 
-# Install node, go, ninja, pyenv and dependencies.
+# Install Node, Go, Mono, Ninja, pyenv and dependencies.
 for pkg in $REQUIREMENTS; do
   # Install package, or upgrade it if it is already installed.
   brew install $pkg || brew outdated $pkg || brew upgrade $pkg

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -16,14 +16,15 @@ source ci/travis/travis_install.${TRAVIS_OS_NAME}.sh
 # pyenv setup
 #############
 
-export PYENV_ROOT="${HOME}/.pyenv"
+PYENV_ROOT="${HOME}/.pyenv"
 
 if [ ! -d "${PYENV_ROOT}/.git" ]; then
+  rm -rf ${PYENV_ROOT}
   git clone https://github.com/yyuu/pyenv.git ${PYENV_ROOT}
 fi
 pushd ${PYENV_ROOT}
 git fetch --tags
-git checkout v20160202
+git checkout v1.0.8
 popd
 
 export PATH="${PYENV_ROOT}/bin:${PATH}"


### PR DESCRIPTION
Even if [Ubuntu 14.04 (Trusty) on Travis is still in beta](https://docs.travis-ci.com/user/trusty-ci-environment/), we should migrate to this version since it's closer to the versions that we support (16.04 and later). We should also stop using C♯ as the language to run our builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/713)
<!-- Reviewable:end -->
