### PR TITLE
[READY] Replace UserOption with IsolatedYcmd

### DIFF
--- a/ycmd/tests/__init__.py
+++ b/ycmd/tests/__init__.py
@@ -60,20 +60,32 @@ def SharedYcmd( test ):
   return Wrapper
 
 
-def IsolatedYcmd( test ):
+def IsolatedYcmd( custom_options = {} ):
   """Defines a decorator to be attached to tests of this package. This decorator
   passes a unique ycmd application as a parameter. It should be used on tests
   that change the server state in a irreversible way (ex: a semantic subserver
   is stopped or restarted) or expect a clean state (ex: no semantic subserver
-  started, no .ycm_extra_conf.py loaded, etc).
+  started, no .ycm_extra_conf.py loaded, etc). Use the optional parameter
+  |custom_options| to give additional options and/or override the default ones.
 
-  Do NOT attach it to test generators but directly to the yielded tests."""
-  @functools.wraps( test )
-  def Wrapper( *args, **kwargs ):
-    old_server_state = handlers._server_state
+  Do NOT attach it to test generators but directly to the yielded tests.
 
-    try:
-      test( SetUpApp(), *args, **kwargs )
-    finally:
-      handlers._server_state = old_server_state
-  return Wrapper
+  Example usage:
+
+    from ycmd.tests import IsolatedYcmd
+
+    @IsolatedYcmd( { 'auto_trigger': 0 } )
+    def CustomAutoTrigger_test( app ):
+        ...
+  """
+  def Decorator( test ):
+    @functools.wraps( test )
+    def Wrapper( *args, **kwargs ):
+      old_server_state = handlers._server_state
+      app = SetUpApp( custom_options )
+      try:
+        test( app, *args, **kwargs )
+      finally:
+        handlers._server_state = old_server_state
+    return Wrapper
+  return Decorator

--- a/ycmd/tests/clang/__init__.py
+++ b/ycmd/tests/clang/__init__.py
@@ -65,24 +65,34 @@ def SharedYcmd( test ):
   return Wrapper
 
 
-def IsolatedYcmd( test ):
+def IsolatedYcmd( custom_options = {} ):
   """Defines a decorator to be attached to tests of this package. This decorator
   passes a unique ycmd application as a parameter. It should be used on tests
   that change the server state in a irreversible way (ex: a semantic subserver
   is stopped or restarted) or expect a clean state (ex: no semantic subserver
-  started, no .ycm_extra_conf.py loaded, etc).
+  started, no .ycm_extra_conf.py loaded, etc). Use the optional parameter
+  |custom_options| to give additional options and/or override the default ones.
 
-  Do NOT attach it to test generators but directly to the yielded tests."""
-  @functools.wraps( test )
-  def Wrapper( *args, **kwargs ):
-    old_server_state = handlers._server_state
+  Do NOT attach it to test generators but directly to the yielded tests.
 
-    try:
-      test( SetUpApp(), *args, **kwargs )
-    finally:
-      handlers._server_state = old_server_state
-  return Wrapper
+  Example usage:
 
+    from ycmd.tests.python import IsolatedYcmd
+
+    @IsolatedYcmd( { 'auto_trigger': 0 } )
+    def CustomAutoTrigger_test( app ):
+      ...
+  """
+  def Decorator( test ):
+    @functools.wraps( test )
+    def Wrapper( *args, **kwargs ):
+      old_server_state = handlers._server_state
+      try:
+        test( SetUpApp( custom_options ), *args, **kwargs )
+      finally:
+        handlers._server_state = old_server_state
+    return Wrapper
+  return Decorator
 
 
 @contextlib.contextmanager

--- a/ycmd/tests/clang/debug_info_test.py
+++ b/ycmd/tests/clang/debug_info_test.py
@@ -97,7 +97,7 @@ def DebugInfo_FlagsWhenNoExtraConfAndNoCompilationDatabase_test( app ):
   )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def DebugInfo_FlagsWhenExtraConfNotLoadedAndNoCompilationDatabase_test(
   app ):
 
