### PR TITLE
[READY] Do not import urljoin and urlparse from python-future

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,10 +146,10 @@ Here's what you should watch out for:
 - If you run tests and get failures on importing ycm_core that mention
   `initycm_core` or `PyInit_ycm_core`, you've built the C++ parts of ycmd for
   py2 and are trying to run tests in py3 (or vice-versa). Rebuild!
-- Use the `urllib` module from `python-future`:
+- Import the `urljoin` and `urlparse` functions from `ycmd/utils.py`:
 
     ```python
-    from future.moves.urllib.parse import urljoin, urlparse
+    from ycmd.utils import urljoin, urlparse
     ```
 
 

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -26,7 +26,6 @@ from builtins import *  # noqa
 
 from collections import defaultdict
 from future.utils import itervalues
-from future.moves.urllib.parse import urljoin
 import logging
 import os
 import re
@@ -36,7 +35,8 @@ import threading
 from ycmd.completers.completer import Completer
 from ycmd.completers.completer_utils import GetFileContents
 from ycmd.completers.cs import solutiondetection
-from ycmd.utils import ForceSemanticCompletion, CodepointOffsetToByteOffset
+from ycmd.utils import ( ForceSemanticCompletion, CodepointOffsetToByteOffset,
+                         urljoin )
 from ycmd import responses
 from ycmd import utils
 

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -25,14 +25,13 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from ycmd.utils import ToBytes, ToUnicode, ProcessIsRunning
+from ycmd.utils import ToBytes, ToUnicode, ProcessIsRunning, urljoin
 from ycmd.completers.completer import Completer
 from ycmd import responses, utils, hmac_utils
 from tempfile import NamedTemporaryFile
 
 from base64 import b64encode
 from future.utils import native
-from future.moves.urllib.parse import urljoin
 import json
 import logging
 import requests

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -22,11 +22,10 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from ycmd.utils import ToBytes, SetEnviron, ProcessIsRunning
+from ycmd.utils import ToBytes, SetEnviron, ProcessIsRunning, urljoin
 from ycmd.completers.completer import Completer
 from ycmd import responses, utils, hmac_utils
 
-from future.moves.urllib.parse import urljoin
 from future.utils import iteritems, native
 import logging
 import requests

--- a/ycmd/hmac_plugin.py
+++ b/ycmd/hmac_plugin.py
@@ -26,9 +26,8 @@ import logging
 import requests
 from base64 import b64decode, b64encode
 from bottle import request, abort
-from future.moves.urllib.parse import urlparse
 from ycmd import hmac_utils
-from ycmd.utils import ToBytes
+from ycmd.utils import ToBytes, urlparse
 from ycmd.bottle_utils import SetResponseHeader
 
 _HMAC_HEADER = 'x-ycm-hmac'

--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -23,7 +23,6 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 from base64 import b64decode, b64encode
-from future.moves.urllib.parse import urljoin, urlparse
 from future.utils import native
 from hamcrest import assert_that, empty, equal_to, is_in
 from tempfile import NamedTemporaryFile
@@ -42,7 +41,8 @@ from ycmd.tests.test_utils import BuildRequest
 from ycmd.user_options_store import DefaultOptions
 from ycmd.utils import ( CloseStandardStreams, CreateLogfile,
                          GetUnusedLocalhostPort, ReadFile, RemoveIfExists,
-                         SafePopen, SetEnviron, ToBytes, ToUnicode )
+                         SafePopen, SetEnviron, ToBytes, ToUnicode, urljoin,
+                         urlparse )
 
 HEADERS = { 'content-type': 'application/json' }
 HMAC_HEADER = 'x-ycm-hmac'

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -23,14 +23,25 @@ from __future__ import division
 from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future.utils import PY2, native
 
+from future.utils import PY2, native
 import os
 import socket
 import subprocess
 import sys
 import tempfile
 import time
+
+
+# Idiom to import urljoin and urlparse on Python 2 and 3. By exposing these
+# functions here, we can import them directly from this module:
+#
+#   from ycmd.utils import urljoin, urlparse
+#
+if PY2:
+  from urlparse import urljoin, urlparse
+else:
+  from urllib.parse import urljoin, urlparse  # noqa
 
 
 # Creation flag to disable creating a console window on Windows. See


### PR DESCRIPTION
PR #722 was supposed to fix the issue where python-future imports any `test.py` file from the Python path. Unfortunately, it now happens on Python 3 instead of Python 2. See https://github.com/Valloric/YouCompleteMe/issues/2577 and https://github.com/PythonCharmers/python-future/issues/268 for an explanation. To avoid that, we reproduce the `urllib` compatibility fix from python-future in `ycmd/utils.py` but only for `urljoin` and `urlparse` since we don't need the other functions. We then import `urljoin` and `urlparse` from `ycmd.utils` instead of `future.moves.urllib.parse`.

Once this is merged, we'll do the same in YCM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/724)
<!-- Reviewable:end -->
