### PR TITLE
[READY] Rename JediCompleter to PythonCompleter

### DIFF
--- a/ycmd/completers/python/hook.py
+++ b/ycmd/completers/python/hook.py
@@ -23,8 +23,8 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *  # noqa
 
-from ycmd.completers.python.jedi_completer import JediCompleter
+from ycmd.completers.python.python_completer import PythonCompleter
 
 
 def GetCompleter( user_options ):
-  return JediCompleter( user_options )
+  return PythonCompleter( user_options )

--- a/ycmd/completers/python/python_completer.py
+++ b/ycmd/completers/python/python_completer.py
@@ -52,7 +52,7 @@ PATH_TO_JEDIHTTP = os.path.abspath(
                 'third_party', 'JediHTTP', 'jedihttp.py' ) )
 
 
-class JediCompleter( Completer ):
+class PythonCompleter( Completer ):
   """
   A Completer that uses the Jedi engine HTTP wrapper JediHTTP.
   https://jedi.readthedocs.org/en/latest/
@@ -60,7 +60,7 @@ class JediCompleter( Completer ):
   """
 
   def __init__( self, user_options ):
-    super( JediCompleter, self ).__init__( user_options )
+    super( PythonCompleter, self ).__init__( user_options )
     self._server_lock = threading.RLock()
     self._jedihttp_port = None
     self._jedihttp_phandle = None

--- a/ycmd/tests/python/user_defined_python_test.py
+++ b/ycmd/tests/python/user_defined_python_test.py
@@ -29,7 +29,7 @@ from mock import patch
 import sys
 
 from ycmd import utils
-from ycmd.completers.python.jedi_completer import BINARY_NOT_FOUND_MESSAGE
+from ycmd.completers.python.python_completer import BINARY_NOT_FOUND_MESSAGE
 from ycmd.tests.python import IsolatedYcmd
 from ycmd.tests.test_utils import BuildRequest, ErrorMatcher, UserOption
 


### PR DESCRIPTION
The completer name for Python should not be tied to Jedi. For instance, if we decide to replace Jedi with another semantic engine or if we add diagnostics support through flake8, `JediCompleter` would not be a suitable name anymore and we would have to change it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/716)
<!-- Reviewable:end -->
