### PR TITLE
[READY][API] Drop include_subservers parameter in healthy and ready endpoints

### DIFF
--- a/examples/example_client.py
+++ b/examples/example_client.py
@@ -102,10 +102,10 @@ class YcmdHandle( object ):
     return returncode is None
 
 
-  def IsReady( self, include_subservers = False ):
+  def IsReady( self, filetype = None ):
     if not self.IsAlive():
       return False
-    params = { 'include_subservers': 1 } if include_subservers else None
+    params = { 'subserver': filetype } if filetype else None
     response = self.GetFromHandler( 'ready', params )
     response.raise_for_status()
     return response.json()
@@ -191,7 +191,7 @@ class YcmdHandle( object ):
     self.PostToHandlerAndLog( EXTRA_CONF_HANDLER, request_json )
 
 
-  def WaitUntilReady( self, include_subservers = False ):
+  def WaitUntilReady( self, filetype = None ):
     total_slept = 0
     time.sleep( 0.5 )
     total_slept += 0.5
@@ -202,7 +202,7 @@ class YcmdHandle( object ):
               'waited for the server for {0} seconds, aborting'.format(
                     MAX_SERVER_WAIT_TIME_SECONDS ) )
 
-        if self.IsReady( include_subservers ):
+        if self.IsReady( filetype ):
           return
       except requests.exceptions.ConnectionError:
         pass
@@ -461,7 +461,7 @@ def CsharpSemanticCompletionResults( server ):
   # We have to wait until OmniSharpServer has started and loaded the solution
   # file
   print( 'Waiting for OmniSharpServer to become ready...' )
-  server.WaitUntilReady( include_subservers = True )
+  server.WaitUntilReady( filetype = 'cs' )
   server.SendCodeCompletionRequest( test_filename = 'some_csharp.cs',
                                     filetype = 'cs',
                                     line_num = 10,

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -141,9 +141,10 @@ def FilterAndSortCandidates():
 @app.get( '/healthy' )
 def GetHealthy():
   _logger.info( 'Received health request' )
-  if request.query.include_subservers:
-    cs_completer = _server_state.GetFiletypeCompleter( ['cs'] )
-    return _JsonResponse( cs_completer.ServerIsHealthy() )
+  if request.query.subserver:
+    filetype = request.query.subserver
+    completer = _server_state.GetFiletypeCompleter( [ filetype ] )
+    return _JsonResponse( completer.ServerIsHealthy() )
   return _JsonResponse( True )
 
 
@@ -152,15 +153,9 @@ def GetReady():
   _logger.info( 'Received ready request' )
   if request.query.subserver:
     filetype = request.query.subserver
-    return _JsonResponse( _IsSubserverReady( filetype ) )
-  if request.query.include_subservers:
-    return _JsonResponse( _IsSubserverReady( 'cs' ) )
+    completer = _server_state.GetFiletypeCompleter( [ filetype ] )
+    return _JsonResponse( completer.ServerIsReady() )
   return _JsonResponse( True )
-
-
-def _IsSubserverReady( filetype ):
-  completer = _server_state.GetFiletypeCompleter( [filetype] )
-  return completer.ServerIsReady()
 
 
 @app.post( '/semantic_completion_available' )

--- a/ycmd/tests/misc_handlers_test.py
+++ b/ycmd/tests/misc_handlers_test.py
@@ -32,6 +32,30 @@ from ycmd.tests.test_utils import BuildRequest, DummyCompleter, PatchCompleter
 
 
 @SharedYcmd
+def MiscHandlers_Healthy_test( app ):
+  assert_that( app.get( '/healthy' ).json, equal_to( True ) )
+
+
+@SharedYcmd
+def MiscHandlers_Healthy_Subserver_test( app ):
+  with PatchCompleter( DummyCompleter, filetype = 'dummy_filetype' ):
+    assert_that( app.get( '/healthy', { 'subserver': 'dummy_filetype' } ).json,
+                 equal_to( True ) )
+
+
+@SharedYcmd
+def MiscHandlers_Ready_test( app ):
+  assert_that( app.get( '/ready' ).json, equal_to( True ) )
+
+
+@SharedYcmd
+def MiscHandlers_Ready_Subserver_test( app ):
+  with PatchCompleter( DummyCompleter, filetype = 'dummy_filetype' ):
+    assert_that( app.get( '/ready', { 'subserver': 'dummy_filetype' } ).json,
+                 equal_to( True ) )
+
+
+@SharedYcmd
 def MiscHandlers_SemanticCompletionAvailable_test( app ):
   with PatchCompleter( DummyCompleter, filetype = 'dummy_filetype' ):
     request_data = BuildRequest( filetype = 'dummy_filetype' )


### PR DESCRIPTION
The `ready` endpoint currently accepts two parameters:
 - `subserver`: return `True` if the subserver for the given filetype is ready;
 - `include_subservers`: return `True` if the C# subserver is ready.

From this, it's obvious that we don't need the `include_subservers` parameter and that we should drop it in favor of `subserver`. We don't use this parameter anywhere in our code base and, AFAIK, no clients rely on it so we can safely remove it.

For consistency, we update the `healthy` endpoint by renaming its `include_subservers` parameter to `subserver` and extending it to any filetype. For the same reason as above, this shouldn't break anything.

Add tests for these two endpoints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/759)
<!-- Reviewable:end -->
