### PR TITLE
[READY] Support unknown languages from tags

### DIFF
--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -106,8 +106,6 @@ const std::unordered_map < const char *,
         { "YACC"       , "yacc"       }
       };
 
-const char *const NOT_FOUND = "YCMFOOBAR_NOT_FOUND";
-
 }  // unnamed namespace
 
 
@@ -135,10 +133,7 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
     std::string language( matches[ 3 ] );
     std::string filetype = FindWithDefault( LANG_TO_FILETYPE,
                                             language.c_str(),
-                                            NOT_FOUND );
-
-    if ( filetype == NOT_FOUND )
-      continue;
+                                            Lowercase( language ).c_str() );
 
     std::string identifier( matches[ 1 ] );
     fs::path path( matches[ 2 ].str() );

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -119,6 +119,12 @@ char Lowercase( char letter ) {
   return letter;
 }
 
+std::string Lowercase( const std::string &text ) {
+  std::string result;
+  for ( char letter : text )
+    result.push_back( Lowercase( letter ) );
+  return result;
+}
 
 char Uppercase( char letter ) {
   if ( IsLowercase( letter ) )

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -87,6 +87,7 @@ YCM_DLL_EXPORT bool IsLowercase( char letter );
 YCM_DLL_EXPORT bool IsLowercase( const std::string &text );
 YCM_DLL_EXPORT bool IsUppercase( char letter );
 YCM_DLL_EXPORT char Lowercase( char letter );
+YCM_DLL_EXPORT std::string Lowercase( const std::string &text );
 YCM_DLL_EXPORT char Uppercase( char letter );
 YCM_DLL_EXPORT bool HasUppercase( const std::string &text );
 YCM_DLL_EXPORT char SwapCase( char letter );

--- a/cpp/ycm/tests/IdentifierUtils_test.cpp
+++ b/cpp/ycm/tests/IdentifierUtils_test.cpp
@@ -49,7 +49,14 @@ TEST( IdentifierUtilsTest, ExtractIdentifiersFromTagsFileWorks ) {
   expected[ "c" ][ ( root / "foo" / "zoo" ).string() ].push_back( "Floo::goo" );
   expected[ "c" ][ ( root / "foo" / "goo maa" ).string() ].push_back( "!goo" );
 
+  expected[ "fakelang" ][ ( root / "foo" ).string() ].push_back( "zoro" );
+
   expected[ "cs" ][ ( root / "m_oo" ).string() ].push_back( "#bleh" );
+
+  expected[ "foobar" ][ ( testfile_parent / "foo.bar" ).string() ]
+  .push_back( "API" );
+  expected[ "foobar" ][ ( testfile_parent / "foo.bar" ).string() ]
+  .push_back( "DELETE" );
 
   EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
                ContainerEq( expected ) );

--- a/cpp/ycm/tests/Utils_test.cpp
+++ b/cpp/ycm/tests/Utils_test.cpp
@@ -107,6 +107,8 @@ TEST( UtilsTest, Lowercase ) {
   EXPECT_EQ( Lowercase( 'A' ), 'a' );
   EXPECT_EQ( Lowercase( 'Z' ), 'z' );
   EXPECT_EQ( Lowercase( ';' ), ';' );
+
+  EXPECT_EQ( Lowercase( "lOwER_CasE" ), "lower_case" );
 }
 
 TEST( UtilsTest, Uppercase ) {

--- a/cpp/ycm/tests/testdata/basic.tags
+++ b/cpp/ycm/tests/testdata/basic.tags
@@ -13,3 +13,5 @@ Floo::goo	/foo/zoo	language:C
 !goo	/foo/goo maa	language:C
 zoro	/foo	language:fakelang
 #bleh	/m_oo	123ntoh;;;\"eu	language:C#	;\"
+API	foo.bar	/^        class TEST $/;"       c	language:FooBar
+DELETE	foo.bar	/^        DELETE:  =>$/;"   m	language:FooBar


### PR DESCRIPTION
When a language from a tags file is unknown, set the filetype to its name in lowercase. This allows the use of tags for custom languages.

Fixes #809.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/810)
<!-- Reviewable:end -->
