### PR TITLE
[READY] Require coverage.py package older than version 4.4

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -13,4 +13,7 @@ unittest2    >= 1.1.0
 psutil       >= 3.3.0, != 5.0.1
 # This needs to be kept in sync with submodule checkout in third_party
 future       == 0.15.2
-coverage     >= 4.2
+# coverage.py 4.4 removed the path from the filename attribute in its reports.
+# This leads to incorrect coverage from codecov as it relies on this attribute
+# to find the source file.
+coverage     >= 4.2, < 4.4


### PR DESCRIPTION
Reports from Codecov show that some lines of `ycmd/utils.py` are not covered while they should be. For instance, [the `_GetWindowsExecutable` function](https://codecov.io/gh/Valloric/ycmd/src/master/ycmd/utils.py#L218) is not covered but [we are testing it through the `FindExecutable` function](https://github.com/Valloric/ycmd/blob/1ebfbd4ca5bbfcb49817967dfc9fbc3f82312f66/ycmd/tests/utils_test.py#L512-L549). This can be confirmed by looking at the [AppVeyor uploads on Codecov](https://codecov.io/gh/Valloric/ycmd/commit/1ebfbd4ca5bbfcb49817967dfc9fbc3f82312f66/build). These reports contain the lines 218-230 for the `utils.py` file.

Codecov doesn't report these lines as covered because of [a change introduced in the version 4.4 of coverage.py](https://bitbucket.org/ned/coveragepy/issues/526/generated-xml-invalid-paths-for-cobertura). This change removes the path from the filename attribute in the XML reports generated by coverage.py. The issue is that Codecov relies on combining the root project and this attribute to find the source file and display its coverage. Since the root project is `c:\projects\ycmd` on AppVeyor, Codecov will look for `c:\projects\ycmd\utils.py` instead of `c:\projects\ycmd\ycmd\utils.py` thus not finding the file and ignoring its coverage. See https://github.com/pyca/cryptography/pull/3660 and [this bitbucket issue](https://bitbucket.org/ned/coveragepy/issues/578/incomplete-file-path-in-xml-report) for more details.

The reports from Travis are not affected by this issue because Travis has a version of coverage.py older than 4.4 in its cache while AppVeyor doesn't seem to cache Python packages at all (not sure why but that's another matter).

A simple solution is to require coverage.py to be older than version 4.4 in `test_requirements.txt`.

I am waiting for the coverage results before changing the PR status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/770)
<!-- Reviewable:end -->
