### PR TITLE
[READY] Ignore identifiers from comments and strings by filetype

### DIFF
--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -229,7 +229,7 @@ def _IdentifiersFromBuffer( text,
                             filetype,
                             collect_from_comments_and_strings ):
   if not collect_from_comments_and_strings:
-    text = identifier_utils.RemoveIdentifierFreeText( text )
+    text = identifier_utils.RemoveIdentifierFreeText( text, filetype )
   idents = identifier_utils.ExtractIdentifiersFromText( text, filetype )
   vector = ycm_core.StringVector()
   for ident in idents:

--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -26,30 +26,76 @@ from builtins import *  # noqa
 
 import re
 
-COMMENT_AND_STRING_REGEX = re.compile(
-  "//.*?$" # Anything following '//'
-  "|"
-  "#.*?$"  # Anything following '#'
-  "|"
-  "/\*(?:\n|.)*?\*/"  # C-style comments, '/* ... */'
-  "|"
-  # Python-style multi-line single-quote string
-  "'''(?:\n|.)*?'''"
-  "|"
-  # Python-style multi-line double-quote string
-  '"""(?:\n|.)*?"""'
-  "|"
-  # Anything inside single quotes, '...', but mind:
-  #  1. that the starting single quote is not escaped
-  #  2. the escaped slash (\\)
-  #  3. the escaped single quote inside the string
-  r"(?<!\\)'(?:\\\\|\\'|.)*?'"
-  "|"
-  # Anything inside double quotes, "...", but mind:
-  #  1. that the starting double quote is not escaped
-  #  2. the escaped slash (\\)
-  #  3. the escaped double quote inside the string
-  r'(?<!\\)"(?:\\\\|\\"|.)*?"', re.MULTILINE )
+C_STYLE_COMMENT = "/\*(?:\n|.)*?\*/"
+CPP_STYLE_COMMENT = "//.*?$"
+PYTHON_STYLE_COMMENT = "#.*?$"
+# Anything inside single quotes, '...', but mind:
+#  1. that the starting single quote is not escaped
+#  2. the escaped slash (\\)
+#  3. the escaped single quote inside the string
+SINGLE_QUOTE_STRING = r"(?<!\\)'(?:\\\\|\\'|.)*?'"
+# Anything inside double quotes, "...", but mind:
+#  1. that the starting double quote is not escaped
+#  2. the escaped slash (\\)
+#  3. the escaped double quote inside the string
+DOUBLE_QUOTE_STRING = r'(?<!\\)"(?:\\\\|\\"|.)*?"'
+# Anything inside back quotes, `...`, but mind:
+#  1. that the starting back quote is not escaped
+#  2. the escaped slash (\\)
+#  3. the escaped back quote inside the string
+BACK_QUOTE_STRING = r'(?<!\\)`(?:\\\\|\\`|.)*?`'
+# Python-style multiline single-quote string
+MULTILINE_SINGLE_QUOTE_STRING = "'''(?:\n|.)*?'''"
+# Python-style multiline double-quote string
+MULTILINE_DOUBLE_QUOTE_STRING = '"""(?:\n|.)*?"""'
+
+DEFAULT_COMMENT_AND_STRING_REGEX = re.compile( "|".join( [
+  C_STYLE_COMMENT,
+  CPP_STYLE_COMMENT,
+  PYTHON_STYLE_COMMENT,
+  MULTILINE_SINGLE_QUOTE_STRING,
+  MULTILINE_DOUBLE_QUOTE_STRING,
+  SINGLE_QUOTE_STRING,
+  DOUBLE_QUOTE_STRING ] ), re.MULTILINE )
+
+FILETYPE_TO_COMMENT_AND_STRING_REGEX = {
+  # Spec:
+  # http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3690.pdf
+  'cpp': re.compile( "|".join( [ C_STYLE_COMMENT,
+                                 CPP_STYLE_COMMENT,
+                                 SINGLE_QUOTE_STRING,
+                                 DOUBLE_QUOTE_STRING ] ), re.MULTILINE ),
+
+  # Spec:
+  # https://golang.org/ref/spec#Comments
+  # https://golang.org/ref/spec#String_literals
+  # https://golang.org/ref/spec#Rune_literals
+  'go': re.compile( "|".join( [ C_STYLE_COMMENT,
+                                CPP_STYLE_COMMENT,
+                                SINGLE_QUOTE_STRING,
+                                DOUBLE_QUOTE_STRING,
+                                BACK_QUOTE_STRING ] ), re.MULTILINE ),
+
+  # Spec:
+  # https://docs.python.org/3.6/reference/lexical_analysis.html#comments
+  # https://docs.python.org/3.6/reference/lexical_analysis.html#literals
+  'python': re.compile( "|".join( [ PYTHON_STYLE_COMMENT,
+                                    MULTILINE_SINGLE_QUOTE_STRING,
+                                    MULTILINE_DOUBLE_QUOTE_STRING,
+                                    SINGLE_QUOTE_STRING,
+                                    DOUBLE_QUOTE_STRING ] ), re.MULTILINE ),
+
+  # Spec:
+  # https://doc.rust-lang.org/reference.html#comments
+  # https://doc.rust-lang.org/reference.html#character-and-string-literals
+  'rust': re.compile( "|".join( [ CPP_STYLE_COMMENT,
+                                  SINGLE_QUOTE_STRING,
+                                  DOUBLE_QUOTE_STRING ] ), re.MULTILINE )
+}
+
+for filetype in [ 'c', 'objc', 'objcpp', 'javascript', 'typescript' ]:
+  FILETYPE_TO_COMMENT_AND_STRING_REGEX[ filetype ] = (
+    FILETYPE_TO_COMMENT_AND_STRING_REGEX[ 'cpp' ] )
 
 # At least c++ and javascript support unicode identifiers, and identifiers may
 # start with unicode character, e.g. ålpha. So we need to accept any identifier
