### PR TITLE
[READY] Build boost in parallel

### DIFF
--- a/update_boost.py
+++ b/update_boost.py
@@ -14,6 +14,7 @@ import tarfile
 from tempfile import mkdtemp
 from shutil import rmtree
 from distutils.dir_util import copy_tree
+from multiprocessing import cpu_count
 
 DIR_OF_THIS_SCRIPT = os.path.dirname( os.path.abspath( __file__ ) )
 DIR_OF_THIRD_PARTY = os.path.join( DIR_OF_THIS_SCRIPT, 'third_party' )
@@ -142,6 +143,7 @@ def ExtractBoostParts( args ):
                                               '.sh' ) )
     subprocess.call( [ bootstrap ] )
     subprocess.call( [ os.path.join( os.curdir, 'b2' ),
+                       '-j' + str( cpu_count() ),
                        os.path.join( 'tools', 'bcp' ) ] )
     boost_parts_dir = os.path.join( os.curdir, 'boost_parts' )
     os.mkdir( boost_parts_dir )


### PR DESCRIPTION
Boost's `b2` utility allows for building in parallel, using more jobs in the same way `make` allows - by specifying `-j` and the number of cores.

This change uses the same method of figuring out the number of jobs as `build.py`.

While boost isn't updated often, this was one of the things I had to change while working on #741, because it was annoying to work with multiple rebuilds on one core.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/748)
<!-- Reviewable:end -->
