### PR TITLE
[READY] Further increase timeout in tests

### DIFF
--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -130,7 +130,7 @@ class Client_test( object ):
     return response.json()
 
 
-  def _WaitUntilReady( self, filetype = None, timeout = 20 ):
+  def _WaitUntilReady( self, filetype = None, timeout = 30 ):
     expiration = time.time() + timeout
     while True:
       try:

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -209,20 +209,17 @@ def StopCompleterServer( app, filetype, filepath = '/foo' ):
                  expect_errors = True )
 
 
-def WaitUntilCompleterServerReady( app, filetype ):
-  retries = 100
+def WaitUntilCompleterServerReady( app, filetype, timeout = 30 ):
+  expiration = time.time() + timeout
+  while True:
+    if time.time() > expiration:
+      raise RuntimeError( 'Waited for the {0} subserver to be ready for '
+                          '{1} seconds, aborting.'.format( filetype, timeout ) )
 
-  while retries > 0:
-    result = app.get( '/ready', { 'subserver': filetype } ).json
-    if result:
+    if app.get( '/ready', { 'subserver': filetype } ).json:
       return
 
-    time.sleep( 0.2 )
-    retries = retries - 1
-
-  raise RuntimeError(
-    'Timeout waiting for "{0}" filetype completer'.format( filetype ) )
-
+    time.sleep( 0.1 )
 
 
 def ClearCompletionsCache():


### PR DESCRIPTION
20 seconds is not long enough for the C# server to be ready on Linux Travis. Increase timeout to 30 seconds. Rewrite `WaitUntilCompleterServerReady` to accept a timeout parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/757)
<!-- Reviewable:end -->
