### PR TITLE
[READY] Fix shutdown tests flakiness on Travis

### DIFF
--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -131,7 +131,7 @@ class Client_test( object ):
     return response.json()
 
 
-  def _WaitUntilReady( self, filetype = None, timeout = 5 ):
+  def _WaitUntilReady( self, filetype = None, timeout = 10 ):
     expiration = time.time() + timeout
     while True:
       try:


### PR DESCRIPTION
OmniSharp server takes sometimes longer than 5 seconds to be ready on Travis so we increase the timeout to 10 seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/715)
<!-- Reviewable:end -->
