### PR TITLE
[READY] Fix memory leak when clearing candidates

### DIFF
--- a/cpp/ycm/CandidateRepository.cpp
+++ b/cpp/ycm/CandidateRepository.cpp
@@ -86,6 +86,9 @@ std::vector< const Candidate * > CandidateRepository::GetCandidatesForStrings(
 
 
 void CandidateRepository::ClearCandidates() {
+  for ( const CandidateHolder::value_type & pair : candidate_holder_ ) {
+    delete pair.second;
+  }
   candidate_holder_.clear();
 }
 


### PR DESCRIPTION
This is an obvious memory leak given `CandidateRepository` destructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/780)
<!-- Reviewable:end -->
