### PR TITLE
[READY] Let ycmd check rustup configured path as the last means to finding rust src path

### DIFF
--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -22,7 +22,8 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from ycmd.utils import ToBytes, SetEnviron, ProcessIsRunning, urljoin
+from ycmd.utils import ( FindExecutable, ToUnicode, ToBytes, SetEnviron,
+                         ProcessIsRunning, urljoin )
 from ycmd.completers.completer import Completer
 from ycmd import responses, utils, hmac_utils
 
@@ -35,6 +36,7 @@ import base64
 import binascii
 import threading
 import os
+import subprocess
 
 from os import path as p
 
@@ -64,6 +66,16 @@ ERROR_FROM_RACERD_MESSAGE = (
   'See YCM docs for details.' )
 
 LOGFILE_FORMAT = 'racerd_{port}_{std}_'
+
+
+def _GetRustSysroot( rustc_exec ):
+  return ToUnicode( utils.SafePopen( [ rustc_exec,
+                                        '--print',
+                                        'sysroot' ],
+                                      stdin_windows = subprocess.PIPE,
+                                      stdout = subprocess.PIPE,
+                                      stderr = subprocess.PIPE )
+                              .communicate()[ 0 ].rstrip() )
 
 
 def FindRacerdBinary( user_options ):
@@ -127,13 +139,28 @@ class RustCompleter( Completer ):
     """
     Attempt to read user option for rust_src_path. Fallback to environment
     variable if it's not provided.
+    Finally try to be smart and figure out the path assuming the user set up
+    rust by the means of rustup.
     """
     rust_src_path = ( self.user_options[ 'rust_src_path' ] or
                       os.environ.get( 'RUST_SRC_PATH' ) )
 
     if rust_src_path:
       return os.path.expanduser( os.path.expandvars( rust_src_path ) )
-    return None
+
+    # Try to figure out the src path using rustup
+    rustc_executable = FindExecutable( 'rustc' )
+    if not rustc_executable:
+      return None
+
+    rust_sysroot = _GetRustSysroot( rustc_executable )
+    rust_src_path = p.join( rust_sysroot,
+                            'lib',
+                            'rustlib',
+                            'src',
+                            'rust',
+                            'src' )
+    return rust_src_path if p.isdir( rust_src_path ) else None
 
 
   def SupportedFiletypes( self ):

--- a/ycmd/tests/rust/get_completions_test.py
+++ b/ycmd/tests/rust/get_completions_test.py
@@ -54,9 +54,12 @@ def GetCompletions_Basic_test( app ):
                           CompletionEntryMatcher( 'build_shuttle' ) ) )
 
 
-@SharedYcmd
+@IsolatedYcmd()
+@patch( 'ycmd.completers.rust.rust_completer._GetRustSysroot',
+        return_value = '/non/existing/rust/src/path' )
 def GetCompletions_WhenStandardLibraryCompletionFails_MentionRustSrcPath_test(
-  app ):
+  app, *args ):
+  WaitUntilCompleterServerReady( app, 'rust' )
   filepath = PathToTestFile( 'std_completions.rs' )
   contents = ReadFile( filepath )
 
@@ -74,8 +77,11 @@ def GetCompletions_WhenStandardLibraryCompletionFails_MentionRustSrcPath_test(
                ErrorMatcher( RuntimeError, ERROR_FROM_RACERD_MESSAGE ) )
 
 
-@SharedYcmd
-def GetCompletions_WhenNoCompletionsFound_MentionRustSrcPath_test( app ):
+@IsolatedYcmd()
+@patch( 'ycmd.completers.rust.rust_completer._GetRustSysroot',
+        return_value = '/non/existing/rust/src/path' )
+def GetCompletions_WhenNoCompletionsFound_MentionRustSrcPath_test( app, *args ):
+  WaitUntilCompleterServerReady( app, 'rust' )
   filepath = PathToTestFile( 'test.rs' )
   contents = ReadFile( filepath )
 
@@ -132,3 +138,41 @@ def GetCompletions_NonExistingRustSrcPathFromEnvironmentVariable_test( app ):
   assert_that( response,
                ErrorMatcher( RuntimeError,
                              NON_EXISTING_RUST_SOURCES_PATH_MESSAGE ) )
+
+
+@IsolatedYcmd()
+@patch( 'ycmd.completers.rust.rust_completer.FindExecutable',
+        return_value = None )
+def GetCompletions_WhenRustcNotFound_MentionRustSrcPath_test( app, *args ):
+  WaitUntilCompleterServerReady( app, 'rust' )
+  filepath = PathToTestFile( 'test.rs' )
+  contents = ReadFile( filepath )
+
+  completion_data = BuildRequest( filepath = filepath,
+                                  filetype = 'rust',
+                                  contents = contents,
+                                  force_semantic = True,
+                                  line_num = 1,
+                                  column_num = 1 )
+
+  response = app.post_json( '/completions',
+                            completion_data,
+                            expect_errors = True ).json
+  assert_that( response,
+               ErrorMatcher( RuntimeError, ERROR_FROM_RACERD_MESSAGE ) )
+
+
+@IsolatedYcmd()
+@patch( 'ycmd.completers.rust.rust_completer._GetRustSysroot',
+        return_value = PathToTestFile( 'rustup-toolchain' ) )
+def GetCompletions_RustupPathHeuristics_test( app, *args ):
+  request_data = BuildRequest( filetype = 'rust' )
+
+  assert_that( app.post_json( '/debug_info', request_data ).json,
+               has_entry( 'completer', has_entry( 'items', has_items(
+                 has_entry( 'value', PathToTestFile( 'rustup-toolchain',
+                                                     'lib',
+                                                     'rustlib',
+                                                     'src',
+                                                     'rust',
+                                                     'src' ) ) ) ) ) )


### PR DESCRIPTION
In Valloric/YouCompleteMe#2379 there was talk about enabling ycmd to check rust src path provided by rustup.

This allows users to have rust completion with zero ycmd configuration.

Tests are not included because tests themselves should behave differently based on how rustup was used and I'm not sure how to test that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/785)
<!-- Reviewable:end -->
