### PR TITLE
Implement diagnostic information for TypeScript

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -487,8 +487,8 @@ class TypeScriptCompleter( Completer ):
         line_value,
         ts_diagnostic
       )
-      if ( distance < distance_to_closest_ts_diagnostic
-            or not closest_ts_diagnostic ):
+      if ( not closest_ts_diagnostic
+            or distance < distance_to_closest_ts_diagnostic ):
         distance_to_closest_ts_diagnostic = distance
         closest_ts_diagnostic = ts_diagnostic
 

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -31,6 +31,7 @@ import re
 import subprocess
 import itertools
 import threading
+from functools import partial
 
 from tempfile import NamedTemporaryFile
 
@@ -42,6 +43,7 @@ from ycmd.completers.completer_utils import GetFileContents
 BINARY_NOT_FOUND_MESSAGE = ( 'TSServer not found. '
                              'TypeScript 1.5 or higher is required.' )
 SERVER_NOT_RUNNING_MESSAGE = 'TSServer is not running.'
+NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 
 MAX_DETAILED_COMPLETIONS = 100
 RESPONSE_TIMEOUT_SECONDS = 10
@@ -88,6 +90,57 @@ def ShouldEnableTypescriptCompleter():
   _logger.info( 'Using TSServer located at {0}'.format( PATH_TO_TSSERVER ) )
 
   return True
+
+
+def TsDiagnosticToYcmdDiagnostic( filepath, line_value, ts_diagnostic ):
+  ts_start_location = ts_diagnostic[ 'startLocation' ]
+  ts_end_location = ts_diagnostic[ 'endLocation' ]
+
+  start_offset = utils.CodepointOffsetToByteOffset( line_value,
+                                              ts_start_location[ 'offset' ] )
+  end_offset = utils.CodepointOffsetToByteOffset( line_value,
+                                            ts_end_location[ 'offset' ] )
+
+  location = responses.Location( ts_start_location[ 'line' ],
+                                 start_offset,
+                                 filepath )
+  location_end = responses.Location( ts_end_location[ 'line' ],
+                                     end_offset,
+                                     filepath )
+
+  location_extent = responses.Range( location, location_end )
+
+  return responses.Diagnostic( [ location_extent ],
+                               location,
+                               location_extent,
+                               ts_diagnostic[ 'message' ],
+                               'ERROR' )
+
+
+def IsLineInTsDiagnosticRange( line, ts_diagnostic ):
+  ts_start_line = ts_diagnostic[ 'startLocation' ][ 'line' ]
+  ts_end_line = ts_diagnostic[ 'endLocation' ][ 'line' ]
+
+  return ts_start_line <= line and ts_end_line >= line
+
+
+def GetByteOffsetDistanceFromTsDiagnosticRange(
+      byte_offset,
+      line_value,
+      ts_diagnostic ):
+  ts_start_offset = ts_diagnostic[ 'startLocation' ][ 'offset' ]
+  ts_end_offset = ts_diagnostic[ 'endLocation' ][ 'offset' ]
+
+  codepoint_offset = utils.ByteOffsetToCodepointOffset( line_value,
+                                                        byte_offset )
+
+  start_difference = codepoint_offset - ts_start_offset
+  end_difference = codepoint_offset - (ts_end_offset - 1)
+
+  if (start_difference >= 0) and (end_difference <= 0):
+    return 0
+  else:
+    return min(abs(start_difference), abs(end_difference))
 
 
 class TypeScriptCompleter( Completer ):
@@ -380,6 +433,89 @@ class TypeScriptCompleter( Completer ):
 
   def OnFileReadyToParse( self, request_data ):
     self._Reload( request_data )
