### PR TITLE
[READY] Fix warning message when the --no-clang-completer option is specified

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -145,7 +145,7 @@ def FixupCompleters( parsed_args ):
     completers = completers.difference( parsed_args.no_completers )
   elif parsed_args.no_clang_completer:
     print( 'WARNING: The "--no-clang-completer" flag is deprecated. '
-           'Please use "--no-completer cfamily" instead.' )
+           'Please use "--no-completers cfamily" instead.' )
     completers.remove( 'cfamily' )
 
   if 'USE_CLANG_COMPLETER' in os.environ:


### PR DESCRIPTION
The option replacing `--no-clang-completer` ends with a `s`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/764)
<!-- Reviewable:end -->