@@ -116,12 +162,17 @@ FILETYPE_TO_IDENTIFIER_REGEX[ 'lisp' ] = (
   FILETYPE_TO_IDENTIFIER_REGEX[ 'clojure' ] )
 
 
+def CommentAndStringRegexForFiletype( filetype ):
+  return FILETYPE_TO_COMMENT_AND_STRING_REGEX.get(
+    filetype, DEFAULT_COMMENT_AND_STRING_REGEX )
+
+
 def IdentifierRegexForFiletype( filetype ):
   return FILETYPE_TO_IDENTIFIER_REGEX.get( filetype, DEFAULT_IDENTIFIER_REGEX )
 
 
-def RemoveIdentifierFreeText( text ):
-  return COMMENT_AND_STRING_REGEX.sub( '', text )
+def RemoveIdentifierFreeText( text, filetype = None ):
+  return CommentAndStringRegexForFiletype( filetype ).sub( '', text )
 
 
 def ExtractIdentifiersFromText( text, filetype = None ):

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -275,6 +275,8 @@ def GetCompletions_FilteredNoResults_Fallback_test( app ):
           CompletionEntryMatcher( 'do_', '[ID]' ),
           CompletionEntryMatcher( 'do_something', '[ID]' ),
           CompletionEntryMatcher( 'do_another_thing', '[ID]' ),
+          CompletionEntryMatcher( 'DO_SOMETHING_TO', '[ID]' ),
+          CompletionEntryMatcher( 'DO_SOMETHING_VIA', '[ID]' )
         ),
         'errors': empty()
       } )

