### PR TITLE
[READY] Do not sort header paths in filename completer

### DIFF
--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -161,7 +161,7 @@ class FilenameCompleter( Completer ):
       paths.extend( os.path.join( include_path, path_dir, relative_path ) for
                     relative_path in relative_paths  )
 
-    return sorted( set( paths ) )
+    return paths
 
 
 def _GetAbsolutePathForCompletions( path_dir,

--- a/ycmd/tests/filename_completer_test.py
+++ b/ycmd/tests/filename_completer_test.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 import os
-from hamcrest import assert_that, contains_inanyorder
+from hamcrest import assert_that, contains_inanyorder, empty
 from nose.tools import eq_, ok_
 from ycmd.completers.general.filename_completer import FilenameCompleter
 from ycmd.request_wrap import RequestWrap
@@ -117,66 +117,68 @@ class FilenameCompleter_test( object ):
 
   def QuotedIncludeCompletion_test( self ):
     data = self._CompletionResultsForLine( '#include "' )
-    eq_( [
-          ( u'foo漢字.txt', '[File]' ),
-          ( 'include',    '[Dir]' ),
-          ( 'Qt',         '[Dir]' ),
-          ( 'QtGui',      '[File&Dir]' ),
-          ( 'QDialog',    '[File]' ),
-          ( 'QWidget',    '[File]' ),
-          ( 'test.cpp',   '[File]' ),
-          ( 'test.hpp',   '[File]' ),
-        ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'QDialog',     '[File]'     ),
+      ( 'QWidget',     '[File]'     ),
+      ( 'Qt',          '[Dir]'      ),
+      ( 'QtGui',       '[File&Dir]' ),
+      ( 'foo漢字.txt', '[File]'     ),
+      ( 'include',     '[Dir]'      ),
+      ( 'test.cpp',    '[File]'     ),
+      ( 'test.hpp',    '[File]'     )
+    ) )
 
     data = self._CompletionResultsForLine( '#include "include/' )
-    eq_( [
-          ( 'Qt',       '[Dir]' ),
-          ( 'QtGui',    '[Dir]' ),
-        ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'Qt',    '[Dir]' ),
+      ( 'QtGui', '[Dir]' )
+    ) )
 
 
   def IncludeCompletion_test( self ):
     data = self._CompletionResultsForLine( '#include <' )
-    eq_( [
-          ( 'Qt',       '[Dir]' ),
-          ( 'QtGui',    '[File&Dir]' ),
-          ( 'QDialog',  '[File]' ),
-          ( 'QWidget',  '[File]' ),
-        ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'QDialog', '[File]'     ),
+      ( 'QWidget', '[File]'     ),
+      ( 'Qt',      '[Dir]'      ),
+      ( 'QtGui',   '[File&Dir]' )
+    ) )
 
     data = self._CompletionResultsForLine( '#include <QtGui/' )
-    eq_( [
-          ( 'QDialog',  '[File]' ),
-          ( 'QWidget',  '[File]' ),
-        ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'QDialog', '[File]' ),
+      ( 'QWidget', '[File]' )
+    ) )
 
 
   def SystemPathCompletion_test( self ):
     # Order of system path completion entries may differ
     # on different systems
-    data = sorted( self._CompletionResultsForLine( 'const char* c = "./' ) )
-    eq_( [
-          ( u'foo漢字.txt', '[File]' ),
-          ( 'include',    '[Dir]' ),
-          ( 'test.cpp',   '[File]' ),
-          ( 'test.hpp',   '[File]' ),
-        ], data )
+    data = self._CompletionResultsForLine( 'const char* c = "./' )
+    assert_that( data, contains_inanyorder(
+      ( 'foo漢字.txt', '[File]' ),
+      ( 'include',     '[Dir]'  ),
+      ( 'test.cpp',    '[File]' ),
+      ( 'test.hpp',    '[File]' )
+    ) )
 
-    data = sorted(
-      self._CompletionResultsForLine( 'const char* c = "./include/' ) )
-    eq_( [
-          ( 'Qt',       '[Dir]' ),
-          ( 'QtGui',    '[Dir]' ),
-        ], data )
+    data = self._CompletionResultsForLine( 'const char* c = "./include/' )
+    assert_that( data, contains_inanyorder(
+      ( 'Qt',       '[Dir]' ),
+      ( 'QtGui',    '[Dir]' )
+    ) )
 
 
   def EnvVar_AtStart_File_test( self ):
     os.environ[ 'YCM_TEST_DATA_DIR' ] = DATA_DIR
