### PR TITLE
[READY] Increase timeout in shutdown tests

### DIFF
--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -130,7 +130,7 @@ class Client_test( object ):
     return response.json()
 
 
-  def _WaitUntilReady( self, filetype = None, timeout = 10 ):
+  def _WaitUntilReady( self, filetype = None, timeout = 20 ):
     expiration = time.time() + timeout
     while True:
       try:


### PR DESCRIPTION
OmniSharp server now takes about 15 seconds to be ready on Linux Travis. Increase timeout to 20 seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/755)
<!-- Reviewable:end -->
