### PR TITLE
Support using Python embedded distribution.

### DIFF
--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -28,6 +28,7 @@ import os
 import re
 import sys
 
+PYTHON_STDLIB_ZIP_REGEX = re.compile( "python[23][0-9].zip" )
 CORE_MISSING_ERROR_REGEX = re.compile( "No module named '?ycm_core'?" )
 CORE_PYTHON2_ERROR_REGEX = re.compile(
   'dynamic module does not define (?:init|module export) '
@@ -145,7 +146,8 @@ def PathToNearestThirdPartyFolder( path ):
 
 
 def IsStandardLibraryFolder( path ):
-  return os.path.isfile( os.path.join( path, 'os.py' ) )
+  return (os.path.isfile( path ) and PYTHON_STDLIB_ZIP_REGEX.match( os.path.basename( path ) )) \
+          or os.path.isfile( os.path.join( path, 'os.py' ) )
 
 
 def IsVirtualEnvLibraryFolder( path ):

--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -146,9 +146,9 @@ def PathToNearestThirdPartyFolder( path ):
 
 
 def IsStandardLibraryFolder( path ):
-  return (os.path.isfile( path ) \
-          and PYTHON_STDLIB_ZIP_REGEX.match( os.path.basename( path ) )) \
-         or os.path.isfile( os.path.join( path, 'os.py' ) )
+  return ( ( os.path.isfile( path )
+             and PYTHON_STDLIB_ZIP_REGEX.match( os.path.basename( path ) ) )
+           or os.path.isfile( os.path.join( path, 'os.py' ) ) )
 
 
 def IsVirtualEnvLibraryFolder( path ):

--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -146,8 +146,9 @@ def PathToNearestThirdPartyFolder( path ):
 
 
 def IsStandardLibraryFolder( path ):
-  return (os.path.isfile( path ) and PYTHON_STDLIB_ZIP_REGEX.match( os.path.basename( path ) )) \
-          or os.path.isfile( os.path.join( path, 'os.py' ) )
+  return (os.path.isfile( path ) \
+          and PYTHON_STDLIB_ZIP_REGEX.match( os.path.basename( path ) )) \
+         or os.path.isfile( os.path.join( path, 'os.py' ) )
 
 
 def IsVirtualEnvLibraryFolder( path ):

--- a/ycmd/tests/server_utils_test.py
+++ b/ycmd/tests/server_utils_test.py
@@ -31,6 +31,7 @@ import sys
 
 from ycmd.server_utils import ( AddNearestThirdPartyFoldersToSysPath,
                                 CompatibleWithCurrentCore,
+                                GetStandardLibraryIndexInSysPath,
                                 PathToNearestThirdPartyFolder )
 from ycmd.tests import PathToTestFile
 
@@ -216,3 +217,30 @@ def AddNearestThirdPartyFoldersToSysPath_IgnoreVirtualEnvLibrary_test( *args ):
     os.path.join( DIR_OF_THIRD_PARTY, 'python-future', 'src' ),
     PathToTestFile( 'python-future', 'another', 'path' )
   ) )
+
+
+@patch( 'sys.path', [
+  PathToTestFile( 'python-future', 'some', 'path' ),
+  PathToTestFile( 'python-future', 'another', 'path' ) ] )
+def GetStandardLibraryIndexInSysPath_ErrorIfNoStandardLibrary_test( *args ):
+  assert_that(
+    calling( GetStandardLibraryIndexInSysPath ),
+    raises( RuntimeError,
+            'Could not find standard library path in Python path.' ) )
+
+
+@patch( 'sys.path', [
+  PathToTestFile( 'python-future', 'some', 'path' ),
+  PathToTestFile( 'python-future', 'standard_library' ),
+  PathToTestFile( 'python-future', 'another', 'path' ) ] )
+def GetStandardLibraryIndexInSysPath_FindFullStandardLibrary_test( *args ):
+  assert_that( GetStandardLibraryIndexInSysPath(), equal_to( 1 ) )
+
+
+@patch( 'sys.path', [
+  PathToTestFile( 'python-future', 'some', 'path' ),
+  PathToTestFile( 'python-future', 'embedded_standard_library',
+                                   'python35.zip' ),
+  PathToTestFile( 'python-future', 'another', 'path' ) ] )
+def GetStandardLibraryIndexInSysPath_FindEmbeddedStandardLibrary_test( *args ):
+  assert_that( GetStandardLibraryIndexInSysPath(), equal_to( 1 ) )


### PR DESCRIPTION
See https://docs.python.org/3/using/windows.html#embedded-distribution

In the embedded distribution, the Python standard library is provided as
a zip archive containing pre-compiled and optimized .pyc files.  This
means that looking for 'os.py' to determine the standard library path
doesn't work.

This patch supports locating the standard library path when an embedded
distribution is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/786)
<!-- Reviewable:end -->