-    data = sorted( self._CompletionResultsForLine(
-                            'set x = $YCM_TEST_DATA_DIR/include/QtGui/' ) )
+    data = self._CompletionResultsForLine(
+      'set x = $YCM_TEST_DATA_DIR/include/QtGui/' )
 
     os.environ.pop( 'YCM_TEST_DATA_DIR' )
-    eq_( [ ( 'QDialog', '[File]' ), ( 'QWidget', '[File]' ) ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'QDialog', '[File]' ),
+      ( 'QWidget', '[File]' )
+    ) )
 
 
   def EnvVar_AtStart_File_Partial_test( self ):
@@ -185,130 +187,144 @@ class FilenameCompleter_test( object ):
     # $YCM_TEST_DIR/testdata/filename_completer/inner_dir/ and the client
     # filters based on the additional characters.
     os.environ[ 'YCM_TEST_DIR' ] = TEST_DIR
-    data = sorted( self._CompletionResultsForLine(
-                    'set x = $YCM_TEST_DIR/testdata/filename_completer/'
-                      'inner_dir/te' ) )
+    data = self._CompletionResultsForLine(
+      'set x = $YCM_TEST_DIR/testdata/filename_completer/inner_dir/te' )
     os.environ.pop( 'YCM_TEST_DIR' )
 
-    eq_( [
-          ( u'foo漢字.txt', '[File]' ),
-          ( 'include',    '[Dir]' ),
-          ( 'test.cpp',   '[File]' ),
-          ( 'test.hpp',   '[File]' ),
-        ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'foo漢字.txt', '[File]' ),
+      ( 'include',    '[Dir]' ),
+      ( 'test.cpp',   '[File]' ),
+      ( 'test.hpp',   '[File]' )
+    ) )
 
 
   def EnvVar_AtStart_Dir_test( self ):
     os.environ[ 'YCMTESTDIR' ] = TEST_DIR
 
-    data = sorted( self._CompletionResultsForLine(
-                      'set x = $YCMTESTDIR/testdata/filename_completer/' ) )
+    data = self._CompletionResultsForLine(
+      'set x = $YCMTESTDIR/testdata/filename_completer/' )
 
     os.environ.pop( 'YCMTESTDIR' )
 
-    eq_( [ ( 'inner_dir', '[Dir]' ), ( '∂†∫', '[Dir]' ) ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'inner_dir', '[Dir]' ),
+      ( '∂†∫',       '[Dir]' )
+    ) )
 
 
   def EnvVar_AtStart_Dir_Partial_test( self ):
     os.environ[ 'ycm_test_dir' ] = TEST_DIR
-    data = sorted( self._CompletionResultsForLine(
-                    'set x = $ycm_test_dir/testdata/filename_completer/inn' ) )
+    data = self._CompletionResultsForLine(
+      'set x = $ycm_test_dir/testdata/filename_completer/inn' )
 
     os.environ.pop( 'ycm_test_dir' )
-    eq_( [ ( 'inner_dir', '[Dir]' ), ( '∂†∫', '[Dir]' ) ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'inner_dir', '[Dir]' ),
+      ( '∂†∫',       '[Dir]' )
+    ) )
 
 
   def EnvVar_InMiddle_File_test( self ):
     os.environ[ 'YCM_TEST_filename_completer' ] = 'inner_dir'
-    data = sorted( self._CompletionResultsForLine(
+    data = self._CompletionResultsForLine(
       'set x = '
       + TEST_DIR
-      + '/testdata/filename_completer/$YCM_TEST_filename_completer/' ) )
+      + '/testdata/filename_completer/$YCM_TEST_filename_completer/' )
     os.environ.pop( 'YCM_TEST_filename_completer' )
-    eq_( [
-          ( u'foo漢字.txt', '[File]' ),
-          ( 'include',    '[Dir]' ),
-          ( 'test.cpp',   '[File]' ),
-          ( 'test.hpp',   '[File]' ),
-        ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'foo漢字.txt', '[File]' ),
+      ( 'include',     '[Dir]' ),
+      ( 'test.cpp',    '[File]' ),
+      ( 'test.hpp',    '[File]' )
+    ) )
 
 
   def EnvVar_InMiddle_File_Partial_test( self ):
     os.environ[ 'YCM_TEST_filename_c0mpleter' ] = 'inner_dir'
