### PR TITLE
[READY] Fix compilation with Clang 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ before_install:
 install:
   # source because it sets up env vars on some platforms
   - source ci/travis/travis_install.sh
-compiler:
-  - gcc
 script:
   - ci/travis/travis_script.sh
 after_success:
@@ -21,18 +19,22 @@ env:
     # Travis can run out of RAM, so we need to be careful here.
     - YCM_CORES=3
     - COVERAGE=true
+    - USE_CLANG_COMPLETER=true
   matrix:
-    - USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6
-    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6
-    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.7
-    - USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=3.3
-    - YCM_BENCHMARK=true YCMD_PYTHON_VERSION=3.3 COVERAGE=false
+    - YCMD_PYTHON_VERSION=2.6 USE_CLANG_COMPLETER=false
+    - YCMD_PYTHON_VERSION=2.6
+    - YCMD_PYTHON_VERSION=2.7
+    - YCMD_PYTHON_VERSION=3.3
+    - YCMD_PYTHON_VERSION=3.3 YCM_COMPILER=clang
+    - YCMD_PYTHON_VERSION=3.3 YCM_BENCHMARK=true COVERAGE=false
 matrix:
   exclude:
     - os: osx
-      env: USE_CLANG_COMPLETER=false YCMD_PYTHON_VERSION=2.6
+      env: YCMD_PYTHON_VERSION=2.6 USE_CLANG_COMPLETER=false
     - os: osx
-      env: USE_CLANG_COMPLETER=true YCMD_PYTHON_VERSION=2.6
+      env: YCMD_PYTHON_VERSION=2.6
+    - os: osx
+      env: YCMD_PYTHON_VERSION=3.3 YCM_COMPILER=clang
 addons:
   # If this doesn't make much sense to you, see the travis docs:
   #    https://docs.travis-ci.com/user/migrating-from-legacy/
@@ -49,6 +51,9 @@ addons:
      # 4.9 is the first version of GCC with good enough C++11 support; in
      # particular regex support.
      - g++-4.9
+     # Install Clang 3.4 and its standard library.
+     - clang
+     - libc++-dev
      # Required to build the OmniSharp server.
      - mono-devel
      - ninja-build

--- a/ci/travis/travis_install.linux.sh
+++ b/ci/travis/travis_install.linux.sh
@@ -3,10 +3,17 @@
 # We can't use sudo, so we have to approximate the behaviour of the following:
 # $ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
 
-mkdir ${HOME}/bin
+mkdir -p ${HOME}/bin
 
-ln -s /usr/bin/g++-4.9 ${HOME}/bin/c++
-ln -s /usr/bin/gcc-4.9 ${HOME}/bin/cc
+if [ "${YCM_COMPILER}" == "clang" ]; then
+  ln -s /usr/bin/clang++ ${HOME}/bin/c++
+  ln -s /usr/bin/clang ${HOME}/bin/cc
+  # Tell CMake to compile with libc++ when using Clang.
+  export EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DHAS_LIBCXX11=ON"
+else
+  ln -s /usr/bin/g++-4.9 ${HOME}/bin/c++
+  ln -s /usr/bin/gcc-4.9 ${HOME}/bin/cc
+fi
 ln -s /usr/bin/gcov-4.9 ${HOME}/bin/gcov
 
 export PATH=${HOME}/bin:${PATH}

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -113,14 +113,14 @@ const char *const NOT_FOUND = "YCMFOOBAR_NOT_FOUND";
 FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
   const fs::path &path_to_tag_file ) {
   std::vector< std::string > tags_file_contents;
+  FiletypeIdentifierMap filetype_identifier_map;
 
   try {
     tags_file_contents = ReadUtf8File( path_to_tag_file );
   } catch ( ... ) {
-    return {};
+    return filetype_identifier_map;
   }
 
-  FiletypeIdentifierMap filetype_identifier_map;
   std::smatch matches;
   const std::regex expression( TAG_REGEX, std::regex::optimize );
 


### PR DESCRIPTION
Compiling with Clang 3.4 results in the following error:
```
cpp/ycm/IdentifierUtils.cpp:120:12: error: chosen constructor is explicit in copy-initialization
    return {};
           ^~
/usr/include/c++/v1/map:838:14: note: constructor declared here
    explicit map(const key_compare& __comp = key_compare())
             ^
1 error generated.
```
See issue https://github.com/Valloric/ycmd/issues/791.

As Valloric suggested, this PR adds a Linux build with Clang 3.4 on Travis. We are supposed to support Clang 3.3 but 3.4 is the oldest version available on Travis.

I'll update the PR with the fix once the Clang build failed.

Fixes #791.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/793)
<!-- Reviewable:end -->
