### PR TITLE
[READY] Removing unnecessary travis webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,5 +70,3 @@ cache:
     - $HOME/.pyenv  # pyenv
     - $TRAVIS_BUILD_DIR/clang_archives  # Clang downloads
     - $TRAVIS_BUILD_DIR/third_party/racerd/target  # Racerd compilation
-notifications:
-    webhooks: http://35.185.255.222:54856/travis


### PR DESCRIPTION
Our homu instance gets travis events through GitHub status events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/756)
<!-- Reviewable:end -->