-    data = sorted( self._CompletionResultsForLine(
+    data = self._CompletionResultsForLine(
       'set x = '
       + TEST_DIR
-      + '/testdata/filename_completer/$YCM_TEST_filename_c0mpleter/te' ) )
+      + '/testdata/filename_completer/$YCM_TEST_filename_c0mpleter/te' )
     os.environ.pop( 'YCM_TEST_filename_c0mpleter' )
-    eq_( [
-          ( u'foo漢字.txt', '[File]' ),
-          ( 'include',    '[Dir]' ),
-          ( 'test.cpp',   '[File]' ),
-          ( 'test.hpp',   '[File]' ),
-        ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'foo漢字.txt', '[File]' ),
+      ( 'include',     '[Dir]'  ),
+      ( 'test.cpp',    '[File]' ),
+      ( 'test.hpp',    '[File]' )
+    ) )
 
 
   def EnvVar_InMiddle_Dir_test( self ):
     os.environ[ 'YCM_TEST_td' ] = 'testd'
-    data = sorted( self._CompletionResultsForLine(
-          'set x = ' + TEST_DIR + '/${YCM_TEST_td}ata/filename_completer/' ) )
+    data = self._CompletionResultsForLine(
+      'set x = ' + TEST_DIR + '/${YCM_TEST_td}ata/filename_completer/' )
 
     os.environ.pop( 'YCM_TEST_td' )
-    eq_( [ ( 'inner_dir', '[Dir]' ), ( '∂†∫', '[Dir]' ) ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'inner_dir', '[Dir]' ),
+      ( '∂†∫',       '[Dir]' )
+    ) )
 
 
   def EnvVar_InMiddle_Dir_Partial_test( self ):
     os.environ[ 'YCM_TEST_td' ] = 'tdata'
-    data = sorted( self._CompletionResultsForLine(
-          'set x = ' + TEST_DIR + '/tes${YCM_TEST_td}/filename_completer/' ) )
+    data = self._CompletionResultsForLine(
+      'set x = ' + TEST_DIR + '/tes${YCM_TEST_td}/filename_completer/' )
     os.environ.pop( 'YCM_TEST_td' )
 
-    eq_( [ ( 'inner_dir', '[Dir]' ), ( '∂†∫', '[Dir]' ) ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'inner_dir', '[Dir]' ),
+      ( '∂†∫',       '[Dir]' )
+    ) )
 
 
   def EnvVar_Undefined_test( self ):
-    data = sorted( self._CompletionResultsForLine(
-      'set x = ' + TEST_DIR + '/testdata/filename_completer${YCM_TEST_td}/' ) )
+    data = self._CompletionResultsForLine(
+      'set x = ' + TEST_DIR + '/testdata/filename_completer${YCM_TEST_td}/' )
 
-    eq_( [ ], data )
+    assert_that( data, empty() )
 
 
   def EnvVar_Empty_Matches_test( self ):
     os.environ[ 'YCM_empty_var' ] = ''
-    data = sorted( self._CompletionResultsForLine(
+    data = self._CompletionResultsForLine(
       'set x = '
       + TEST_DIR
-      + '/testdata/filename_completer${YCM_empty_var}/' ) )
+      + '/testdata/filename_completer${YCM_empty_var}/' )
     os.environ.pop( 'YCM_empty_var' )
 
-    eq_( [ ( 'inner_dir', '[Dir]' ), ( '∂†∫', '[Dir]' ) ], data )
+    assert_that( data, contains_inanyorder(
+      ( 'inner_dir', '[Dir]' ),
+      ( '∂†∫', '[Dir]' )
+    ) )
 
 
   def EnvVar_Undefined_Garbage_test( self ):
     os.environ[ 'YCM_TEST_td' ] = 'testdata/filename_completer'
-    data = sorted( self._CompletionResultsForLine(
-                    'set x = ' + TEST_DIR + '/$YCM_TEST_td}/' ) )
+    data = self._CompletionResultsForLine(
+      'set x = ' + TEST_DIR + '/$YCM_TEST_td}/' )
 
     os.environ.pop( 'YCM_TEST_td' )
-    eq_( [ ], data )
+    assert_that( data, empty() )
 
 
   def EnvVar_Undefined_Garbage_2_test( self ):
     os.environ[ 'YCM_TEST_td' ] = 'testdata/filename_completer'
-    data = sorted( self._CompletionResultsForLine(
-                    'set x = ' + TEST_DIR + '/${YCM_TEST_td/' ) )
+    data = self._CompletionResultsForLine(
+      'set x = ' + TEST_DIR + '/${YCM_TEST_td/' )
 
     os.environ.pop( 'YCM_TEST_td' )