+
+    diagnostics = self.GetDiagnosticsForCurrentFile( request_data )
+    diagnostic_data = [ responses.BuildDiagnosticData( x )
+                        for x in diagnostics ]
+
+    return diagnostic_data
+
+
+  def GetTsDiagnosticsForCurrentFile( self, filename, request_data ):
+    # This returns the data the TypeScript server responded with.
+    # Note that its that "offset" values represent codepoint offsets,
+    # not byte offsets, which are required by the ycmd API.
+
+    ts_diagnostics = itertools.chain(
+      self._GetSemanticDiagnostics(filename),
+      self._GetSyntacticDiagnostics(filename)
+    )
+
+    return ts_diagnostics
+
+  def GetDiagnosticsForCurrentFile( self, request_data ):
+    filename = request_data[ 'filepath' ]
+    line_value = request_data[ 'line_value' ]
+
+    ts_diagnostics = self.GetTsDiagnosticsForCurrentFile( filename,
+                                                          request_data )
+
+    return [ TsDiagnosticToYcmdDiagnostic( filename, line_value, x )
+             for x in ts_diagnostics ]
+
+
+  def GetDetailedDiagnostic( self, request_data ):
+    filename = request_data[ 'filepath' ]
+    line_value = request_data[ 'line_value' ]
+    current_line = request_data[ 'line_num' ]
+    current_byte_offset = request_data[ 'column_num' ]
+
+    ts_diagnostics = self.GetTsDiagnosticsForCurrentFile( filename,
+                                                          request_data )
+    ts_diagnostics_on_line = list( filter(
+      partial( IsLineInTsDiagnosticRange, current_line ),
+      ts_diagnostics
+    ) )
+
+    if len(ts_diagnostics_on_line) is 0:
+      raise ValueError( NO_DIAGNOSTIC_MESSAGE )
+
+    closest_ts_diagnostic = None
+    distance_to_closest_ts_diagnostic = None
+
+    for ts_diagnostic in ts_diagnostics_on_line:
+      distance = GetByteOffsetDistanceFromTsDiagnosticRange(
+        current_byte_offset,
+        line_value,
+        ts_diagnostic
+      )
+      if ( distance < distance_to_closest_ts_diagnostic
+            or closest_ts_diagnostic is None ):
+        distance_to_closest_ts_diagnostic = distance
+        closest_ts_diagnostic = ts_diagnostic
+
+    closest_diagnostic = TsDiagnosticToYcmdDiagnostic(
+      filename,
+      line_value,
+      closest_ts_diagnostic
+    )
+
+    return responses.BuildDisplayMessageResponse(
+      closest_diagnostic.text_ )
+
+
+  def _GetSemanticDiagnostics( self, filename ):
+    return self._SendRequest( 'semanticDiagnosticsSync', {
+      'file': filename,
+      'includeLinePosition': True
+    } )
+
+
+  def _GetSyntacticDiagnostics( self, filename ):
+    return self._SendRequest( 'syntacticDiagnosticsSync', {
+      'file': filename,
+      'includeLinePosition': True
+    })
 
 
   def _GoToDefinition( self, request_data ):

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -139,8 +139,8 @@ def GetByteOffsetDistanceFromTsDiagnosticRange(
 
   if (start_difference >= 0) and (end_difference <= 0):
     return 0
-  else:
-    return min(abs(start_difference), abs(end_difference))
+
+  return min(abs(start_difference), abs(end_difference))
 
 
 class TypeScriptCompleter( Completer ):
@@ -435,20 +435,18 @@ class TypeScriptCompleter( Completer ):
     self._Reload( request_data )
 
     diagnostics = self.GetDiagnosticsForCurrentFile( request_data )
-    diagnostic_data = [ responses.BuildDiagnosticData( x )
+    return [ responses.BuildDiagnosticData( x )
                         for x in diagnostics ]
-
-    return diagnostic_data
 
 
   def GetTsDiagnosticsForCurrentFile( self, filename, request_data ):
     # This returns the data the TypeScript server responded with.
-    # Note that its that "offset" values represent codepoint offsets,
+    # Note that its "offset" values represent codepoint offsets,
     # not byte offsets, which are required by the ycmd API.
 
     ts_diagnostics = itertools.chain(
-      self._GetSemanticDiagnostics(filename),
-      self._GetSyntacticDiagnostics(filename)
+      self._GetSemanticDiagnostics( filename ),
+      self._GetSyntacticDiagnostics( filename )
     )
 
     return ts_diagnostics
@@ -477,7 +475,7 @@ class TypeScriptCompleter( Completer ):
       ts_diagnostics
     ) )
 
-    if len(ts_diagnostics_on_line) is 0:
+    if not ts_diagnostics_on_line:
       raise ValueError( NO_DIAGNOSTIC_MESSAGE )
 
     closest_ts_diagnostic = None