--- a/ycmd/tests/identifier_utils_test.py
+++ b/ycmd/tests/identifier_utils_test.py
@@ -31,86 +31,77 @@ from hamcrest import assert_that, has_item
 
 def RemoveIdentifierFreeText_CppComments_test():
   eq_( "foo \nbar \nqux",
-       iu.RemoveIdentifierFreeText(
-          "foo \nbar //foo \nqux" ) )
+       iu.RemoveIdentifierFreeText( "foo \nbar //foo \nqux" ) )
 
 
 def RemoveIdentifierFreeText_PythonComments_test():
   eq_( "foo \nbar \nqux",
-       iu.RemoveIdentifierFreeText(
-          "foo \nbar #foo \nqux" ) )
+       iu.RemoveIdentifierFreeText( "foo \nbar #foo \nqux" ) )
 
 
 def RemoveIdentifierFreeText_CstyleComments_test():
   eq_( "foo \nbar \nqux",
-       iu.RemoveIdentifierFreeText(
-          "foo \nbar /* foo */\nqux" ) )
+       iu.RemoveIdentifierFreeText( "foo \nbar /* foo */\nqux" ) )
 
   eq_( "foo \nbar \nqux",
-       iu.RemoveIdentifierFreeText(
-          "foo \nbar /* foo \n foo2 */\nqux" ) )
+       iu.RemoveIdentifierFreeText( "foo \nbar /* foo \n foo2 */\nqux" ) )
 
 
 def RemoveIdentifierFreeText_SimpleSingleQuoteString_test():
   eq_( "foo \nbar \nqux",
-       iu.RemoveIdentifierFreeText(
-          "foo \nbar 'foo'\nqux" ) )
+       iu.RemoveIdentifierFreeText( "foo \nbar 'foo'\nqux" ) )
 
 
 def RemoveIdentifierFreeText_SimpleDoubleQuoteString_test():
   eq_( "foo \nbar \nqux",
-       iu.RemoveIdentifierFreeText(
-          'foo \nbar "foo"\nqux' ) )
+       iu.RemoveIdentifierFreeText( 'foo \nbar "foo"\nqux' ) )
 
 
 def RemoveIdentifierFreeText_EscapedQuotes_test():
   eq_( "foo \nbar \nqux",
-       iu.RemoveIdentifierFreeText(
-          "foo \nbar 'fo\\'oz\\nfoo'\nqux" ) )
+       iu.RemoveIdentifierFreeText( "foo \nbar 'fo\\'oz\\nfoo'\nqux" ) )
 
   eq_( "foo \nbar \nqux",
-       iu.RemoveIdentifierFreeText(
-          'foo \nbar "fo\\"oz\\nfoo"\nqux' ) )
+       iu.RemoveIdentifierFreeText( 'foo \nbar "fo\\"oz\\nfoo"\nqux' ) )
 
 
 def RemoveIdentifierFreeText_SlashesInStrings_test():
   eq_( "foo \nbar baz\nqux ",
-       iu.RemoveIdentifierFreeText(
-           'foo \nbar "fo\\\\"baz\nqux "qwe"' ) )
+       iu.RemoveIdentifierFreeText( 'foo \nbar "fo\\\\"baz\nqux "qwe"' ) )
 
   eq_( "foo \nbar \nqux ",
-       iu.RemoveIdentifierFreeText(
-           "foo '\\\\'\nbar '\\\\'\nqux '\\\\'" ) )
+       iu.RemoveIdentifierFreeText( "foo '\\\\'\nbar '\\\\'\nqux '\\\\'" ) )
 
 
 def RemoveIdentifierFreeText_EscapedQuotesStartStrings_test():
   eq_( "\\\"foo\\\" zoo",
-       iu.RemoveIdentifierFreeText(
-           "\\\"foo\\\"'\"''bar' zoo'test'" ) )
+       iu.RemoveIdentifierFreeText( "\\\"foo\\\"'\"''bar' zoo'test'" ) )
 
   eq_( "\\'foo\\' zoo",
-       iu.RemoveIdentifierFreeText(
-           "\\'foo\\'\"'\"\"bar\" zoo\"test\"" ) )
+       iu.RemoveIdentifierFreeText( "\\'foo\\'\"'\"\"bar\" zoo\"test\"" ) )
 
 
 def RemoveIdentifierFreeText_NoMultilineString_test():
   eq_( "'\nlet x = \nlet y = ",
-       iu.RemoveIdentifierFreeText(
-           "'\nlet x = 'foo'\nlet y = 'bar'" ) )
+       iu.RemoveIdentifierFreeText( "'\nlet x = 'foo'\nlet y = 'bar'" ) )
 
   eq_( "\"\nlet x = \nlet y = ",
-       iu.RemoveIdentifierFreeText(
-           "\"\nlet x = \"foo\"\nlet y = \"bar\"" ) )
+       iu.RemoveIdentifierFreeText( "\"\nlet x = \"foo\"\nlet y = \"bar\"" ) )
 
 
 def RemoveIdentifierFreeText_PythonMultilineString_test():
   eq_( "\nzoo",
-       iu.RemoveIdentifierFreeText(
-           "\"\"\"\nfoobar\n\"\"\"\nzoo" ) )
+       iu.RemoveIdentifierFreeText( "\"\"\"\nfoobar\n\"\"\"\nzoo" ) )
 
   eq_( "\nzoo",
-       iu.RemoveIdentifierFreeText(
-           "'''\nfoobar\n'''\nzoo" ) )
+       iu.RemoveIdentifierFreeText( "'''\nfoobar\n'''\nzoo" ) )
+
+
+def RemoveIdentifierFreeText_GoBackQuoteString_test():
+  eq_( "foo \nbar `foo`\nqux",
+       iu.RemoveIdentifierFreeText( "foo \nbar `foo`\nqux" ) )
+  eq_( "foo \nbar \nqux",
+       iu.RemoveIdentifierFreeText( "foo \nbar `foo`\nqux", filetype = 'go' ) )
 
 
 def ExtractIdentifiersFromText_test():


### PR DESCRIPTION
When `collect_identifiers_from_comments_and_strings` is `0`, we are ignoring identifiers inside comments and strings from different languages. This is incorrect because we may ignore identifiers from comments that are not actual comments in the current working language. For instance, the `include` identifier will be ignored in the following C++ code:
```cpp
#include <iostream>
```
because we assume it's inside a Python-style comment.

The solution is to ignore identifiers from comments and strings according to filetype similarly to what we do to extract identifiers. For now, I've added support to the languages for which ycmd provides semantic completion. We'll add more with time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/746)
<!-- Reviewable:end -->
