### PR TITLE
build: Fix finding the python library

### DIFF
--- a/build.py
+++ b/build.py
@@ -153,7 +153,7 @@ def GetPossiblePythonLibraryDirectories():
   # On pyenv, there is no Python dynamic library in the directory returned by
   # the LIBPL variable. Such library is located in the parent folder of the
   # standard Python library modules.
-  return [ sysconfig.get_config_var( 'LIBPL' ), library_dir ]
+  return [ sysconfig.get_config_var( 'LIBPL' ), library_dir, '/usr/lib64', '/usr/lib']
 
 
 def FindPythonLibraries():


### PR DESCRIPTION
This fixes detection of the python3 libraries on openSUSE. cmake
normally correctly detects python but this custom code doesn't check the
default directories for libraries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/747)
<!-- Reviewable:end -->
