### PR TITLE
[READY] Improve clang completer coverage

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangCompleter.h
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.h
@@ -47,7 +47,7 @@ public:
 
   bool UpdatingTranslationUnit( const std::string &filename );
 
-  std::vector< Diagnostic > UpdateTranslationUnit(
+  YCM_DLL_EXPORT std::vector< Diagnostic > UpdateTranslationUnit(
     const std::string &filename,
     const std::vector< UnsavedFile > &unsaved_files,
     const std::vector< std::string > &flags );
@@ -59,7 +59,7 @@ public:
     const std::vector< UnsavedFile > &unsaved_files,
     const std::vector< std::string > &flags );
 
-  Location GetDeclarationLocation(
+  YCM_DLL_EXPORT Location GetDeclarationLocation(
     const std::string &filename,
     int line,
     int column,
@@ -75,7 +75,7 @@ public:
     const std::vector< std::string > &flags,
     bool reparse = true );
 
-  std::string GetTypeAtLocation(
+  YCM_DLL_EXPORT std::string GetTypeAtLocation(
     const std::string &filename,
     int line,
     int column,
@@ -83,7 +83,7 @@ public:
     const std::vector< std::string > &flags,
     bool reparse = true );
 
-  std::string GetEnclosingFunctionAtLocation(
+  YCM_DLL_EXPORT std::string GetEnclosingFunctionAtLocation(
     const std::string &filename,
     int line,
     int column,
@@ -91,7 +91,7 @@ public:
     const std::vector< std::string > &flags,
     bool reparse = true );
 
-  std::vector< FixIt > GetFixItsForLocationInFile(
+  YCM_DLL_EXPORT std::vector< FixIt > GetFixItsForLocationInFile(
     const std::string &filename,
     int line,
     int column,
@@ -99,7 +99,7 @@ public:
     const std::vector< std::string > &flags,
     bool reparse = true );
 
-  DocumentationData GetDocsForLocationInFile(
+  YCM_DLL_EXPORT DocumentationData GetDocsForLocationInFile(
     const std::string &filename,
     int line,
     int column,

--- a/cpp/ycm/ClangCompleter/CompletionData.h
+++ b/cpp/ycm/ClangCompleter/CompletionData.h
@@ -88,11 +88,10 @@ struct CompletionData {
   }
 
   bool operator== ( const CompletionData &other ) const {
-    return
-      kind_ == other.kind_ &&
-      everything_except_return_type_ == other.everything_except_return_type_ &&
-      return_type_ == other.return_type_ &&
-      original_string_ == other.original_string_;
+    return kind_ == other.kind_ &&
+           return_type_ == other.return_type_ &&
+           original_string_ == other.original_string_ &&
+           everything_except_return_type_ == other.everything_except_return_type_;
     // detailed_info_ doesn't matter
   }
 

--- a/cpp/ycm/ClangCompleter/Documentation.h
+++ b/cpp/ycm/ClangCompleter/Documentation.h
@@ -47,6 +47,15 @@ struct DocumentationData {
   std::string canonical_type;
   /// The display name of the referenced cursor
   std::string display_name;
+
+  bool operator == ( const DocumentationData &other ) const {
+    return comment_xml == other.comment_xml &&
+           raw_comment == other.raw_comment &&
+           brief_comment == other.brief_comment &&
+           canonical_type == other.canonical_type &&
+           display_name == other.display_name;
+  }
+
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/ClangCompleter/Location.h
+++ b/cpp/ycm/ClangCompleter/Location.h
@@ -27,10 +27,7 @@ namespace YouCompleteMe {
 
 struct Location {
   // Creates an invalid location
-  Location()
-    : line_number_( 0 ),
-      column_number_( 0 ),
-      filename_( "" ) {}
+  Location() : line_number_( 0 ), column_number_( 0 ), filename_( "" ) {}
 
   Location( const std::string &filename,
             unsigned int line,
@@ -51,10 +48,9 @@ struct Location {
   }
 
   bool operator== ( const Location &other ) const {
-    return
-      line_number_ == other.line_number_ &&
-      column_number_ == other.column_number_ &&
-      filename_ == other.filename_;
+    return line_number_ == other.line_number_ &&
+           column_number_ == other.column_number_ &&
+           filename_ == other.filename_;
   }
 
   bool IsValid() {

--- a/cpp/ycm/ClangCompleter/TranslationUnit.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.h
@@ -40,7 +40,7 @@ public:
   // This constructor creates an invalid, sentinel TU. All of it's methods
   // return empty vectors, and IsCurrentlyUpdating always returns true so that
   // no callers try to rely on the invalid TU.
-  TranslationUnit();
+  YCM_DLL_EXPORT TranslationUnit();
   TranslationUnit( const TranslationUnit& ) = delete;
   TranslationUnit& operator=( const TranslationUnit& ) = delete;
 
@@ -54,12 +54,12 @@ public:
 
   void Destroy();
 
-  bool IsCurrentlyUpdating() const;
+  YCM_DLL_EXPORT bool IsCurrentlyUpdating() const;
 
   std::vector< Diagnostic > Reparse(
     const std::vector< UnsavedFile > &unsaved_files );
 
-  std::vector< CompletionData > CandidatesForLocation(
+  YCM_DLL_EXPORT std::vector< CompletionData > CandidatesForLocation(
     int line,
     int column,
     const std::vector< UnsavedFile > &unsaved_files );
@@ -76,13 +76,13 @@ public:
     const std::vector< UnsavedFile > &unsaved_files,
     bool reparse = true );
 
-  std::string GetTypeAtLocation(
+  YCM_DLL_EXPORT std::string GetTypeAtLocation(
     int line,
     int column,
     const std::vector< UnsavedFile > &unsaved_files,
     bool reparse = true );
 
-  std::string GetEnclosingFunctionAtLocation(
+  YCM_DLL_EXPORT std::string GetEnclosingFunctionAtLocation(
     int line,
     int column,
     const std::vector< UnsavedFile > &unsaved_files,
@@ -94,7 +94,7 @@ public:
     const std::vector< UnsavedFile > &unsaved_files,
     bool reparse = true );
 
-  DocumentationData GetDocsForLocationInFile(
+  YCM_DLL_EXPORT DocumentationData GetDocsForLocationInFile(
     int line,
     int column,
     const std::vector< UnsavedFile > &unsaved_files,

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.h
@@ -33,14 +33,14 @@ namespace YouCompleteMe {
 
 class TranslationUnitStore {
 public:
-  TranslationUnitStore( CXIndex clang_index );
-  ~TranslationUnitStore();
+  YCM_DLL_EXPORT TranslationUnitStore( CXIndex clang_index );
+  YCM_DLL_EXPORT ~TranslationUnitStore();
   TranslationUnitStore( const TranslationUnitStore& ) = delete;
   TranslationUnitStore& operator=( const TranslationUnitStore& ) = delete;
 
   // You can even call this function for the same filename from multiple
   // threads; the TU store will ensure only one TU is created.
-  std::shared_ptr< TranslationUnit > GetOrCreate(
+  YCM_DLL_EXPORT std::shared_ptr< TranslationUnit > GetOrCreate(
     const std::string &filename,
     const std::vector< UnsavedFile > &unsaved_files,
     const std::vector< std::string > &flags );

--- a/cpp/ycm/tests/testdata/basic.cpp
+++ b/cpp/ycm/tests/testdata/basic.cpp
@@ -1,3 +1,13 @@
+class Bar {
+public:
+  int x;
+  int y;
+  char c;
+
+  void barbar() {
+    x = 5;
+  }
+};
 struct Foo {
   int x; //!< A docstring.
   int y;
@@ -7,10 +17,13 @@ struct Foo {
     return 5;
   }
 };
-
+typedef enum { VALUE_1, VALUE_2 } enum_test;
 int main()
 {
   Foo foo;
-  // The location after the dot is line 15, col 7
-  foo.
+  Bar bar;
+  // The location after the dots are lines 26 and 27, column 3
+  bar.barbar();
+  foo.x = 3;
+  enum_test enumerate = VALUE_1;
 }


### PR DESCRIPTION
While this won't make the clang completer coverage reach 100%, it should singnificantly improve it. These tests mostly deal with what happens when clang can't parse the TU, but also with testing all kinds of `GoTo` jumps.

What is left not covered are some partials and more than a few `==` operator overloads that are required for `boost::python`, but are not explicitly used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/751)
<!-- Reviewable:end -->
