### PR TITLE
Return True from /ready request for filetype with no semenatic completer and subserver param

### DIFF
--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -159,8 +159,11 @@ def GetReady():
 
 
 def _IsSubserverReady( filetype ):
-  completer = _server_state.GetFiletypeCompleter( [filetype] )
-  return completer.ServerIsReady()
+  if _server_state.FiletypeCompletionAvailable( [ filetype ] ):
+    completer = _server_state.GetFiletypeCompleter( [ filetype ] )
+    return completer.ServerIsReady()
+  else:
+    return True
 
 
 @app.post( '/semantic_completion_available' )

--- a/ycmd/tests/misc_handlers_test.py
+++ b/ycmd/tests/misc_handlers_test.py
@@ -173,3 +173,17 @@ def MiscHandlers_DebugInfo_ExtraConfFoundButNotLoaded_test( app ):
       'completer': None
     } )
   )
+
+
+@SharedYcmd
+def MiscHandlers_Ready_WithFiletypeCompleter_test( app ):
+  with PatchCompleter( DummyCompleter, filetype = 'dummy_filetype' ):
+    assert_that( app.get( '/ready', { 'subserver': "dummy_filetype" } ).json,
+                 equal_to( True ) )
+
+
+@SharedYcmd
+def MiscHandlers_Ready_NoFiletypeCompleter_test( app ):
+  with PatchCompleter( DummyCompleter, filetype = 'dummy_filetype' ):
+    assert_that( app.get( '/ready', { 'subserver': "another_filetype" } ).json,
+                 equal_to( True ) )


### PR DESCRIPTION
`ready` request should return `true` for a filetype without no semantic completer even if is used for the `subserver` parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/758)
<!-- Reviewable:end -->
