### PR TITLE
[READY] Fix RHEL detection. It actually reports as RedHatEnterpriseServer

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -197,7 +197,7 @@ else()
     # or greater. However, we recommended the devtoolset-6 because it is the
     # newest at the time of writing. And why not.
     if ( ${LSB_RELEASE_ID} STREQUAL "CentOS" OR
-       ${LSB_RELEASE_ID} STREQUAL "REHL" )
+         ${LSB_RELEASE_ID} STREQUAL "RedHatEnterpriseServer" )
       message( STATUS "NOTE: You appear to be on ${LSB_RELEASE_ID} version "
       "${LSB_RELEASE_VERSION}. In order to use this application, you require a "
       "more modern compiler than the default compiler on this platform. "


### PR DESCRIPTION
Shamefully, I actually only tested CentOS at home.

Tested this change at work on RH 6.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/779)
<!-- Reviewable:end -->
