### PR TITLE
[READY] Improve CSS identifier regex

### DIFF
--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -115,9 +115,8 @@ FILETYPE_TO_IDENTIFIER_REGEX = {
     # Default identifier plus the dollar sign.
     'javascript': re.compile( r"(?:[^\W\d]|\$)[\w$]*", re.UNICODE ),
 
-    # Spec: http://www.w3.org/TR/CSS2/syndata.html#characters
-    # Good summary: http://stackoverflow.com/a/449000/1672783
-    'css': re.compile( r"-?[_a-zA-Z]+[\w-]+", re.UNICODE ),
+    # Spec: https://www.w3.org/TR/css-syntax-3/#ident-token-diagram
+    'css': re.compile( r"-?[^\W\d][\w-]*", re.UNICODE ),
 
     # Spec: http://www.w3.org/TR/html5/syntax.html#tag-name-state
     # But not quite since not everything we want to pull out is a tag name. We

--- a/ycmd/tests/identifier_utils_test.py
+++ b/ycmd/tests/identifier_utils_test.py
@@ -177,6 +177,7 @@ def IsIdentifier_TypeScript_test():
 
 def IsIdentifier_Css_test():
   ok_( iu.IsIdentifier( 'foo'      , 'css' ) )
+  ok_( iu.IsIdentifier( 'a'        , 'css' ) )
   ok_( iu.IsIdentifier( 'a1'       , 'css' ) )
   ok_( iu.IsIdentifier( 'a-'       , 'css' ) )
   ok_( iu.IsIdentifier( 'a-b'      , 'css' ) )
@@ -184,12 +185,14 @@ def IsIdentifier_Css_test():
   ok_( iu.IsIdentifier( '-ms-foo'  , 'css' ) )
   ok_( iu.IsIdentifier( '-_o'      , 'css' ) )
   ok_( iu.IsIdentifier( 'font-face', 'css' ) )
+  ok_( iu.IsIdentifier( 'αβγ'      , 'css' ) )
 
   ok_( not iu.IsIdentifier( '-3b', 'css' ) )
   ok_( not iu.IsIdentifier( '-3' , 'css' ) )
+  ok_( not iu.IsIdentifier( '--', 'css' ) )
   ok_( not iu.IsIdentifier( '3'  , 'css' ) )
-  ok_( not iu.IsIdentifier( 'a'  , 'css' ) )
   ok_( not iu.IsIdentifier( '' , 'css' ) )
+  ok_( not iu.IsIdentifier( '€', 'css' ) )
 
 
 def IsIdentifier_R_test():


### PR DESCRIPTION
According to [latest specifications](https://www.w3.org/TR/css-syntax-3/#ident-token-diagram), single character words (an obvious example is the `a` HTML tag) and words starting with a unicode character are valid CSS identifiers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/749)
<!-- Reviewable:end -->
