### PR TITLE
Allow gcc 4.8 to be used

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -115,7 +115,7 @@ endif()
 # Determining the presence of C++11 support in the compiler
 set( CPP11_AVAILABLE false )
 if ( CMAKE_COMPILER_IS_GNUCXX )
-  if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9 )
+  if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8 )
     set( CPP11_AVAILABLE true )
   endif()
 elseif( COMPILER_IS_CLANG )


### PR DESCRIPTION
gcc 4.8 supports c++11 (tested on centos6)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/792)
<!-- Reviewable:end -->
