### PR TITLE
[READY] Fix -include-pch flag handling when converting relative paths to absolute

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -33,12 +33,12 @@ from ycmd.utils import ( ToCppStringCompatible, OnMac, OnWindows, ToUnicode,
 from ycmd.responses import NoExtraConfDetected
 
 
+# -include-pch and --sysroot= must be listed before -include and --sysroot
+# respectively because the latter is a prefix of the former (and the algorithm
+# checks prefixes).
 INCLUDE_FLAGS = [ '-isystem', '-I', '-iquote', '-isysroot', '--sysroot',
-                  '-gcc-toolchain', '-include', '-include-pch', '-iframework',
+                  '-gcc-toolchain', '-include-pch', '-include', '-iframework',
                   '-F', '-imacros' ]
-
-# --sysroot= must be first (or at least, before --sysroot) because the latter is
-# a prefix of the former (and the algorithm checks prefixes)
 PATH_FLAGS =  [ '--sysroot=' ] + INCLUDE_FLAGS
 
 # We need to remove --fcolor-diagnostics because it will cause shell escape

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -576,6 +576,10 @@ def MakeRelativePathsInFlagsAbsolute_test():
       'flags':  [ '-isysroot', '/test' ],
       'expect': [ '-isysroot', os.path.normpath( '/test' ) ],
     },
+    {
+      'flags':  [ '-include-pch', '/test' ],
+      'expect': [ '-include-pch', os.path.normpath( '/test' ) ],
+    },
 
     # Already absolute, single arguments
     {
@@ -592,7 +596,11 @@ def MakeRelativePathsInFlagsAbsolute_test():
     },
     {
       'flags':  [ '-isysroot/test' ],
-      'expect': [ '-isysroot' +  os.path.normpath( '/test' ) ],
+      'expect': [ '-isysroot' + os.path.normpath( '/test' ) ],
+    },
+    {
+      'flags':  [ '-include-pch/test' ],
+      'expect': [ '-include-pch' + os.path.normpath( '/test' ) ],
     },
 
     # Already absolute, double-dash arguments
@@ -611,6 +619,10 @@ def MakeRelativePathsInFlagsAbsolute_test():
     {
       'flags':  [ '--sysroot=/test' ],
       'expect': [ '--sysroot=' + os.path.normpath( '/test' ) ],
+    },
+    {
+      'flags':  [ '--include-pch=/test' ],
+      'expect': [ '--include-pch=/test' ],
     },
 
     # Relative, positional arguments
@@ -632,6 +644,11 @@ def MakeRelativePathsInFlagsAbsolute_test():
     {
       'flags':  [ '-isysroot', 'test' ],
       'expect': [ '-isysroot', os.path.normpath( '/test/test' ) ],
+      'wd':     '/test',
+    },
+    {
+      'flags':  [ '-include-pch', 'test' ],
+      'expect': [ '-include-pch', os.path.normpath( '/test/test' ) ],
       'wd':     '/test',
     },
 
@@ -656,6 +673,11 @@ def MakeRelativePathsInFlagsAbsolute_test():
       'expect': [ '-isysroot' + os.path.normpath( '/test/test' ) ],
       'wd':     '/test',
     },
+    {
+      'flags':  [ '-include-pchtest' ],
+      'expect': [ '-include-pch' + os.path.normpath( '/test/test' ) ],
+      'wd':     '/test',
+    },
 
     # Already absolute, double-dash arguments
     {
@@ -676,6 +698,11 @@ def MakeRelativePathsInFlagsAbsolute_test():
     {
       'flags':  [ '--sysroot=test' ],
       'expect': [ '--sysroot=' + os.path.normpath( '/test/test' ) ],
+      'wd':     '/test',
+    },
+    {
+      'flags':  [ '--include-pch=test' ],
+      'expect': [ '--include-pch=test' ],
       'wd':     '/test',
     },
   ]


### PR DESCRIPTION
Like `--sysroot=`, the `-include-pch` flag must be listed before `-include` because the latter is a prefix of the former and the `_MakeRelativePathsInFlagsAbsolute` function checks prefixes in the list order to extract paths.

Fixes https://github.com/Valloric/ycmd/issues/782.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/783)
<!-- Reviewable:end -->