@@ -490,7 +488,7 @@ class TypeScriptCompleter( Completer ):
         ts_diagnostic
       )
       if ( distance < distance_to_closest_ts_diagnostic
-            or closest_ts_diagnostic is None ):
+            or not closest_ts_diagnostic ):
         distance_to_closest_ts_diagnostic = distance
         closest_ts_diagnostic = ts_diagnostic
 

--- a/ycmd/tests/typescript/diagnostics_test.py
+++ b/ycmd/tests/typescript/diagnostics_test.py
@@ -1,0 +1,108 @@
+
+#
+# Copyright (C) 2017 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
+from hamcrest import ( assert_that,
+                       contains_string,
+                       ends_with,
+                       equal_to,
+                       has_entry,
+                       has_entries )
+
+from ycmd.tests.typescript import PathToTestFile, SharedYcmd
+from ycmd.tests.test_utils import ( BuildRequest )
+from ycmd.utils import ReadFile
+
+
+@SharedYcmd
+def Diagnostics_FileReadyToParse_test( app ):
+  main_filepath = PathToTestFile( 'test.ts' )
+  main_contents = ReadFile( main_filepath )
+
+  event_data = BuildRequest( filepath = main_filepath,
+                             filetype = 'typescript',
+                             contents = main_contents,
+                             event_name = 'BufferVisit' )
+  app.post_json( '/event_notification', event_data )
+
+  event_data = BuildRequest( filepath = main_filepath,
+                             filetype = 'typescript',
+                             contents = main_contents,
+                             event_name = 'FileReadyToParse' )
+  results = app.post_json( '/event_notification', event_data ).json
+
+  expected_text = 'Property \'nonExistingMethod\' ' \
+                  'does not exist on type \'Bar\'.'
+
+  assert_that( results[1],
+               has_entries( {
+                 'kind': equal_to( 'ERROR' ),
+                 'text': equal_to( expected_text ),
+                 'location': has_entries( {
+                   'column_num': 1,
+                   'filepath': ends_with('testdata/test.ts'),
+                   'line_num': 35
+                 } ),
+                 'location_extent': has_entries( {
+                   'start': has_entries( {
+                     'column_num': 1,
+                     'filepath': ends_with('testdata/test.ts'),
+                     'line_num': 35
+                   } ),
+                   'end': has_entries( {
+                     'column_num': 1,
+                     'line_num': 35,
+                     'filepath': ends_with('testdata/test.ts')
+                   } ),
+                 } )
+               } ) )
+
+
+@SharedYcmd
+def Diagnostics_DetailedDiagnostics_test( app ):
+  main_filepath = PathToTestFile( 'test.ts' )
+  main_contents = ReadFile( main_filepath )
+
+  event_data = BuildRequest( filepath = main_filepath,
+                             filetype = 'typescript',
+                             contents = main_contents,
+                             event_name = 'BufferVisit' )
+  app.post_json( '/event_notification', event_data )
+
+  diag_data = BuildRequest( filepath = main_filepath,
+                            filetype = 'typescript',
+                            contents = main_contents,
+                            line_num = 35,
+                            column_num = 6 )
+
+  expected_message = 'Property \'nonExistingMethod\' ' \
+                     'does not exist on type \'Bar\'.'
+
+  results = app.post_json( '/detailed_diagnostic', diag_data ).json
+  assert_that( results,
+               has_entry(
+                   'message',
+                   contains_string( expected_message ) ) )

--- a/ycmd/tests/typescript/diagnostics_test.py
+++ b/ycmd/tests/typescript/diagnostics_test.py
@@ -63,19 +63,19 @@ def Diagnostics_FileReadyToParse_test( app ):
                  'text': equal_to( expected_text ),
                  'location': has_entries( {
                    'column_num': 1,
-                   'filepath': ends_with('testdata/test.ts'),
+                   'filepath': ends_with( 'test.ts' ),
                    'line_num': 35
                  } ),
                  'location_extent': has_entries( {
                    'start': has_entries( {
                      'column_num': 1,
-                     'filepath': ends_with('testdata/test.ts'),
+                     'filepath': ends_with( 'test.ts' ),
                      'line_num': 35
                    } ),
                    'end': has_entries( {
                      'column_num': 1,
                      'line_num': 35,
-                     'filepath': ends_with('testdata/test.ts')
+                     'filepath': ends_with( 'test.ts' )
                    } ),
                  } )
                } ) )
