### PR TITLE
[READY] Tag file reading sanity checks

### DIFF
--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -33,14 +33,18 @@ bool AlmostEqual( double a, double b ) {
 
 
 std::string ReadUtf8File( const fs::path &filepath ) {
-  fs::ifstream file( filepath, std::ios::in | std::ios::binary );
-  std::vector< char > contents( ( std::istreambuf_iterator< char >( file ) ),
-                                std::istreambuf_iterator< char >() );
-
-  if ( contents.size() == 0 )
-    return std::string();
-
-  return std::string( contents.begin(), contents.end() );
+  // fs::is_empty() can throw basic_filesystem_error< Path >
+  // in case filepath doesn't exist, or
+  // in case filepath's file_status is "other".
+  // "other" in this case means everything that is not a regular file,
+  // directory or a smylink.
+  if ( !fs::is_empty( filepath ) && fs::is_regular_file( filepath ) ) {
+    fs::ifstream file( filepath, std::ios::in | std::ios::binary );
+    std::vector< char > contents( ( std::istreambuf_iterator< char >( file ) ),
+                                  std::istreambuf_iterator< char >() );
+    return std::string( contents.begin(), contents.end() );
+  }
+  return std::string();
 }
 
 

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -37,7 +37,7 @@ std::string ReadUtf8File( const fs::path &filepath ) {
   // in case filepath doesn't exist, or
   // in case filepath's file_status is "other".
   // "other" in this case means everything that is not a regular file,
-  // directory or a smylink.
+  // directory or a symlink.
   if ( !fs::is_empty( filepath ) && fs::is_regular_file( filepath ) ) {
     fs::ifstream file( filepath, std::ios::in | std::ios::binary );
     std::vector< char > contents( ( std::istreambuf_iterator< char >( file ) ),

--- a/cpp/ycm/tests/IdentifierUtils_test.cpp
+++ b/cpp/ycm/tests/IdentifierUtils_test.cpp
@@ -58,25 +58,25 @@ TEST( IdentifierUtilsTest, ExtractIdentifiersFromTagsFileWorks ) {
 
 TEST( IdentifierUtilsTest, TagFileIsDirectory ) {
   fs::path testfile = PathToTestFile( "directory.tags" );
-  FiletypeIdentifierMap expected;
 
-  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ), ContainerEq( expected ) );
+  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
+               ContainerEq( FiletypeIdentifierMap() ) );
 }
 
 
 TEST( IdentifierUtilsTest, TagFileIsEmpty ) {
   fs::path testfile = PathToTestFile( "empty.tags" );
-  FiletypeIdentifierMap expected;
 
-  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ), ContainerEq( expected ) );
+  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
+               ContainerEq( FiletypeIdentifierMap() ) );
 }
 
 
 TEST( IdentifierUtilsTest, TagFileInvalidPath ) {
   fs::path testfile = PathToTestFile( "invalid_path_to_tag_file.tags" );
-  FiletypeIdentifierMap expected;
 
-  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ), ContainerEq( expected ) );
+  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
+               ContainerEq( FiletypeIdentifierMap() ) );
 }
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/tests/IdentifierUtils_test.cpp
+++ b/cpp/ycm/tests/IdentifierUtils_test.cpp
@@ -55,5 +55,29 @@ TEST( IdentifierUtilsTest, ExtractIdentifiersFromTagsFileWorks ) {
                ContainerEq( expected ) );
 }
 
+
+TEST( IdentifierUtilsTest, TagFileIsDirectory ) {
+  fs::path testfile = PathToTestFile( "directory.tags" );
+  FiletypeIdentifierMap expected;
+
+  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ), ContainerEq( expected ) );
+}
+
+
+TEST( IdentifierUtilsTest, TagFileIsEmpty ) {
+  fs::path testfile = PathToTestFile( "empty.tags" );
+  FiletypeIdentifierMap expected;
+
+  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ), ContainerEq( expected ) );
+}
+
+
+TEST( IdentifierUtilsTest, TagFileInvalidPath ) {
+  fs::path testfile = PathToTestFile( "invalid_path_to_tag_file.tags" );
+  FiletypeIdentifierMap expected;
+
+  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ), ContainerEq( expected ) );
+}
+
 } // namespace YouCompleteMe
 

--- a/cpp/ycm/tests/testdata/directory.tags/.gitignore
+++ b/cpp/ycm/tests/testdata/directory.tags/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
In `IdentifierUtils.cpp` call to `ReadUtf8File()` is wrapped in a `try/catch` block, but `boost::filesystem::path`, on its own, never throws and never checks anything.

Instead there are methods like `boost::filesystem::is_regular_file(Path)` and `bost::filesystem::is_empty(Path)` that can be used to make sanity checks. `is_empty()` can throw `basic_filesystem_error` exception, as explained in the comment.

As an added bonus, the `catch` block is now reachable and should be covered with the new tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/726)
<!-- Reviewable:end -->