@@ -122,7 +122,7 @@ def DebugInfo_FlagsWhenExtraConfNotLoadedAndNoCompilationDatabase_test(
   )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def DebugInfo_FlagsWhenNoExtraConfAndCompilationDatabaseLoaded_test( app ):
   with TemporaryClangTestDir() as tmp_dir:
     compile_commands = [
@@ -157,7 +157,7 @@ def DebugInfo_FlagsWhenNoExtraConfAndCompilationDatabaseLoaded_test( app ):
       )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def DebugInfo_FlagsWhenNoExtraConfAndInvalidCompilationDatabase_test( app ):
   with TemporaryClangTestDir() as tmp_dir:
     compile_commands = 'garbage'

--- a/ycmd/tests/clang/diagnostics_test.py
+++ b/ycmd/tests/clang/diagnostics_test.py
@@ -31,7 +31,7 @@ from ycmd.tests.test_utils import BuildRequest
 from ycmd.utils import ReadFile
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def Diagnostics_ZeroBasedLineAndColumn_test( app ):
   contents = """
 void foo() {
@@ -79,7 +79,7 @@ void foo() {
                   } ) ) )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def Diagnostics_SimpleLocationExtent_test( app ):
   contents = """
 void foo() {
@@ -111,7 +111,7 @@ void foo() {
                   } ) ) )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def Diagnostics_PragmaOnceWarningIgnored_test( app ):
   contents = """
 #pragma once
@@ -134,7 +134,7 @@ struct Foo {
   assert_that( response, empty() )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def Diagnostics_Works_test( app ):
   contents = """
 struct Foo {
@@ -161,7 +161,7 @@ struct Foo {
                has_entry( 'message', contains_string( "expected ';'" ) ) )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def Diagnostics_Multiline_test( app ):
   contents = """
 struct Foo {
@@ -189,7 +189,7 @@ int main() {
                has_entry( 'message', contains_string( "\n" ) ) )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def Diagnostics_FixIt_Available_test( app ):
   contents = ReadFile( PathToTestFile( 'FixIt_Clang_cpp11.cpp' ) )
 
@@ -222,7 +222,7 @@ def Diagnostics_FixIt_Available_test( app ):
   ) )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def Diagnostics_MultipleMissingIncludes_test( app ):
   contents = ReadFile( PathToTestFile( 'multiple_missing_includes.cc' ) )
 

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -35,7 +35,7 @@ from ycmd.completers.cpp.clang_completer import NO_COMPLETIONS_MESSAGE
 from ycmd.responses import UnknownExtraConf, NoExtraConfDetected
 from ycmd.tests.clang import IsolatedYcmd, PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import ( BuildRequest, CompletionEntryMatcher,
-                                    ErrorMatcher, UserOption, ExpectedFailure )
+                                    ErrorMatcher, ExpectedFailure )
 from ycmd.utils import ReadFile
 
 NO_COMPLETIONS_ERROR = ErrorMatcher( RuntimeError, NO_COMPLETIONS_MESSAGE )
@@ -284,7 +284,7 @@ def GetCompletions_FilteredNoResults_Fallback_test( app ):
   } )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def GetCompletions_WorksWithExplicitFlags_test( app ):
   app.post_json(
     '/ignore_extra_conf_file',
@@ -318,13 +318,12 @@ int main()
   eq_( 7, response_data[ 'completion_start_column' ] )
 
 
-@IsolatedYcmd
+@IsolatedYcmd( { 'auto_trigger': 0 } )
 def GetCompletions_NoCompletionsWhenAutoTriggerOff_test( app ):
-  with UserOption( 'auto_trigger', False ):
-    app.post_json(
-      '/ignore_extra_conf_file',
-      { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-    contents = """
+  app.post_json(
+    '/ignore_extra_conf_file',
+    { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
+  contents = """
 struct Foo {
   int x;
   int y;
@@ -338,19 +337,19 @@ int main()
 }
 """
 
-    completion_data = BuildRequest( filepath = '/foo.cpp',
-                                    filetype = 'cpp',
-                                    contents = contents,
-                                    line_num = 11,
-                                    column_num = 7,
-                                    compilation_flags = ['-x', 'c++'] )
+  completion_data = BuildRequest( filepath = '/foo.cpp',
+                                  filetype = 'cpp',
+                                  contents = contents,
+                                  line_num = 11,
+                                  column_num = 7,
+                                  compilation_flags = ['-x', 'c++'] )
 
-    results = app.post_json( '/completions',
-                             completion_data ).json[ 'completions' ]
-    assert_that( results, empty() )
+  results = app.post_json( '/completions',
+                           completion_data ).json[ 'completions' ]
+  assert_that( results, empty() )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def GetCompletions_UnknownExtraConfException_test( app ):
   filepath = PathToTestFile( 'basic.cpp' )
   completion_data = BuildRequest( filepath = filepath,
@@ -384,7 +383,7 @@ def GetCompletions_UnknownExtraConfException_test( app ):
                                      NoExtraConfDetected.__name__ ) ) )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def GetCompletions_WorksWhenExtraConfExplicitlyAllowed_test( app ):
   app.post_json(
     '/load_extra_conf_file',

--- a/ycmd/tests/cs/__init__.py
+++ b/ycmd/tests/cs/__init__.py
@@ -87,24 +87,35 @@ def SharedYcmd( test ):
   return Wrapper
 
 
-def IsolatedYcmd( test ):
+def IsolatedYcmd( custom_options = {} ):
   """Defines a decorator to be attached to tests of this package. This decorator
   passes a unique ycmd application as a parameter. It should be used on tests
   that change the server state in a irreversible way (ex: a semantic subserver
   is stopped or restarted) or expect a clean state (ex: no semantic subserver
-  started, no .ycm_extra_conf.py loaded, etc).
+  started, no .ycm_extra_conf.py loaded, etc). Use the optional parameter
+  |custom_options| to give additional options and/or override the default ones.
 
-  Do NOT attach it to test generators but directly to the yielded tests."""
-  @functools.wraps( test )
-  def Wrapper( *args, **kwargs ):
-    old_server_state = handlers._server_state
+  Do NOT attach it to test generators but directly to the yielded tests.
 
-    try:
-      app = SetUpApp()
-      app.post_json(
-        '/ignore_extra_conf_file',
-        { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
-      test( app, *args, **kwargs )
-    finally:
-      handlers._server_state = old_server_state
-  return Wrapper
+  Example usage:
+
+    from ycmd.tests.python import IsolatedYcmd
+
+    @IsolatedYcmd( { 'server_keep_logfiles': 1 } )
+    def CustomServerKeepLogfiles_test( app ):
+      ...
+  """
+  def Decorator( test ):
+    @functools.wraps( test )
+    def Wrapper( *args, **kwargs ):
+      old_server_state = handlers._server_state
+      app = SetUpApp( custom_options )
+      try:
+        app.post_json(
+          '/ignore_extra_conf_file',
+          { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
+        test( app, *args, **kwargs )
+      finally:
+        handlers._server_state = old_server_state
+    return Wrapper
+  return Decorator

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -29,13 +29,13 @@ from hamcrest import assert_that, has_entries, contains
 import pprint
 import os.path
 
+from ycmd import user_options_store
 from ycmd.tests.cs import ( IsolatedYcmd, PathToTestFile, SharedYcmd,
                             WrapOmniSharpServer )
 from ycmd.tests.test_utils import ( BuildRequest,
                                     ChunkMatcher,
                                     LocationMatcher,
                                     StopCompleterServer,
-                                    UserOption,
                                     WaitUntilCompleterServerReady )
 from ycmd.utils import ReadFile
 
@@ -498,51 +498,54 @@ def Subcommands_FixIt_Unicode_test( app ):
   } ), filepath = [ 'testy', 'Unicode.cs' ] )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def Subcommands_StopServer_NoErrorIfNotStarted_test( app ):
   filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
   StopCompleterServer( app, 'cs', filepath )
   # Success = no raise
 
 
-@IsolatedYcmd
-def StopServer_KeepLogFiles( app, keeping_log_files ):
-  with UserOption( 'server_keep_logfiles', keeping_log_files ):
-    filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
-    contents = ReadFile( filepath )
-    event_data = BuildRequest( filepath = filepath,
-                               filetype = 'cs',
-                               contents = contents,
-                               event_name = 'FileReadyToParse' )
+def StopServer_KeepLogFiles( app ):
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
+  contents = ReadFile( filepath )
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'cs',
+                             contents = contents,
+                             event_name = 'FileReadyToParse' )
 
-    app.post_json( '/event_notification', event_data )
-    WaitUntilCompleterServerReady( app, 'cs' )
+  app.post_json( '/event_notification', event_data )
+  WaitUntilCompleterServerReady( app, 'cs' )
 
-    event_data = BuildRequest( filetype = 'cs', filepath = filepath )
+  event_data = BuildRequest( filetype = 'cs', filepath = filepath )
 
-    response = app.post_json( '/debug_info', event_data ).json
+  response = app.post_json( '/debug_info', event_data ).json
 
-    logfiles = []
-    for server in response[ 'completer' ][ 'servers' ]:
-      logfiles.extend( server[ 'logfiles' ] )
+  logfiles = []
+  for server in response[ 'completer' ][ 'servers' ]:
+    logfiles.extend( server[ 'logfiles' ] )
 
-    try:
-      for logfile in logfiles:
-        ok_( os.path.exists( logfile ),
-             'Logfile should exist at {0}'.format( logfile ) )
-    finally:
-      StopCompleterServer( app, 'cs', filepath )
+  try:
+    for logfile in logfiles:
+      ok_( os.path.exists( logfile ),
+           'Logfile should exist at {0}'.format( logfile ) )
+  finally:
+    StopCompleterServer( app, 'cs', filepath )
 
-    if keeping_log_files:
-      for logfile in logfiles:
-        ok_( os.path.exists( logfile ),
-             'Logfile should still exist at {0}'.format( logfile ) )
-    else:
-      for logfile in logfiles:
-        ok_( not os.path.exists( logfile ),
-             'Logfile should no longer exist at {0}'.format( logfile ) )
+  if user_options_store.Value( 'server_keep_logfiles' ):
+    for logfile in logfiles:
+      ok_( os.path.exists( logfile ),
+           'Logfile should still exist at {0}'.format( logfile ) )
+  else:
+    for logfile in logfiles:
+      ok_( not os.path.exists( logfile ),
+           'Logfile should no longer exist at {0}'.format( logfile ) )
 
 
-def Subcommands_StopServer_KeepLogFiles_test():
-  yield StopServer_KeepLogFiles, True
-  yield StopServer_KeepLogFiles, False
+@IsolatedYcmd( { 'server_keep_logfiles': 1 } )
+def Subcommands_StopServer_KeepLogFiles_test( app ):
+  StopServer_KeepLogFiles( app )
+
+
+@IsolatedYcmd( { 'server_keep_logfiles': 0 } )
+def Subcommands_StopServer_DoNotKeepLogFiles_test( app ):
+  StopServer_KeepLogFiles( app )

--- a/ycmd/tests/extra_conf_store_test.py
+++ b/ycmd/tests/extra_conf_store_test.py
@@ -29,139 +29,126 @@ from hamcrest import ( assert_that, calling, equal_to, has_length, none, raises,
                        same_instance )
 from ycmd import extra_conf_store
 from ycmd.responses import UnknownExtraConf
-from ycmd.tests import PathToTestFile
-from ycmd.tests.test_utils import UserOption
+from ycmd.tests import IsolatedYcmd, PathToTestFile
 
 
-class ExtraConfStore_test():
+GLOBAL_EXTRA_CONF = PathToTestFile( 'extra_conf', 'global_extra_conf.py' )
+ERRONEOUS_EXTRA_CONF = PathToTestFile( 'extra_conf', 'erroneous_extra_conf.py' )
+NO_EXTRA_CONF = PathToTestFile( 'extra_conf', 'no_extra_conf.py' )
+PROJECT_EXTRA_CONF = PathToTestFile( 'extra_conf', 'project',
+                                     '.ycm_extra_conf.py' )
 
-  def setUp( self ):
-    extra_conf_store.Reset()
+
+@IsolatedYcmd()
+def ExtraConfStore_ModuleForSourceFile_UnknownExtraConf_test( app ):
+  filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
+  assert_that(
+    calling( extra_conf_store.ModuleForSourceFile ).with_args( filename ),
+    raises( UnknownExtraConf, 'Found .*\.ycm_extra_conf\.py\. Load?' )
+  )
 
 
-  def ModuleForSourceFile_UnknownExtraConf_test( self ):
-    filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
+@IsolatedYcmd( { 'confirm_extra_conf': 0 } )
+def ExtraConfStore_ModuleForSourceFile_NoConfirmation_test( app ):
+  filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
+  module = extra_conf_store.ModuleForSourceFile( filename )
+  assert_that( inspect.ismodule( module ) )
+  assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+
+
+@IsolatedYcmd( { 'extra_conf_globlist': [ PROJECT_EXTRA_CONF ] } )
+def ExtraConfStore_ModuleForSourceFile_Whitelisted_test( app ):
+  filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
+  module = extra_conf_store.ModuleForSourceFile( filename )
+  assert_that( inspect.ismodule( module ) )
+  assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+
+
+@IsolatedYcmd( { 'extra_conf_globlist': [ '!' + PROJECT_EXTRA_CONF ] } )
+def ExtraConfStore_ModuleForSourceFile_Blacklisted_test( app ):
+  filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
+  assert_that( extra_conf_store.ModuleForSourceFile( filename ), none() )
+
+
+@IsolatedYcmd( { 'global_ycm_extra_conf': GLOBAL_EXTRA_CONF } )
+def ExtraConfStore_ModuleForSourceFile_GlobalExtraConf_test( app ):
+  filename = PathToTestFile( 'extra_conf', 'some_file' )
+  module = extra_conf_store.ModuleForSourceFile( filename )
+  assert_that( inspect.ismodule( module ) )
+  assert_that( inspect.getfile( module ), equal_to( GLOBAL_EXTRA_CONF ) )
+
+
+@IsolatedYcmd( { 'global_ycm_extra_conf': NO_EXTRA_CONF } )
+@patch( 'ycmd.extra_conf_store._logger', autospec = True )
+def ExtraConfStore_CallGlobalExtraConfMethod_NoGlobalExtraConf_test( app,
+                                                                     logger ):
+  extra_conf_store._CallGlobalExtraConfMethod( 'SomeMethod' )
+  assert_that( logger.method_calls, has_length( 1 ) )
+  logger.debug.assert_called_with( 'No global extra conf, not calling method '
+                                   'SomeMethod' )
+
+
+@IsolatedYcmd( { 'global_ycm_extra_conf': GLOBAL_EXTRA_CONF } )
+@patch( 'ycmd.extra_conf_store._logger', autospec = True )
+def CallGlobalExtraConfMethod_NoMethodInGlobalExtraConf_test( app, logger ):
+  extra_conf_store._CallGlobalExtraConfMethod( 'MissingMethod' )
+  assert_that( logger.method_calls, has_length( 1 ) )
+  logger.debug.assert_called_with( 'Global extra conf not loaded or '
+                                   'no function MissingMethod' )
+
+
+@IsolatedYcmd( { 'global_ycm_extra_conf': GLOBAL_EXTRA_CONF } )
+@patch( 'ycmd.extra_conf_store._logger', autospec = True )
+def CallGlobalExtraConfMethod_NoExceptionFromMethod_test( app, logger ):
+  extra_conf_store._CallGlobalExtraConfMethod( 'NoException' )
+  assert_that( logger.method_calls, has_length( 1 ) )
+  logger.info.assert_called_with( 'Calling global extra conf method '
+                                  'NoException on conf file '
+                                  '{0}'.format( GLOBAL_EXTRA_CONF ) )
+
+
+@IsolatedYcmd( { 'global_ycm_extra_conf': GLOBAL_EXTRA_CONF } )
+@patch( 'ycmd.extra_conf_store._logger', autospec = True )
+def CallGlobalExtraConfMethod_CatchExceptionFromMethod_test( app, logger ):
+  extra_conf_store._CallGlobalExtraConfMethod( 'RaiseException' )
+  assert_that( logger.method_calls, has_length( 2 ) )
+  logger.info.assert_called_with( 'Calling global extra conf method '
+                                  'RaiseException on conf file '
+                                  '{0}'.format( GLOBAL_EXTRA_CONF ) )
+  logger.exception.assert_called_with(
+    'Error occurred while calling global extra conf method RaiseException '
+    'on conf file {0}'.format( GLOBAL_EXTRA_CONF ) )
+
+
+@IsolatedYcmd( { 'global_ycm_extra_conf': ERRONEOUS_EXTRA_CONF } )
+@patch( 'ycmd.extra_conf_store._logger', autospec = True )
+def CallGlobalExtraConfMethod_CatchExceptionFromExtraConf_test( app, logger ):
+  extra_conf_store._CallGlobalExtraConfMethod( 'NoException' )
+  assert_that( logger.method_calls, has_length( 1 ) )
+  logger.exception.assert_called_with( 'Error occurred while '
+                                       'loading global extra conf '
+                                       '{0}'.format( ERRONEOUS_EXTRA_CONF ) )
+
+
+@IsolatedYcmd()
+def Load_DoNotReloadExtraConf_NoForce_test( app ):
+  with patch( 'ycmd.extra_conf_store._ShouldLoad', return_value = True ):
+    module = extra_conf_store.Load( PROJECT_EXTRA_CONF )
+    assert_that( inspect.ismodule( module ) )
+    assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
     assert_that(
-      calling( extra_conf_store.ModuleForSourceFile ).with_args( filename ),
-      raises( UnknownExtraConf, 'Found .*\.ycm_extra_conf\.py\. Load?' )
+      extra_conf_store.Load( PROJECT_EXTRA_CONF ),
+      same_instance( module )
     )
 
 
-  def ModuleForSourceFile_NoConfirmation_test( self ):
-    filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
-    extra_conf_file = PathToTestFile( 'extra_conf', 'project',
-                                      '.ycm_extra_conf.py' )
-    with UserOption( 'confirm_extra_conf', 0 ):
-      module = extra_conf_store.ModuleForSourceFile( filename )
-      assert_that( inspect.ismodule( module ) )
-      assert_that( inspect.getfile( module ), equal_to( extra_conf_file ) )
-
-
-  def ModuleForSourceFile_Whitelisted_test( self ):
-    filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
-    extra_conf_file = PathToTestFile( 'extra_conf', 'project',
-                                      '.ycm_extra_conf.py' )
-    with UserOption( 'extra_conf_globlist', [ extra_conf_file ] ):
-      module = extra_conf_store.ModuleForSourceFile( filename )
-      assert_that( inspect.ismodule( module ) )
-      assert_that( inspect.getfile( module ), equal_to( extra_conf_file ) )
-
-
-  def ModuleForSourceFile_Blacklisted_test( self ):
-    filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
-    extra_conf_file = PathToTestFile( 'extra_conf', 'project',
-                                      '.ycm_extra_conf.py' )
-    with UserOption( 'extra_conf_globlist', [ '!' + extra_conf_file ] ):
-      assert_that( extra_conf_store.ModuleForSourceFile( filename ), none() )
-
-
-  def ModuleForSourceFile_GlobalExtraConf_test( self ):
-    filename = PathToTestFile( 'extra_conf', 'some_file' )
-    extra_conf_file = PathToTestFile( 'extra_conf', 'global_extra_conf.py' )
-    with UserOption( 'global_ycm_extra_conf', extra_conf_file ):
-      module = extra_conf_store.ModuleForSourceFile( filename )
-      assert_that( inspect.ismodule( module ) )
-      assert_that( inspect.getfile( module ), equal_to( extra_conf_file ) )
-
-
-  @patch( 'ycmd.extra_conf_store._logger', autospec = True )
-  def CallGlobalExtraConfMethod_NoGlobalExtraConf_test( self, logger ):
-    with UserOption( 'global_ycm_extra_conf',
-                     PathToTestFile( 'extra_conf', 'no_extra_conf.py' ) ):
-      extra_conf_store._CallGlobalExtraConfMethod( 'SomeMethod' )
-    assert_that( logger.method_calls, has_length( 1 ) )
-    logger.debug.assert_called_with( 'No global extra conf, not calling method '
-                                     'SomeMethod' )
-
-
-  @patch( 'ycmd.extra_conf_store._logger', autospec = True )
-  def CallGlobalExtraConfMethod_NoMethodInGlobalExtraConf_test( self, logger ):
-    with UserOption( 'global_ycm_extra_conf',
-                     PathToTestFile( 'extra_conf', 'global_extra_conf.py' ) ):
-      extra_conf_store._CallGlobalExtraConfMethod( 'MissingMethod' )
-    assert_that( logger.method_calls, has_length( 1 ) )
-    logger.debug.assert_called_with( 'Global extra conf not loaded or '
-                                     'no function MissingMethod' )
-
-
-  @patch( 'ycmd.extra_conf_store._logger', autospec = True )
-  def CallGlobalExtraConfMethod_NoExceptionFromMethod_test( self, logger ):
-    extra_conf_file = PathToTestFile( 'extra_conf', 'global_extra_conf.py' )
-    with UserOption( 'global_ycm_extra_conf', extra_conf_file ):
-      extra_conf_store._CallGlobalExtraConfMethod( 'NoException' )
-    assert_that( logger.method_calls, has_length( 1 ) )
-    logger.info.assert_called_with( 'Calling global extra conf method '
-                                    'NoException on conf file '
-                                    '{0}'.format( extra_conf_file ) )
-
-
-  @patch( 'ycmd.extra_conf_store._logger', autospec = True )
-  def CallGlobalExtraConfMethod_CatchExceptionFromMethod_test( self, logger ):
-    extra_conf_file = PathToTestFile( 'extra_conf', 'global_extra_conf.py' )
-    with UserOption( 'global_ycm_extra_conf', extra_conf_file ):
-      extra_conf_store._CallGlobalExtraConfMethod( 'RaiseException' )
-    assert_that( logger.method_calls, has_length( 2 ) )
-    logger.info.assert_called_with( 'Calling global extra conf method '
-                                    'RaiseException on conf file '
-                                    '{0}'.format( extra_conf_file ) )
-    logger.exception.assert_called_with(
-      'Error occurred while calling global extra conf method RaiseException '
-      'on conf file {0}'.format( extra_conf_file ) )
-
-
-  @patch( 'ycmd.extra_conf_store._logger', autospec = True )
-  def CallGlobalExtraConfMethod_CatchExceptionFromExtraConf_test( self,
-                                                                  logger ):
-    extra_conf_file = PathToTestFile( 'extra_conf', 'erroneous_extra_conf.py' )
-    with UserOption( 'global_ycm_extra_conf', extra_conf_file ):
-      extra_conf_store._CallGlobalExtraConfMethod( 'NoException' )
-    assert_that( logger.method_calls, has_length( 1 ) )
-    logger.exception.assert_called_with( 'Error occurred while '
-                                         'loading global extra conf '
-                                         '{0}'.format( extra_conf_file ) )
-
-
-  def Load_DoNotReloadExtraConf_NoForce_test( self ):
-    extra_conf_file = PathToTestFile( 'extra_conf', 'project',
-                                      '.ycm_extra_conf.py' )
-    with patch( 'ycmd.extra_conf_store._ShouldLoad', return_value = True ):
-      module = extra_conf_store.Load( extra_conf_file )
-      assert_that( inspect.ismodule( module ) )
-      assert_that( inspect.getfile( module ), equal_to( extra_conf_file ) )
-      assert_that(
-        extra_conf_store.Load( extra_conf_file ),
-        same_instance( module )
-      )
-
-
-  def Load_DoNotReloadExtraConf_ForceEqualsTrue_test( self ):
-    extra_conf_file = PathToTestFile( 'extra_conf', 'project',
-                                      '.ycm_extra_conf.py' )
-    with patch( 'ycmd.extra_conf_store._ShouldLoad', return_value = True ):
-      module = extra_conf_store.Load( extra_conf_file )
-      assert_that( inspect.ismodule( module ) )
-      assert_that( inspect.getfile( module ), equal_to( extra_conf_file ) )
-      assert_that(
-        extra_conf_store.Load( extra_conf_file, force = True ),
-        same_instance( module )
-      )
+@IsolatedYcmd()
+def Load_DoNotReloadExtraConf_ForceEqualsTrue_test( app ):
+  with patch( 'ycmd.extra_conf_store._ShouldLoad', return_value = True ):
+    module = extra_conf_store.Load( PROJECT_EXTRA_CONF )
+    assert_that( inspect.ismodule( module ) )
+    assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+    assert_that(
+      extra_conf_store.Load( PROJECT_EXTRA_CONF, force = True ),
+      same_instance( module )
+    )

--- a/ycmd/tests/misc_handlers_test.py
+++ b/ycmd/tests/misc_handlers_test.py
@@ -175,7 +175,7 @@ def MiscHandlers_DebugInfo_NoExtraConfFound_test( app ):
   )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def MiscHandlers_DebugInfo_ExtraConfFoundButNotLoaded_test( app ):
   filepath = PathToTestFile( 'extra_conf', 'project', '.ycm_extra_conf.py' )
   request_data = BuildRequest( filepath = filepath )

--- a/ycmd/tests/python/__init__.py
+++ b/ycmd/tests/python/__init__.py
@@ -71,21 +71,33 @@ def SharedYcmd( test ):
   return Wrapper
 
 
-def IsolatedYcmd( test ):
+def IsolatedYcmd( custom_options = {} ):
   """Defines a decorator to be attached to tests of this package. This decorator
   passes a unique ycmd application as a parameter. It should be used on tests
   that change the server state in a irreversible way (ex: a semantic subserver
   is stopped or restarted) or expect a clean state (ex: no semantic subserver
-  started, no .ycm_extra_conf.py loaded, etc).
+  started, no .ycm_extra_conf.py loaded, etc). Use the optional parameter
+  |custom_options| to give additional options and/or override the default ones.
 
-  Do NOT attach it to test generators but directly to the yielded tests."""
-  @functools.wraps( test )
-  def Wrapper( *args, **kwargs ):
-    old_server_state = handlers._server_state
-    app = SetUpApp()
-    try:
-      test( app, *args, **kwargs )
-    finally:
-      StopCompleterServer( app, 'python' )
-      handlers._server_state = old_server_state
-  return Wrapper
+  Do NOT attach it to test generators but directly to the yielded tests.
+
+  Example usage:
+
+    from ycmd.tests.python import IsolatedYcmd
+
+    @IsolatedYcmd( { 'python_binary_path': '/some/path' } )
+    def CustomPythonBinaryPath_test( app ):
+      ...
+  """
+  def Decorator( test ):
+    @functools.wraps( test )
+    def Wrapper( *args, **kwargs ):
+      old_server_state = handlers._server_state
+      app = SetUpApp( custom_options )
+      try:
+        test( app, *args, **kwargs )
+      finally:
+        StopCompleterServer( app, 'python' )
+        handlers._server_state = old_server_state
+    return Wrapper
+  return Decorator

--- a/ycmd/tests/rust/__init__.py
+++ b/ycmd/tests/rust/__init__.py
@@ -87,7 +87,7 @@ def IsolatedYcmd( custom_options = {} ):
 
     @IsolatedYcmd( { 'rust_src_path': '/some/path' } )
     def CustomRustSrcPath_test( app ):
-        ...
+      ...
   """
   def Decorator( test ):
     @functools.wraps( test )

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -155,18 +155,6 @@ def PatchCompleter( completer, filetype ):
 
 
 @contextlib.contextmanager
-def UserOption( key, value ):
-  try:
-    current_options = dict( user_options_store.GetAll() )
-    user_options = current_options.copy()
-    user_options.update( { key: value } )
-    handlers.UpdateUserOptions( user_options )
-    yield user_options
-  finally:
-    handlers.UpdateUserOptions( current_options )
-
-
-@contextlib.contextmanager
 def CurrentWorkingDirectory( path ):
   old_cwd = GetCurrentDirectory()
   os.chdir( path )


### PR DESCRIPTION
[Dropping the `UserOption` function was mentioned some time ago](https://github.com/Valloric/ycmd/pull/699#issuecomment-277072790) in PR https://github.com/Valloric/ycmd/pull/699:

> This function updates an option and reverts it by replacing our ServerState instance with a new one, losing all references to the already initialized completers. In particular, this makes it impossible to stop a completer server (e.g. racerd) that was already started once this function is called.

We replace its usage with the `IsolatedYcmd` functions, which are extended with a parameter to customize options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/812)
<!-- Reviewable:end -->
