### PR TITLE
[READY] Remove unused functions in ClangUtils

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangUtils.cpp
+++ b/cpp/ycm/ClangCompleter/ClangUtils.cpp
@@ -35,14 +35,6 @@ bool CursorIsValid( CXCursor cursor ) {
          !clang_isInvalid( clang_getCursorKind( cursor ) );
 }
 
-bool CursorIsReference( CXCursor cursor ) {
-  return clang_isReference( clang_getCursorKind( cursor ) );
-}
-
-bool CursorIsDeclaration( CXCursor cursor ) {
-  return clang_isDeclaration( clang_getCursorKind( cursor ) );
-}
-
 std::string CXFileToFilepath( CXFile file ) {
   return CXStringToString( clang_getFileName( file ) );
 }

--- a/cpp/ycm/ClangCompleter/ClangUtils.h
+++ b/cpp/ycm/ClangCompleter/ClangUtils.h
@@ -33,10 +33,6 @@ std::string CXStringToString( CXString text );
 
 bool CursorIsValid( CXCursor cursor );
 
-bool CursorIsReference( CXCursor cursor );
-
-bool CursorIsDeclaration( CXCursor cursor );
-
 std::string CXFileToFilepath( CXFile file );
 
 std::string ClangVersion();


### PR DESCRIPTION
According to the history of the file these functions are there since the file has been moved into the ycmd directory but right now they are not used, so I don't see a valid reason to keep them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/737)
<!-- Reviewable:end -->
