### PR TITLE
[READY] Fix virtualenv prefix in build script

### DIFF
--- a/build.py
+++ b/build.py
@@ -146,8 +146,19 @@ def CheckCall( args, **kwargs ):
     sys.exit( error.returncode )
 
 
+def GetGlobalPythonPrefix():
+  # In a virtualenv, sys.real_prefix points to the parent Python prefix.
+  if hasattr( sys, 'real_prefix' ):
+    return sys.real_prefix
+  # In a pyvenv (only available on Python 3), sys.base_prefix points to the
+  # parent Python prefix. Outside a pyvenv, it is equal to sys.prefix.
+  if PY_MAJOR >= 3:
+    return sys.base_prefix
+  return sys.prefix
+
+
 def GetPossiblePythonLibraryDirectories():
-  prefix = sys.base_prefix if PY_MAJOR >= 3 else sys.prefix
+  prefix = GetGlobalPythonPrefix()
 
   if OnWindows():
     return [ p.join( prefix, 'libs' ) ]


### PR DESCRIPTION
In a virtualenv, `sys.prefix` points to the virtualenv directory. Use `sys.real_prefix` instead.

Fixes #798.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/799)
<!-- Reviewable:end -->
