### PR TITLE
[READY] Expand Rust source path

### DIFF
--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -128,17 +128,11 @@ class RustCompleter( Completer ):
     Attempt to read user option for rust_src_path. Fallback to environment
     variable if it's not provided.
     """
-    rust_src_path = self.user_options[ 'rust_src_path' ]
+    rust_src_path = ( self.user_options[ 'rust_src_path' ] or
+                      os.environ.get( 'RUST_SRC_PATH' ) )
 
-    # Early return if user provided config
     if rust_src_path:
-      return rust_src_path
-
-    # Fall back to environment variable
-    env_key = 'RUST_SRC_PATH'
-    if env_key in os.environ:
-      return os.environ[ env_key ]
-
+      return os.path.expanduser( os.path.expandvars( rust_src_path ) )
     return None
 
 


### PR DESCRIPTION
The `rust_src_path` option provided by the user may contain a `~` or an environment variable so we should expand it. See PR https://github.com/Valloric/YouCompleteMe/pull/2695.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/784)
<!-- Reviewable:end -->
