### PR TITLE
[READY] Ignore package-lock.json.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ doc/tags
 
 # Exclude tern installation area
 third_party/tern_runtime/node_modules
+third_party/tern_runtime/package-lock.json
 
 # Exclude vagrant directory
 .vagrant/


### PR DESCRIPTION
Since npm 5 (it would appear), npm is now writing a new file to our `tern_runtime` directory `package-lock.json`, which appears as an untracked file. 

The [purpose of the file](https://docs.npmjs.com/files/package-lock.json) seems to be to  lock the entire hierarchy of dependencies.

In theory, we _could_ commit this file and only update it when our dependencies dependencies (and their dependencies) update, but this just seems like a _lot_ of pointless admin.

So we just ignore the file and stick with what we have.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/821)
<!-- Reviewable:end -->
