### PR TITLE
[READY] Specify .NET Framework 4.5

### DIFF
--- a/build.py
+++ b/build.py
@@ -420,7 +420,8 @@ def BuildOmniSharp():
     sys.exit( 'ERROR: msbuild or xbuild is required to build Omnisharp.' )
 
   os.chdir( p.join( DIR_OF_THIS_SCRIPT, 'third_party', 'OmniSharpServer' ) )
-  CheckCall( [ build_command, '/property:Configuration=Release' ] )
+  CheckCall( [ build_command, '/property:Configuration=Release',
+                              '/property:TargetFrameworkVersion=v4.5' ] )
 
 
 def BuildGoCode():


### PR DESCRIPTION
As explained in #765, [the OmniSharpServer project file specifies version 4.0 of .NET Framework](https://github.com/OmniSharp/omnisharp-server/blob/e1902915c6790bcec00b8d551199c8a3537d33c9/OmniSharp/OmniSharp.csproj#L10) but recent versions of Visual Studio and Mono dropped this version; at least 4.5 is required.

Specifies this version through the `/property:TargetFrameworkVersion` flag in the build script.

Fixes https://github.com/Valloric/ycmd/issues/765.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/767)
<!-- Reviewable:end -->