-    eq_( [ ], data )
+    assert_that( data, empty() )
 
 
   def EnvVar_Undefined_Garbage_3_test( self ):
     os.environ[ 'YCM_TEST_td' ] = 'testdata/filename_completer'
-    data = sorted( self._CompletionResultsForLine(
-                    'set x = ' + TEST_DIR + '/$ YCM_TEST_td/' ) )
+    data = self._CompletionResultsForLine(
+      'set x = ' + TEST_DIR + '/$ YCM_TEST_td/' )
 
     os.environ.pop( 'YCM_TEST_td' )
-    eq_( [ ], data )
+    assert_that( data, empty() )
 
 
   def Unicode_In_Line_Works_test( self ):
@@ -316,10 +332,10 @@ class FilenameCompleter_test( object ):
       contents = "var x = /†/testing",
       # The † character is 3 bytes in UTF-8
       column_num = 15 ) )
-    eq_( [ ], self._CompletionResultsForLine(
+    assert_that( self._CompletionResultsForLine(
       contents = "var x = /†/testing",
       # The † character is 3 bytes in UTF-8
-      column_num = 15 ) )
+      column_num = 15 ), empty() )
 
 
   def Unicode_Paths_test( self ):
@@ -334,7 +350,7 @@ class FilenameCompleter_test( object ):
     assert_that( self._CompletionResultsForLine( contents,
                                                  column_num = column_num ),
                  contains_inanyorder( ( 'inner_dir', '[Dir]' ),
-                                      ( '∂†∫', '[Dir]' )  ) )
+                                      ( '∂†∫',       '[Dir]' )  ) )
 
 
 @IsolatedYcmd( { 'filepath_completion_use_working_dir': 0 } )
@@ -344,12 +360,11 @@ def WorkingDir_UseFilePath_test( app ):
 
   completer = FilenameCompleter( user_options_store.GetAll() )
 
-  data = sorted( _CompletionResultsForLine( completer, 'ls ./include/' ) )
-  eq_( [
+  data = _CompletionResultsForLine( completer, 'ls ./include/' )
+  assert_that( data, contains_inanyorder(
     ( 'Qt',    '[Dir]' ),
     ( 'QtGui', '[Dir]' )
-  ], data )
-
+  ) )
 
 
 @IsolatedYcmd( { 'filepath_completion_use_working_dir': 1 } )
@@ -363,11 +378,11 @@ def WorkingDir_UseServerWorkingDirectory_test( app ):
 
     # We don't supply working_dir in the request, so the current working
     # directory is used.
-    data = sorted( _CompletionResultsForLine( completer, 'ls ./' ) )
-    eq_( [
+    data = _CompletionResultsForLine( completer, 'ls ./' )
+    assert_that( data, contains_inanyorder(
       ( 'Qt',    '[Dir]' ),
       ( 'QtGui', '[Dir]' )
-    ], data )
+    ) )
 
 
 @IsolatedYcmd( { 'filepath_completion_use_working_dir': 1 } )
@@ -381,10 +396,10 @@ def WorkingDir_UseServerWorkingDirectory_Unicode_test( app ):
 
     # We don't supply working_dir in the request, so the current working
     # directory is used.
-    data = sorted( _CompletionResultsForLine( completer, 'ls ./' ) )
-    eq_( [
+    data = _CompletionResultsForLine( completer, 'ls ./' )
+    assert_that( data, contains_inanyorder(
       ( '†es†.txt', '[File]' )
-    ], data )
+    ) )
 
 
 @IsolatedYcmd( { 'filepath_completion_use_working_dir': 1 } )
@@ -397,10 +412,10 @@ def WorkingDir_UseClientWorkingDirectory_test( app ):
 
   # We supply working_dir in the request, so we expect results to be
   # relative to the supplied path.
-  data = sorted( _CompletionResultsForLine( completer, 'ls ./', {
+  data = _CompletionResultsForLine( completer, 'ls ./', {
     'working_dir': test_dir
-  } ) )
-  eq_( [
+  } )
+  assert_that( data, contains_inanyorder(
     ( 'Qt',    '[Dir]' ),
     ( 'QtGui', '[Dir]' )
-  ], data )
+  ) )


### PR DESCRIPTION
There is no point in sorting header paths and removing duplicates by converting the list to a set in the filename completer since the paths are going through the `FilterAndSortCandidates` function even when the query is empty (thanks to PR #819).

Rewrite the filename completer tests to use the `contains_inanyorder` and `empty` matchers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/824)
<!-- Reviewable:end -->
