### PR TITLE
[READY] Handle unicode pathname when loading source on Python 2

### DIFF
--- a/ycmd/tests/testdata/uni¢𐍈d€.py
+++ b/ycmd/tests/testdata/uni¢𐍈d€.py
@@ -1,0 +1,2 @@
+def SomeMethod():
+  return True

--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -29,8 +29,10 @@ import subprocess
 import tempfile
 import ycm_core
 from future.utils import native
+from hamcrest import assert_that, equal_to, has_property, instance_of
 from mock import patch, call
 from nose.tools import eq_, ok_, raises
+from types import ModuleType
 from ycmd import utils
 from ycmd.tests.test_utils import ( Py2Only, Py3Only, WindowsOnly, UnixOnly,
                                     CurrentWorkingDirectory,
@@ -545,6 +547,16 @@ def FindExecutable_CurrentDirectory_test():
 def FindExecutable_AdditionalPathExt_test():
   with TemporaryExecutable( extension = '.xyz' ) as executable:
     eq_( executable, utils.FindExecutable( executable ) )
+
+
+def LoadPythonSource_UnicodePath_test():
+  filename = PathToTestFile( u'uni¢𐍈d€.py' )
+  module = utils.LoadPythonSource( 'module_name', filename )
+  assert_that( module, instance_of( ModuleType ) )
+  assert_that( module.__file__, equal_to( filename ) )
+  assert_that( module.__name__, equal_to( 'module_name' ) )
+  assert_that( module, has_property( 'SomeMethod' ) )
+  assert_that( module.SomeMethod(), equal_to( True ) )
 
 
 @Py2Only


### PR DESCRIPTION
`imp.load_source` raises a `UnicodeEncodeError` exception on Python 2 when loading a file whose path contains non-ASCII characters. See http://bugs.python.org/issue9425. Handle this case by reading the file and executing its content into a new module.

Fixes #727.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/728)
<!-- Reviewable:end -->
