### PR TITLE
[READY] Remove Boost.Regex in favour of std variant

### DIFF
--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -124,10 +124,8 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
   std::smatch matches;
   const std::regex expression( TAG_REGEX );
 
-  for ( auto line : tags_file_contents )
-  {
-    if ( std::regex_search( line, matches, expression ) )
-    {
+  for ( auto line : tags_file_contents ) {
+    if ( std::regex_search( line, matches, expression ) ) {
       std::string language( matches[ 3 ] );
       std::string filetype = FindWithDefault( LANG_TO_FILETYPE,
                                               language.c_str(),
@@ -140,7 +138,8 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
       path = fs::absolute( path, path_to_tag_file.parent_path() )
               .make_preferred();
 
-      filetype_identifier_map[ filetype ][ path.string() ].push_back( identifier );
+      filetype_identifier_map[ filetype ][ path.string() ]
+              .push_back( identifier );
     }
   }
 

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -19,12 +19,11 @@
 #include "Utils.h"
 
 #include <unordered_map>
-#include <boost/regex.hpp>
-#include <boost/algorithm/string/regex.hpp>
+#include <regex>
 
 namespace YouCompleteMe {
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace {
 
@@ -37,9 +36,9 @@ const char *const TAG_REGEX =
   // The second field is the path to the file that has the identifier; either
   // absolute or relative to the tags file.
   "([^\\t\\n\\r]+)"
-  "\\t.*?"  // Non-greedy everything
+  "\\t[^\\n]*?"  // Non-greedy everything
   "language:([^\\t\\n\\r]+)"  // We want to capture the language of the file
-  ".*?$";
+  "[^\\n]*?$";
 
 // Only used as the equality comparer for the below unordered_map which stores
 // const char* pointers and not std::string but needs to hash based on string
@@ -125,11 +124,10 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
   std::string::const_iterator start = tags_file_contents.begin();
   std::string::const_iterator end   = tags_file_contents.end();
 
-  boost::smatch matches;
-  const boost::regex expression( TAG_REGEX );
-  const boost::match_flag_type options = boost::match_not_dot_newline;
+  std::smatch matches;
+  const std::regex expression( TAG_REGEX );
 
-  while ( boost::regex_search( start, end, matches, expression, options ) ) {
+  while ( std::regex_search( start, end, matches, expression, options ) ) {
     start = matches[ 0 ].second;
 
     std::string language( matches[ 3 ] );

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -31,14 +31,14 @@ namespace {
 // http://ctags.sourceforge.net/FORMAT
 // TL;DR: The only supported format is the one Exuberant Ctags emits.
 const char *const TAG_REGEX =
-  "^([^\\t\\n\\r]+)"  // The first field is the identifier
+  "^([^\\t]+)"  // The first field is the identifier
   "\\t"  // A TAB char is the field separator
   // The second field is the path to the file that has the identifier; either
   // absolute or relative to the tags file.
-  "([^\\t\\n\\r]+)"
-  "\\t[^\\n]*?"  // Non-greedy everything
-  "language:([^\\t\\n\\r]+)"  // We want to capture the language of the file
-  "[^\\n]*?$";
+  "([^\\t]+)"
+  "\\t.*"
+  "language:([^\\t]+)"  // We want to capture the language of the file
+  ".*$";
 
 // Only used as the equality comparer for the below unordered_map which stores
 // const char* pointers and not std::string but needs to hash based on string
@@ -112,34 +112,34 @@ const char *const NOT_FOUND = "YCMFOOBAR_NOT_FOUND";
 
 FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
   const fs::path &path_to_tag_file ) {
-  FiletypeIdentifierMap filetype_identifier_map;
   std::vector< std::string > tags_file_contents;
 
   try {
     tags_file_contents = ReadUtf8File( path_to_tag_file );
   } catch ( ... ) {
-    return filetype_identifier_map;
+    return {};
   }
 
+  FiletypeIdentifierMap filetype_identifier_map;
   std::smatch matches;
-  const std::regex expression( TAG_REGEX );
+  const std::regex expression( TAG_REGEX, std::regex::optimize );
 
-  for ( auto line : tags_file_contents ) {
+  for ( const auto& line : tags_file_contents ) {
     if ( std::regex_search( line, matches, expression ) ) {
-      std::string language( matches[ 3 ] );
-      std::string filetype = FindWithDefault( LANG_TO_FILETYPE,
+      const std::string language( matches[ 3 ] );
+      const std::string filetype = FindWithDefault( LANG_TO_FILETYPE,
                                               language.c_str(),
                                               NOT_FOUND );
       if ( filetype == NOT_FOUND )
         continue;
 
-      std::string identifier( matches[ 1 ] );
+      const std::string identifier( matches[ 1 ] );
       fs::path path( matches[ 2 ].str() );
       path = fs::absolute( path, path_to_tag_file.parent_path() )
               .make_preferred();
 
       filetype_identifier_map[ filetype ][ path.string() ]
-              .push_back( identifier );
+              .emplace_back( identifier );
     }
   }
 

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -128,8 +128,8 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
     if ( std::regex_search( line, matches, expression ) ) {
       const std::string language( matches[ 3 ] );
       const std::string filetype = FindWithDefault( LANG_TO_FILETYPE,
-                                              language.c_str(),
-                                              NOT_FOUND );
+                                                    language.c_str(),
+                                                    NOT_FOUND );
       if ( filetype == NOT_FOUND )
         continue;
 

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -139,7 +139,7 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
               .make_preferred();
 
       filetype_identifier_map[ filetype ][ path.string() ]
-              .emplace_back( identifier );
+              .emplace_back( std::move( identifier ) );
     }
   }
 

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -36,9 +36,8 @@ std::vector< std::string > ReadUtf8File( const fs::path &filepath ) {
   fs::ifstream file( filepath, std::ios::in | std::ios::binary );
   std::string line;
   std::vector< std::string > contents;
-  while( getline( file, line ) )
-  {
-	  contents.push_back(line);
+  while( getline( file, line ) ) {
+    contents.push_back(line);
   }
 
   if ( contents.size() == 0 )

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -37,7 +37,7 @@ std::vector< std::string > ReadUtf8File( const fs::path &filepath ) {
   std::string line;
   std::vector< std::string > contents;
   while( getline( file, line ) ) {
-    contents.push_back(line);
+    contents.push_back( line );
   }
 
   if ( contents.size() == 0 )

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -43,7 +43,7 @@ std::vector< std::string > ReadUtf8File( const fs::path &filepath ) {
     fs::ifstream file( filepath, std::ios::in | std::ios::binary );
     std::string line;
     while( getline( file, line ) ) {
-      contents.push_back( line );
+      contents.emplace_back( std::move( line ) );
     }
   }
   return contents;

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -43,7 +43,7 @@ std::vector< std::string > ReadUtf8File( const fs::path &filepath ) {
     fs::ifstream file( filepath, std::ios::in | std::ios::binary );
     std::string line;
     while( getline( file, line ) ) {
-      contents.emplace_back( std::move( line ) );
+      contents.emplace_back( line );
     }
   }
   return contents;

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -32,19 +32,19 @@ bool AlmostEqual( double a, double b ) {
 }
 
 
-std::string ReadUtf8File( const fs::path &filepath ) {
-  // fs::is_empty() can throw basic_filesystem_error< Path >
-  // in case filepath doesn't exist, or
-  // in case filepath's file_status is "other".
-  // "other" in this case means everything that is not a regular file,
-  // directory or a symlink.
-  if ( !fs::is_empty( filepath ) && fs::is_regular_file( filepath ) ) {
-    fs::ifstream file( filepath, std::ios::in | std::ios::binary );
-    std::vector< char > contents( ( std::istreambuf_iterator< char >( file ) ),
-                                  std::istreambuf_iterator< char >() );
-    return std::string( contents.begin(), contents.end() );
+std::vector< std::string > ReadUtf8File( const fs::path &filepath ) {
+  fs::ifstream file( filepath, std::ios::in | std::ios::binary );
+  std::string line;
+  std::vector< std::string > contents;
+  while( getline( file, line ) )
+  {
+	  contents.push_back(line);
   }
-  return std::string();
+
+  if ( contents.size() == 0 )
+    return std::vector< std::string >();
+
+  return contents;
 }
 
 

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -33,16 +33,19 @@ bool AlmostEqual( double a, double b ) {
 
 
 std::vector< std::string > ReadUtf8File( const fs::path &filepath ) {
-  fs::ifstream file( filepath, std::ios::in | std::ios::binary );
-  std::string line;
   std::vector< std::string > contents;
-  while( getline( file, line ) ) {
-    contents.push_back( line );
+  // fs::is_empty() can throw basic_filesystem_error< Path >
+  // in case filepath doesn't exist, or
+  // in case filepath's file_status is "other".
+  // "other" in this case means everything that is not a regular file,
+  // directory or a symlink.
+  if ( !fs::is_empty( filepath ) && fs::is_regular_file( filepath ) ) {
+    fs::ifstream file( filepath, std::ios::in | std::ios::binary );
+    std::string line;
+    while( getline( file, line ) ) {
+      contents.push_back( line );
+    }
   }
-
-  if ( contents.size() == 0 )
-    return std::vector< std::string >();
-
   return contents;
 }
 

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -32,7 +32,7 @@ bool AlmostEqual( double a, double b );
 
 // Reads the entire contents of the specified file. If the file does not exist,
 // an exception is thrown.
-std::string ReadUtf8File( const fs::path &filepath );
+std::vector< std::string > ReadUtf8File( const fs::path &filepath );
 
 // Writes the entire contents of the specified file. If the file does not exist,
 // an exception is thrown.


### PR DESCRIPTION
The final piece in boost to std transition. Continuation of #705.

To make this work on linux with gcc `ReadUtf8File()` had to be changed to return a string vector. Otherwise no matches were ever found. Seems like a gcc bug.

That being said tests on linux are stll failing. On OSX on the other hand tests are all passing. The tests that are failing are:

- IdentifierCompleterTest.TagsEndToEndWorks
- IdentifierUtilsTest.ExtractIdentifiersFromTagsFileWorks

Even though the tests are failing on linux, reading the `basic.tags` file results in the expected behaviour (i.e. tags are provided for completion).

Note:
This leaves only boost::filesystem and boost::python. So `update_boost.py` should be updated, as well as some parts of `CMakeLists.txt` that mention boost threads that are no longer in use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/719)
<!-- Reviewable:end -->
