### PR TITLE
[READY] Do not install aliases from future

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,7 @@ Here's what you should watch out for:
     from __future__ import unicode_literals
     from __future__ import print_function
     from __future__ import division
-    from future import standard_library
-    standard_library.install_aliases()
+    # Not installing aliases from python-future; it's unreliable and slow.
     from builtins import *  # noqa
     ```
 
@@ -147,6 +146,12 @@ Here's what you should watch out for:
 - If you run tests and get failures on importing ycm_core that mention
   `initycm_core` or `PyInit_ycm_core`, you've built the C++ parts of ycmd for
   py2 and are trying to run tests in py3 (or vice-versa). Rebuild!
+- Use the `urllib` module from `python-future`:
+
+    ```python
+    from future.moves.urllib.parse import urljoin, urlparse
+    ```
+
 
 [build-bots]: https://travis-ci.org/Valloric/ycmd
 [ycmd-users]: https://groups.google.com/forum/?hl=en#!forum/ycmd-users

--- a/run_tests.py
+++ b/run_tests.py
@@ -4,8 +4,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import platform

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,7 +4,8 @@ flake8       >= 3.0.0; python_version == '2.7' or python_version >  '3.3'
 mock         >= 1.3.0
 nose         >= 1.3.7
 PyHamcrest   >= 1.8.5
-WebTest      >= 2.0.20
+# WebTest 2.0.24 dropped support of Python 2.6
+WebTest      >= 2.0.20, < 2.0.24
 ordereddict  >= 1.1
 nose-exclude >= 0.4.1
 unittest2    >= 1.1.0

--- a/ycmd/__main__.py
+++ b/ycmd/__main__.py
@@ -28,8 +28,7 @@ sys.path.insert( 0, os.path.dirname( os.path.abspath( __file__ ) ) )
 from server_utils import SetUpPythonPath, CompatibleWithCurrentCore
 SetUpPythonPath()
 
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import atexit

--- a/ycmd/bottle_utils.py
+++ b/ycmd/bottle_utils.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from future.utils import PY2

--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import os

--- a/ycmd/completers/c/hook.py
+++ b/ycmd/completers/c/hook.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import ycm_core

--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import abc

--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -19,10 +19,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future.utils import iteritems
 
 # Must not import ycm_core here! Vim imports completer, which imports this file.
 # We don't want ycm_core inside Vim.
@@ -30,6 +28,7 @@ import os
 import re
 import copy
 from collections import defaultdict
+from future.utils import iteritems
 from ycmd.utils import ToCppStringCompatible, ToUnicode, ReadFile
 
 

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -20,16 +20,17 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future.utils import iteritems
 
 from collections import defaultdict
-import ycm_core
-import re
+from future.utils import iteritems
 import os.path
+import re
 import textwrap
+import xml.etree.ElementTree
+
+import ycm_core
 from ycmd import responses
 from ycmd.utils import ToCppStringCompatible, ToUnicode
 from ycmd.completers.completer import Completer
@@ -38,8 +39,6 @@ from ycmd.completers.cpp.flags import ( Flags, PrepareFlagsForClang,
                                         NoCompilationDatabase )
 from ycmd.completers.cpp.ephemeral_values_set import EphemeralValuesSet
 from ycmd.responses import NoExtraConfDetected, UnknownExtraConf
-
-import xml.etree.ElementTree
 
 CLANG_FILETYPES = set( [ 'c', 'cpp', 'objc', 'objcpp' ] )
 PARSING_FILE_MESSAGE = 'Still parsing file, no completions yet.'

--- a/ycmd/completers/cpp/clang_helpers.py
+++ b/ycmd/completers/cpp/clang_helpers.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 

--- a/ycmd/completers/cpp/ephemeral_values_set.py
+++ b/ycmd/completers/cpp/ephemeral_values_set.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import threading

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import ycm_core

--- a/ycmd/completers/cpp/hook.py
+++ b/ycmd/completers/cpp/hook.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import ycm_core

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -21,24 +21,24 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future import standard_library
-standard_library.install_aliases()
-from future.utils import itervalues
 
 from collections import defaultdict
+from future.utils import itervalues
+from future.moves.urllib.parse import urljoin
+import logging
 import os
 import re
+import requests
+import threading
+
 from ycmd.completers.completer import Completer
+from ycmd.completers.completer_utils import GetFileContents
+from ycmd.completers.cs import solutiondetection
 from ycmd.utils import ForceSemanticCompletion, CodepointOffsetToByteOffset
 from ycmd import responses
 from ycmd import utils
-from ycmd.completers.completer_utils import GetFileContents
-import requests
-import urllib.parse
-import logging
-from . import solutiondetection
-import threading
 
 SERVER_NOT_FOUND_MSG = ( 'OmniSharp server binary not found at {0}. ' +
                          'Did you compile it? You can do so by running ' +
@@ -584,7 +584,7 @@ class CsharpSolutionCompleter( object ):
 
   def _GetResponse( self, handler, parameters = {}, timeout = None ):
     """ Handle communication with server """
-    target = urllib.parse.urljoin( self._ServerLocation(), handler )
+    target = urljoin( self._ServerLocation(), handler )
     response = requests.post( target, data = parameters, timeout = timeout )
     return response.json()
 

--- a/ycmd/completers/cs/hook.py
+++ b/ycmd/completers/cs/hook.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.completers.cs.cs_completer import CsharpCompleter

--- a/ycmd/completers/cs/solutiondetection.py
+++ b/ycmd/completers/cs/solutiondetection.py
@@ -20,8 +20,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import os

--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -20,8 +20,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import os

--- a/ycmd/completers/general/general_completer_store.py
+++ b/ycmd/completers/general/general_completer_store.py
@@ -20,8 +20,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.completers.completer import Completer

--- a/ycmd/completers/general/ultisnips_completer.py
+++ b/ycmd/completers/general/ultisnips_completer.py
@@ -20,8 +20,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.completers.general_completer import GeneralCompleter

--- a/ycmd/completers/general_completer.py
+++ b/ycmd/completers/general_completer.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.completers.completer import Completer

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -20,8 +20,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import json

--- a/ycmd/completers/go/hook.py
+++ b/ycmd/completers/go/hook.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.completers.go.go_completer import GoCompleter, ShouldEnableGoCompleter

--- a/ycmd/completers/javascript/hook.py
+++ b/ycmd/completers/javascript/hook.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.completers.javascript.tern_completer import (

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -19,11 +19,10 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future.utils import iterkeys
-from future import standard_library
-standard_library.install_aliases()
 
+from future.utils import iterkeys
 import logging
 import os
 import requests

--- a/ycmd/completers/objc/hook.py
+++ b/ycmd/completers/objc/hook.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import ycm_core

--- a/ycmd/completers/objcpp/hook.py
+++ b/ycmd/completers/objcpp/hook.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import ycm_core

--- a/ycmd/completers/python/hook.py
+++ b/ycmd/completers/python/hook.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.completers.python.jedi_completer import JediCompleter

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -22,10 +22,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future import standard_library
-from future.utils import native
-standard_library.install_aliases()
 
 from ycmd.utils import ToBytes, ToUnicode, ProcessIsRunning
 from ycmd.completers.completer import Completer
@@ -33,9 +31,10 @@ from ycmd import responses, utils, hmac_utils
 from tempfile import NamedTemporaryFile
 
 from base64 import b64encode
+from future.utils import native
+from future.moves.urllib.parse import urljoin
 import json
 import logging
-import urllib.parse
 import requests
 import threading
 import sys
@@ -199,7 +198,7 @@ class JediCompleter( Completer ):
   def _GetResponse( self, handler, request_data = {} ):
     """POST JSON data to JediHTTP server and return JSON response."""
     handler = ToBytes( handler )
-    url = urllib.parse.urljoin( self._jedihttp_host, handler )
+    url = urljoin( self._jedihttp_host, handler )
     parameters = self._TranslateRequestForJediHTTP( request_data )
     body = ToBytes( json.dumps( parameters ) ) if parameters else bytes()
     extra_headers = self._ExtraHeaders( handler, body )

--- a/ycmd/completers/rust/hook.py
+++ b/ycmd/completers/rust/hook.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.completers.rust.rust_completer import RustCompleter

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -19,17 +19,16 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future.utils import native, iteritems
-from future import standard_library
-standard_library.install_aliases()
 
 from ycmd.utils import ToBytes, SetEnviron, ProcessIsRunning
 from ycmd.completers.completer import Completer
 from ycmd import responses, utils, hmac_utils
 
+from future.moves.urllib.parse import urljoin
+from future.utils import iteritems, native
 import logging
-import urllib.parse
 import requests
 import json
 import tempfile
@@ -160,7 +159,7 @@ class RustCompleter( Completer ):
     _logger.info( 'RustCompleter._GetResponse' )
     handler = ToBytes( handler )
     method = ToBytes( method )
-    url = urllib.parse.urljoin( ToBytes( self._racerd_host ), handler )
+    url = urljoin( ToBytes( self._racerd_host ), handler )
     parameters = self._ConvertToRacerdRequest( request_data )
     body = ToBytes( json.dumps( parameters ) ) if parameters else bytes()
     extra_headers = self._ExtraHeaders( method, handler, body )

--- a/ycmd/completers/typescript/hook.py
+++ b/ycmd/completers/typescript/hook.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.completers.typescript.typescript_completer import (

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -20,8 +20,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import json

--- a/ycmd/extra_conf_store.py
+++ b/ycmd/extra_conf_store.py
@@ -22,8 +22,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import os

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -20,8 +20,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import bottle

--- a/ycmd/hmac_plugin.py
+++ b/ycmd/hmac_plugin.py
@@ -19,15 +19,14 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import logging
 import requests
-from urllib.parse import urlparse
 from base64 import b64decode, b64encode
 from bottle import request, abort
+from future.moves.urllib.parse import urlparse
 from ycmd import hmac_utils
 from ycmd.utils import ToBytes
 from ycmd.bottle_utils import SetResponseHeader

--- a/ycmd/hmac_utils.py
+++ b/ycmd/hmac_utils.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from builtins import bytes

--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -21,8 +21,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import re

--- a/ycmd/request_validation.py
+++ b/ycmd/request_validation.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.responses import ServerError

--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -21,8 +21,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.utils import ( ByteOffsetToCodepointOffset,

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -20,8 +20,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import os

--- a/ycmd/server_state.py
+++ b/ycmd/server_state.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import os

--- a/ycmd/tests/__init__.py
+++ b/ycmd/tests/__init__.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import functools

--- a/ycmd/tests/bottle_utils_test.py
+++ b/ycmd/tests/bottle_utils_test.py
@@ -19,8 +19,7 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from nose.tools import eq_

--- a/ycmd/tests/clang/__init__.py
+++ b/ycmd/tests/clang/__init__.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import functools

--- a/ycmd/tests/clang/comment_strip_test.py
+++ b/ycmd/tests/clang/comment_strip_test.py
@@ -25,8 +25,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from nose.tools import eq_

--- a/ycmd/tests/clang/debug_info_test.py
+++ b/ycmd/tests/clang/debug_info_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import os

--- a/ycmd/tests/clang/diagnostics_test.py
+++ b/ycmd/tests/clang/diagnostics_test.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( assert_that, contains, contains_string, has_entries,

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import os

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -21,8 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import json

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -21,8 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( assert_that, calling, contains, contains_string,

--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -19,12 +19,12 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future.utils import native
 
 from base64 import b64decode, b64encode
+from future.moves.urllib.parse import urljoin, urlparse
+from future.utils import native
 from hamcrest import assert_that, empty, equal_to, is_in
 from tempfile import NamedTemporaryFile
 import functools
@@ -35,7 +35,6 @@ import requests
 import subprocess
 import sys
 import time
-import urllib.parse
 
 from ycmd.hmac_utils import CreateHmac, CreateRequestHmac, SecureBytesEqual
 from ycmd.tests import PathToTestFile
@@ -222,7 +221,7 @@ class Client_test( object ):
 
 
   def _BuildUri( self, handler ):
-    return native( ToBytes( urllib.parse.urljoin( self._location, handler ) ) )
+    return native( ToBytes( urljoin( self._location, handler ) ) )
 
 
   def _ExtraHeaders( self, method, request_uri, request_body = None ):
@@ -231,7 +230,7 @@ class Client_test( object ):
     headers = dict( HEADERS )
     headers[ HMAC_HEADER ] = b64encode(
         CreateRequestHmac( ToBytes( method ),
-                           ToBytes( urllib.parse.urlparse( request_uri ).path ),
+                           ToBytes( urlparse( request_uri ).path ),
                            request_body,
                            self._hmac_secret ) )
     return headers

--- a/ycmd/tests/completer_test.py
+++ b/ycmd/tests/completer_test.py
@@ -20,8 +20,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from ycmd.tests.test_utils import DummyCompleter, ExpectedFailure

--- a/ycmd/tests/completer_utils_test.py
+++ b/ycmd/tests/completer_utils_test.py
@@ -21,14 +21,14 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future.utils import iteritems
 
 import re
 from collections import defaultdict
+from future.utils import iteritems
 from nose.tools import eq_, ok_
+
 from ycmd.completers import completer_utils as cu
 
 

--- a/ycmd/tests/cs/__init__.py
+++ b/ycmd/tests/cs/__init__.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from contextlib import contextmanager

--- a/ycmd/tests/cs/debug_info_test.py
+++ b/ycmd/tests/cs/debug_info_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( assert_that, contains, empty, has_entries, has_entry,

--- a/ycmd/tests/cs/diagnostics_test.py
+++ b/ycmd/tests/cs/diagnostics_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( assert_that, contains, contains_string, equal_to,

--- a/ycmd/tests/cs/get_completions_test.py
+++ b/ycmd/tests/cs/get_completions_test.py
@@ -21,8 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( assert_that, calling, empty, greater_than, has_item,

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 

--- a/ycmd/tests/diagnostics_test.py
+++ b/ycmd/tests/diagnostics_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that

--- a/ycmd/tests/extra_conf_store_test.py
+++ b/ycmd/tests/extra_conf_store_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import inspect

--- a/ycmd/tests/filename_completer_test.py
+++ b/ycmd/tests/filename_completer_test.py
@@ -21,8 +21,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import os

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -22,8 +22,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( assert_that, equal_to, has_items,

--- a/ycmd/tests/go/__init__.py
+++ b/ycmd/tests/go/__init__.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import functools

--- a/ycmd/tests/go/debug_info_test.py
+++ b/ycmd/tests/go/debug_info_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that, contains, has_entries, has_entry, instance_of

--- a/ycmd/tests/go/get_completions_test.py
+++ b/ycmd/tests/go/get_completions_test.py
@@ -21,8 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that, has_item, has_items

--- a/ycmd/tests/go/go_completer_test.py
+++ b/ycmd/tests/go/go_completer_test.py
@@ -22,8 +22,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that, calling, raises

--- a/ycmd/tests/go/subcommands_test.py
+++ b/ycmd/tests/go/subcommands_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that, has_entries

--- a/ycmd/tests/hmac_utils_test.py
+++ b/ycmd/tests/hmac_utils_test.py
@@ -19,8 +19,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from binascii import hexlify

--- a/ycmd/tests/identifier_completer_test.py
+++ b/ycmd/tests/identifier_completer_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import os

--- a/ycmd/tests/identifier_utils_test.py
+++ b/ycmd/tests/identifier_utils_test.py
@@ -21,8 +21,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from nose.tools import eq_, ok_

--- a/ycmd/tests/javascript/__init__.py
+++ b/ycmd/tests/javascript/__init__.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import functools

--- a/ycmd/tests/javascript/debug_info_test.py
+++ b/ycmd/tests/javascript/debug_info_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( assert_that, contains, empty, has_entries, has_entry,

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -19,8 +19,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that, empty

--- a/ycmd/tests/javascript/get_completions_test.py
+++ b/ycmd/tests/javascript/get_completions_test.py
@@ -19,8 +19,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( assert_that, contains, contains_inanyorder, empty,

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -20,8 +20,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that, contains, contains_inanyorder, has_entries

--- a/ycmd/tests/misc_handlers_test.py
+++ b/ycmd/tests/misc_handlers_test.py
@@ -20,8 +20,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( any_of, assert_that, contains, empty, equal_to,

--- a/ycmd/tests/python/__init__.py
+++ b/ycmd/tests/python/__init__.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import functools

--- a/ycmd/tests/python/debug_info_test.py
+++ b/ycmd/tests/python/debug_info_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that, contains, has_entry, has_entries, instance_of

--- a/ycmd/tests/python/get_completions_test.py
+++ b/ycmd/tests/python/get_completions_test.py
@@ -21,8 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from nose.tools import eq_

--- a/ycmd/tests/python/subcommands_test.py
+++ b/ycmd/tests/python/subcommands_test.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that

--- a/ycmd/tests/python/user_defined_python_test.py
+++ b/ycmd/tests/python/user_defined_python_test.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest.core.base_matcher import BaseMatcher

--- a/ycmd/tests/python_support_test.py
+++ b/ycmd/tests/python_support_test.py
@@ -19,8 +19,7 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 # Intentionally not importing all builtins!
 
 import os

--- a/ycmd/tests/request_validation_test.py
+++ b/ycmd/tests/request_validation_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import raises, assert_that, calling

--- a/ycmd/tests/request_wrap_test.py
+++ b/ycmd/tests/request_wrap_test.py
@@ -21,14 +21,13 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from ycmd.utils import ToBytes
-
 from nose.tools import eq_
-from ..request_wrap import RequestWrap
+
+from ycmd.utils import ToBytes
+from ycmd.request_wrap import RequestWrap
 
 
 def PrepareJson( contents = '', line_num = 1, column_num = 1, filetype = '' ):

--- a/ycmd/tests/rust/__init__.py
+++ b/ycmd/tests/rust/__init__.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import functools

--- a/ycmd/tests/rust/debug_info_test.py
+++ b/ycmd/tests/rust/debug_info_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that, contains, has_entries, has_entry, instance_of

--- a/ycmd/tests/rust/get_completions_test.py
+++ b/ycmd/tests/rust/get_completions_test.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that, empty, has_entry, has_items

--- a/ycmd/tests/rust/subcommands_test.py
+++ b/ycmd/tests/rust/subcommands_test.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from nose.tools import eq_

--- a/ycmd/tests/server_utils_test.py
+++ b/ycmd/tests/server_utils_test.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( assert_that, calling, contains, contains_inanyorder,

--- a/ycmd/tests/shutdown_test.py
+++ b/ycmd/tests/shutdown_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that, equal_to

--- a/ycmd/tests/subcommands_test.py
+++ b/ycmd/tests/subcommands_test.py
@@ -20,8 +20,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from mock import patch

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -21,12 +21,10 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-from future.utils import iteritems
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from future.utils import PY2
+from future.utils import iteritems, PY2
 from hamcrest import contains_string, has_entry, has_entries, assert_that
 from mock import patch
 from webtest import TestApp

--- a/ycmd/tests/typescript/__init__.py
+++ b/ycmd/tests/typescript/__init__.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import functools

--- a/ycmd/tests/typescript/debug_info_test.py
+++ b/ycmd/tests/typescript/debug_info_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( assert_that, contains, empty, has_entries, has_entry,

--- a/ycmd/tests/typescript/event_notification_test.py
+++ b/ycmd/tests/typescript/event_notification_test.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import assert_that, contains, has_entries

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from hamcrest import ( all_of, any_of, assert_that, calling,

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -21,8 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import pprint

--- a/ycmd/tests/typescript/typescript_completer_test.py
+++ b/ycmd/tests/typescript/typescript_completer_test.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from mock import patch, DEFAULT

--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -21,8 +21,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import os

--- a/ycmd/user_options_store.py
+++ b/ycmd/user_options_store.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import json

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -21,8 +21,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 from future.utils import PY2, native
 

--- a/ycmd/watchdog_plugin.py
+++ b/ycmd/watchdog_plugin.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 import time

--- a/ycmd/wsgi_server.py
+++ b/ycmd/wsgi_server.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 from future.utils import listvalues


### PR DESCRIPTION
When calling `standard_library.install_aliases`, `python-future` imports [the `test` module](https://docs.python.org/2/library/test.html) on Python 2 to monkey-patch it. This can fail if the current directory has a file named `test.py` and is part of the `PYTHONPATH` environment variable. In that case, `python-future` will attempt to load the `test.py` file and fail if it contains an error. Here's a simple way to reproduce the issue:
```
$ echo "raise RuntimeError()" > test.py
$ export PYTHONPATH=.
$ python2 /path/to/ycmd/folder/ycmd
Traceback (most recent call last):
  File "C:\Python27\lib\runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "C:\Python27\lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "C:\Users\micbou\.vim\bundle\YouCompleteMe\third_party\ycmd\ycmd\__main__.py", line 32, in <module>
    standard_library.install_aliases()
  File "C:\Users\micbou\.vim\bundle\YouCompleteMe\third_party\ycmd\third_party\python-future\src\future\standard_library\__init__.py", line 483, in install_aliases
    import test
  File "C:\Users\micbou\tests\ycm-issue-2568\test.py", line 1, in <module>
    raise RuntimeError()
