### PR TITLE
improve cmake's lib finding: rename the clang lib only once

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -312,9 +312,15 @@ if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
       set( CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
       # When loading our library, the dynamic linker will look for
       # libclang.so.4, not libclang.so.4.x.
-      file( RENAME
-            ${EXTERNAL_LIBCLANG_PATH}.${CLANG_MAJOR_VERSION}.${CLANG_MINOR_VERSION}
-            ${EXTERNAL_LIBCLANG_PATH}.${CLANG_MAJOR_VERSION} )
+      if( NOT EXISTS "${EXTERNAL_LIBCLANG_PATH}.${CLANG_MAJOR_VERSION}" )
+        if( EXISTS ${EXTERNAL_LIBCLANG_PATH}.${CLANG_MAJOR_VERSION}.${CLANG_MINOR_VERSION} )
+          file( RENAME
+                ${EXTERNAL_LIBCLANG_PATH}.${CLANG_MAJOR_VERSION}.${CLANG_MINOR_VERSION}
+                ${EXTERNAL_LIBCLANG_PATH}.${CLANG_MAJOR_VERSION} )
+        else ( )
+          message( "Required lib file missing: ${EXTERNAL_LIBCLANG_PATH}.${CLANG_MAJOR_VERSION}.${CLANG_MINOR_VERSION} or ${EXTERNAL_LIBCLANG_PATH}.${CLANG_MAJOR_VERSION}" )
+        endif()
+      endif()
     endif()
   endif()
 


### PR DESCRIPTION
if the expected clang lib names are not found, provide an error
message and exit.

As it was, if one run cmake twice, then configure would fail as
the rename operation would no longer find the original file name.
This fix first checks if the required libclang file name does not
exist. If it does not it looks for the libclang file as named in
the original clang distribution and renames it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/743)
<!-- Reviewable:end -->
