### PR TITLE
[READY] Remove unused `Result` empty constructor

### DIFF
--- a/cpp/ycm/Candidate.cpp
+++ b/cpp/ycm/Candidate.cpp
@@ -97,7 +97,7 @@ Result Candidate::QueryMatchResult( const std::string &query,
       node->NearestLetterNodesForLetter( letter );
 
     if ( !nearest )
-      return Result( false );
+      return Result();
 
     // When the query letter is uppercase, then we force an uppercase match
     // but when the query letter is lowercase, then it can match both an
@@ -113,7 +113,7 @@ Result Candidate::QueryMatchResult( const std::string &query,
     }
 
     if ( !node )
-      return Result( false );
+      return Result();
 
     index_sum += node->Index();
   }

--- a/cpp/ycm/Result.cpp
+++ b/cpp/ycm/Result.cpp
@@ -86,20 +86,6 @@ int NumWordBoundaryCharMatches( const std::string &query,
 
 } // unnamed namespace
 
-Result::Result()
-  :
-  query_is_empty_( true ),
-  is_subsequence_( false ),
-  first_char_same_in_query_and_text_( false ),
-  ratio_of_word_boundary_chars_in_query_( 0 ),
-  word_boundary_char_utilization_( 0 ),
-  query_is_candidate_prefix_( false ),
-  text_is_lowercase_( false ),
-  char_match_index_sum_( 0 ),
-  text_( NULL ) {
-}
-
-
 Result::Result( bool is_subsequence )
   :
   query_is_empty_( true ),

--- a/cpp/ycm/Result.h
+++ b/cpp/ycm/Result.h
@@ -24,8 +24,7 @@ namespace YouCompleteMe {
 
 class Result {
 public:
-  Result();
-  explicit Result( bool is_subsequence );
+  explicit Result( bool is_subsequence = false );
 
   Result( bool is_subsequence,
           const std::string *text,


### PR DESCRIPTION
According to the coverage and the build we never use the empty ctor of `Result` and its implementation is actually the same as the ctor taking one parameter with `false` as its parameter, so I didn's see a reason to maintain both.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/739)
<!-- Reviewable:end -->
