### PR TITLE
Remove IdentifierEndsWith() declaration

### DIFF
--- a/cpp/ycm/ClangCompleter/CompletionData.h
+++ b/cpp/ycm/ClangCompleter/CompletionData.h
@@ -119,9 +119,6 @@ private:
                              bool &saw_left_paren,
                              bool &saw_function_params,
                              bool &saw_placeholder );
-
-  bool IdentifierEndsWith( const std::string &identifier,
-                           const std::string &end );
 };
 
 } // namespace YouCompleteMe


### PR DESCRIPTION
Just like @oblitum  pointed out in [#701(comment)](https://github.com/Valloric/ycmd/pull/701#issuecomment-285920780), in `CompletionData.cpp` the `IdentifierEndsWith()` function is called only from function `RemoveTrailingParens()` and both functions are in unnamed namespace, so neither should have declaration in `CompletionData.h`.

@oblitum, in his comment, mentions that he had noticed more odd changes in that PR. While this commit fixes the change he explicitely mentioned I would like to wait and see if he has to add anything else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/732)
<!-- Reviewable:end -->
