### PR TITLE
[READY] Add an option to make relative paths in flags from extra conf absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ The return value must be one of the following:
 
   - `flags`: (mandatory) a list of compiler flags.
 
+  - `include_paths_relative_to_dir': (optional) the directory to which the
+    include paths in the list of flags are relative. Defaults to ycmd working
+    directory.
+
   - `do_cache`: (optional) a boolean indicating whether or not the result of
     this call (i.e. the list of flags) should be cached for this file name.
     Defaults to `True`. If unsure, the default is almost always correct.

--- a/cpp/ycm/.ycm_extra_conf.py
+++ b/cpp/ycm/.ycm_extra_conf.py
@@ -106,35 +106,6 @@ def DirectoryOfThisScript():
   return os.path.dirname( os.path.abspath( __file__ ) )
 
 
-def MakeRelativePathsInFlagsAbsolute( flags, working_directory ):
-  if not working_directory:
-    return list( flags )
-  new_flags = []
-  make_next_absolute = False
-  path_flags = [ '-isystem', '-I', '-iquote', '--sysroot=' ]
-  for flag in flags:
-    new_flag = flag
-
-    if make_next_absolute:
-      make_next_absolute = False
-      if not flag.startswith( '/' ):
-        new_flag = os.path.join( working_directory, flag )
-
-    for path_flag in path_flags:
-      if flag == path_flag:
-        make_next_absolute = True
-        break
-
-      if flag.startswith( path_flag ):
-        path = flag[ len( path_flag ): ]
-        new_flag = path_flag + os.path.join( working_directory, path )
-        break
-
-    if new_flag:
-      new_flags.append( new_flag )
-  return new_flags
-
-
 def IsHeaderFile( filename ):
   extension = os.path.splitext( filename )[ 1 ]
   return extension in [ '.h', '.hxx', '.hpp', '.hh' ]
@@ -159,26 +130,29 @@ def GetCompilationInfoForFile( filename ):
 
 
 def FlagsForFile( filename, **kwargs ):
-  if database:
-    # Bear in mind that compilation_info.compiler_flags_ does NOT return a
-    # python list, but a "list-like" StringVec object
-    compilation_info = GetCompilationInfoForFile( filename )
-    if not compilation_info:
-      return None
+  if not database:
+    return {
+      'flags': flags,
+      'include_paths_relative_to_dir': DirectoryOfThisScript()
+    }
 
-    final_flags = MakeRelativePathsInFlagsAbsolute(
-      compilation_info.compiler_flags_,
-      compilation_info.compiler_working_dir_ )
+  compilation_info = GetCompilationInfoForFile( filename )
+  if not compilation_info:
+    return None
 
-    # NOTE: This is just for YouCompleteMe; it's highly likely that your project
-    # does NOT need to remove the stdlib flag. DO NOT USE THIS IN YOUR
-    # ycm_extra_conf IF YOU'RE NOT 100% SURE YOU NEED IT.
-    try:
-      final_flags.remove( '-stdlib=libc++' )
-    except ValueError:
-      pass
-  else:
-    relative_to = DirectoryOfThisScript()
-    final_flags = MakeRelativePathsInFlagsAbsolute( flags, relative_to )
+  # Bear in mind that compilation_info.compiler_flags_ does NOT return a
+  # python list, but a "list-like" StringVec object.
+  final_flags = list( compilation_info.compiler_flags_ )
 
-  return { 'flags': final_flags }
+  # NOTE: This is just for YouCompleteMe; it's highly likely that your project
+  # does NOT need to remove the stdlib flag. DO NOT USE THIS IN YOUR
+  # ycm_extra_conf IF YOU'RE NOT 100% SURE YOU NEED IT.
+  try:
+    final_flags.remove( '-stdlib=libc++' )
+  except ValueError:
+    pass
+
+  return {
+    'flags': final_flags,
+    'include_paths_relative_to_dir': compilation_info.compiler_working_dir_
+  }

--- a/examples/.ycm_extra_conf.py
+++ b/examples/.ycm_extra_conf.py
@@ -70,35 +70,6 @@ def DirectoryOfThisScript():
   return os.path.dirname( os.path.abspath( __file__ ) )
 
 
-def MakeRelativePathsInFlagsAbsolute( flags, working_directory ):
-  if not working_directory:
-    return list( flags )
-  new_flags = []
-  make_next_absolute = False
-  path_flags = [ '-isystem', '-I', '-iquote', '--sysroot=' ]
-  for flag in flags:
-    new_flag = flag
-
-    if make_next_absolute:
-      make_next_absolute = False
-      if not flag.startswith( '/' ):
-        new_flag = os.path.join( working_directory, flag )
-
-    for path_flag in path_flags:
-      if flag == path_flag:
-        make_next_absolute = True
-        break
-
-      if flag.startswith( path_flag ):
-        path = flag[ len( path_flag ): ]
-        new_flag = path_flag + os.path.join( working_directory, path )
-        break
-
-    if new_flag:
-      new_flags.append( new_flag )
-  return new_flags
-
-
 def IsHeaderFile( filename ):
   extension = os.path.splitext( filename )[ 1 ]
   return extension in [ '.h', '.hxx', '.hpp', '.hh' ]
@@ -125,18 +96,19 @@ def GetCompilationInfoForFile( filename ):
 # This is the entry point; this function is called by ycmd to produce flags for
 # a file.
 def FlagsForFile( filename, **kwargs ):
-  if database:
-    # Bear in mind that compilation_info.compiler_flags_ does NOT return a
-    # python list, but a "list-like" StringVec object
-    compilation_info = GetCompilationInfoForFile( filename )
-    if not compilation_info:
-      return None
+  if not database:
+    return {
+      'flags': flags,
+      'include_paths_relative_to_dir': DirectoryOfThisScript()
+    }
 
-    final_flags = MakeRelativePathsInFlagsAbsolute(
-      compilation_info.compiler_flags_,
-      compilation_info.compiler_working_dir_ )
-  else:
-    relative_to = DirectoryOfThisScript()
-    final_flags = MakeRelativePathsInFlagsAbsolute( flags, relative_to )
+  compilation_info = GetCompilationInfoForFile( filename )
+  if not compilation_info:
+    return None
 
-  return { 'flags': final_flags }
+  # Bear in mind that compilation_info.compiler_flags_ does NOT return a
+  # python list, but a "list-like" StringVec object.
+  return {
+    'flags': list( compilation_info.compiler_flags_ ),
+    'include_paths_relative_to_dir': compilation_info.compiler_working_dir_
+  }

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -290,9 +290,15 @@ def _CallExtraConfFlagsForFile( module, filename, client_data ):
   # For the sake of backwards compatibility, we need to first check whether the
   # FlagsForFile function in the extra conf module even allows keyword args.
   if inspect.getargspec( module.FlagsForFile ).keywords:
-    return module.FlagsForFile( filename, client_data = client_data )
+    results = module.FlagsForFile( filename, client_data = client_data )
   else:
-    return module.FlagsForFile( filename )
+    results = module.FlagsForFile( filename )
+
+  results[ 'flags' ] = _MakeRelativePathsInFlagsAbsolute(
+      results[ 'flags' ],
+      results.get( 'include_paths_relative_to_dir' ) )
+
+  return results
 
 
 def _SysRootSpecifedIn( flags ):


### PR DESCRIPTION
Since PR https://github.com/Valloric/ycmd/pull/680, all the infrastructure is here to convert any relative paths in the list of flags from the `.ycm_extra_conf.py` file to absolute ones. We just need to use the `_MakeRelativePathsInFlagsAbsolute` function.

This PR adds a new optional key `working_directory` to the dictionary returned by the `FlagsForFile` function in the `.ycm_extra_conf.py` file. This option allows specifying the working directory i.e. the directory for which the paths in the list of flags are relative to.

Update YCM's own `.ycm_extra_conf.py` file to reflect this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/795)
<!-- Reviewable:end -->
