### PR TITLE
[READY] Fix unused variable in benchmark setup

### DIFF
--- a/cpp/ycm/benchmarks/IdentifierCompleter_bench.cpp
+++ b/cpp/ycm/benchmarks/IdentifierCompleter_bench.cpp
@@ -23,7 +23,7 @@ namespace YouCompleteMe {
 
 class IdentifierCompleterFixture : public benchmark::Fixture {
 public:
-  void SetUp( const benchmark::State& state ) {
+  void SetUp( const benchmark::State& ) {
     CandidateRepository::Instance().ClearCandidates();
   }
 };


### PR DESCRIPTION
When running the `benchmark.py` script with the `--enable-debug` option on Linux, the compilation fails with the following error:
```
IdentifierCompleter_bench.cpp:26:39: error: unused parameter ‘state’ [-Werror=unused-parameter]
   void SetUp( const benchmark::State& state ) {
                                       ^
```
This is fixed by removing the parameter name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/778)
<!-- Reviewable:end -->
