### PR TITLE
[READY] Write python used during build before installing completers

### DIFF
--- a/build.py
+++ b/build.py
@@ -525,6 +525,7 @@ def Main():
   args = ParseArguments()
   ExitIfYcmdLibInUseOnWindows()
   BuildYcmdLib( args )
+  WritePythonUsedDuringBuild()
   if args.omnisharp_completer or args.all_completers:
     BuildOmniSharp()
   if args.gocode_completer or args.all_completers:
@@ -533,7 +534,6 @@ def Main():
     SetUpTern()
   if args.racer_completer or args.all_completers:
     BuildRacerd()
-  WritePythonUsedDuringBuild()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If ycmd compilation is successful but installing a completer fails, we don't create the `PYTHON_USED_DURING_BUILDING` file. This can be an issue if the user gives up on the completer installation and the client uses the Python from this file to start ycmd (like YCM does). This could explain issue https://github.com/Valloric/YouCompleteMe/issues/2729.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/808)
<!-- Reviewable:end -->