RuntimeError
```
One could argue that people should avoid naming Python files the same as modules from the standard library. I would agree for something like `os.py` but `test.py` is a really common name. In fact, this issue has already been reported multiple times: https://github.com/Valloric/YouCompleteMe/issues/2332, https://github.com/Valloric/YouCompleteMe/issues/2467 and https://github.com/Valloric/YouCompleteMe/issues/2568. So, we should do something about it. Since we only need the aliases for the `urllib` module (in particular, the `urljoin` and `urlparse` functions), the solution is to remove the lines:
```python
from future import standard_library
standard_library.install_aliases()
```
from the top of each file and import `urljoin` and `urlparse` where we need them with:
```python
from future.moves.urllib.parse import urljoin, urlparse
```

Another benefit of this change is that it improves ycmd startup time on Python 2 (about 20%):

<table>
  <tr>
    <th rowspan="2">Platform</th>
    <th colspan="2">First run (ms)</th>
    <th colspan="2">Subsequent runs (ms)</th>
  </tr>
  <tr>
    <td>Before</td>
    <td>After</td>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>    
    <td>Ubuntu 16.04 64-bit</td>
    <td>229</td>
    <td>178</td>
    <td>202</td>
    <td>156</td>
  </tr>
  <tr>
    <td>macOS 10.12</td>
    <td>257</td>
    <td>204</td>
    <td>222</td>
    <td>173</td>
  </tr>
  <tr> 
    <td>Windows 10 64-bit</td>
    <td>406</td>
    <td>315</td>
    <td>298</td>
    <td>245</td>
  </tr>  
</table>

These results were obtained by running [this script](https://github.com/micbou/ycmd/blob/profiling-startup/startup.py) on each platform. They represent the time it takes for the server to be ready.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/722)
<!-- Reviewable:end -->