@@ -92,16 +92,17 @@ def Diagnostics_DetailedDiagnostics_test( app ):
                              event_name = 'BufferVisit' )
   app.post_json( '/event_notification', event_data )
 
-  diag_data = BuildRequest( filepath = main_filepath,
+  event_data = BuildRequest( filepath = main_filepath,
                             filetype = 'typescript',
                             contents = main_contents,
                             line_num = 35,
                             column_num = 6 )
 
+  results = app.post_json( '/detailed_diagnostic', event_data ).json
+
   expected_message = 'Property \'nonExistingMethod\' ' \
                      'does not exist on type \'Bar\'.'
 
-  results = app.post_json( '/detailed_diagnostic', diag_data ).json
   assert_that( results,
                has_entry(
                    'message',

--- a/ycmd/tests/typescript/diagnostics_test.py
+++ b/ycmd/tests/typescript/diagnostics_test.py
@@ -1,5 +1,3 @@
-
-#
 # Copyright (C) 2017 ycmd contributors
 #
 # This file is part of ycmd.
@@ -27,13 +25,12 @@ from builtins import *  # noqa
 
 from hamcrest import ( assert_that,
                        contains_string,
-                       ends_with,
                        equal_to,
                        has_entry,
                        has_entries )
 
 from ycmd.tests.typescript import PathToTestFile, SharedYcmd
-from ycmd.tests.test_utils import ( BuildRequest )
+from ycmd.tests.test_utils import BuildRequest
 from ycmd.utils import ReadFile
 
 
@@ -54,8 +51,8 @@ def Diagnostics_FileReadyToParse_test( app ):
                              event_name = 'FileReadyToParse' )
   results = app.post_json( '/event_notification', event_data ).json
 
-  expected_text = 'Property \'nonExistingMethod\' ' \
-                  'does not exist on type \'Bar\'.'
+  expected_text = ( 'Property \'nonExistingMethod\' '
+                    'does not exist on type \'Bar\'.' )
 
   assert_that( results[1],
                has_entries( {
@@ -63,19 +60,19 @@ def Diagnostics_FileReadyToParse_test( app ):
                  'text': equal_to( expected_text ),
                  'location': has_entries( {
                    'column_num': 1,
-                   'filepath': ends_with( 'test.ts' ),
+                   'filepath': main_filepath,
                    'line_num': 35
                  } ),
                  'location_extent': has_entries( {
                    'start': has_entries( {
                      'column_num': 1,
-                     'filepath': ends_with( 'test.ts' ),
+                     'filepath': main_filepath,
                      'line_num': 35
                    } ),
                    'end': has_entries( {
                      'column_num': 1,
                      'line_num': 35,
-                     'filepath': ends_with( 'test.ts' )
+                     'filepath': main_filepath
                    } ),
                  } )
                } ) )
@@ -93,15 +90,15 @@ def Diagnostics_DetailedDiagnostics_test( app ):
   app.post_json( '/event_notification', event_data )
 
   event_data = BuildRequest( filepath = main_filepath,
-                            filetype = 'typescript',
-                            contents = main_contents,
-                            line_num = 35,
-                            column_num = 6 )
+                             filetype = 'typescript',
+                             contents = main_contents,
+                             line_num = 35,
+                             column_num = 6 )
 
   results = app.post_json( '/detailed_diagnostic', event_data ).json
 
-  expected_message = 'Property \'nonExistingMethod\' ' \
-                     'does not exist on type \'Bar\'.'
+  expected_message = ( 'Property \'nonExistingMethod\' '
+                       'does not exist on type \'Bar\'.' )
 
   assert_that( results,
                has_entry(


### PR DESCRIPTION
YCMD already uses the TypeScript [tsserver](https://github.com/Microsoft/TypeScript/wiki/Standalone-Server-(tsserver)) for code completion. This change just implements diagnostic information (i.e. it shows compiler errors) similar to how it's implemented for C#.
![screen shot 2017-03-11 at 5 35 48 pm](https://cloud.githubusercontent.com/assets/2939386/23827421/4339ca84-0681-11e7-83d9-7db3023b318e.png)
Related: https://github.com/Valloric/YouCompleteMe/issues/2442

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/718)
<!-- Reviewable:end -->
