### PR TITLE
[READY] Resolve symlinks in extra conf glob pattern

### DIFF
--- a/ycmd/extra_conf_store.py
+++ b/ycmd/extra_conf_store.py
@@ -184,10 +184,13 @@ def Load( module_file, force = False ):
 def _MatchesGlobPattern( filename, glob ):
   """Returns true if a filename matches a given pattern. A '~' in glob will be
   expanded to the home directory and checking will be performed using absolute
-  paths. See the documentation of fnmatch for the supported patterns."""
+  paths with symlinks resolved (except on Windows). See the documentation of
+  fnmatch for the supported patterns."""
 
-  abspath = os.path.abspath( filename )
-  return fnmatch( abspath, os.path.abspath( os.path.expanduser( glob ) ) )
+  # NOTE: os.path.realpath does not resolve symlinks on Windows.
+  # See https://bugs.python.org/issue9949
+  realpath = os.path.realpath( filename )
+  return fnmatch( realpath, os.path.realpath( os.path.expanduser( glob ) ) )
 
 
 def _ExtraConfModuleSourceFilesForFile( filename ):

--- a/ycmd/tests/extra_conf_store_test.py
+++ b/ycmd/tests/extra_conf_store_test.py
@@ -30,6 +30,7 @@ from hamcrest import ( assert_that, calling, equal_to, has_length, none, raises,
 from ycmd import extra_conf_store
 from ycmd.responses import UnknownExtraConf
 from ycmd.tests import IsolatedYcmd, PathToTestFile
+from ycmd.tests.test_utils import TemporarySymlink, UnixOnly
 
 
 GLOBAL_EXTRA_CONF = PathToTestFile( 'extra_conf', 'global_extra_conf.py' )
@@ -68,6 +69,18 @@ def ExtraConfStore_ModuleForSourceFile_Whitelisted_test( app ):
 def ExtraConfStore_ModuleForSourceFile_Blacklisted_test( app ):
   filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
   assert_that( extra_conf_store.ModuleForSourceFile( filename ), none() )
+
+
+@UnixOnly
+@IsolatedYcmd( { 'extra_conf_globlist': [
+    PathToTestFile( 'extra_conf', 'symlink', '*' ) ] } )
+def ExtraConfStore_ModuleForSourceFile_SupportSymlink_test( app ):
+  with TemporarySymlink( PathToTestFile( 'extra_conf', 'project' ),
+                         PathToTestFile( 'extra_conf', 'symlink' ) ):
+    filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
+    module = extra_conf_store.ModuleForSourceFile( filename )
+    assert_that( inspect.ismodule( module ) )
+    assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
 
 
 @IsolatedYcmd( { 'global_ycm_extra_conf': GLOBAL_EXTRA_CONF } )

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -173,6 +173,15 @@ def TemporaryExecutable( extension = '.exe' ):
     yield executable.name
 
 
+@contextlib.contextmanager
+def TemporarySymlink( source, link ):
+  os.symlink( source, link )
+  try:
+    yield
+  finally:
+    os.remove( link )
+
+
 def SetUpApp( custom_options = {} ):
   bottle.debug( True )
   options = user_options_store.DefaultOptions()


### PR DESCRIPTION
When a `.ycm_extra_conf.py` file is found, ycmd determines if this file should be white/blacklisted by checking that its path matches one of the patterns from [the `extra_conf_globlist` option](https://github.com/Valloric/YouCompleteMe#the-gycm_extra_conf_globlist-option). This is done by converting the `.ycm_extra_conf.py` path and the patterns to absolute paths through [the `os.path.abspath` function](https://docs.python.org/2/library/os.path.html#os.path.abspath). However, this function doesn't resolve symbolic links. This means that if a pattern in `extra_conf_globlist` contains a symbolic link, any `.ycm_extra_conf.py` file that should be matched by this pattern if the symlink was resolved, won't be white/blacklisted.

This is fixed on UNIX by replacing `os.path.abspath` with [the `os.path.realpath` function](https://docs.python.org/2/library/os.path.html#os.path.realpath). Windows symlinks are not supported because [`os.path.realpath` doesn't resolve symlinks on this platform](https://bugs.python.org/issue9949) and writing our own implementation of `os.path.realpath` supporting Windows symlinks is not worth the trouble.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/814)
<!-- Reviewable:end -->
