### PR TITLE
[READY] Run flake8 and nose as modules

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -42,7 +42,9 @@ import argparse
 def RunFlake8():
   print( 'Running flake8' )
   subprocess.check_call( [
-    'flake8',
+    sys.executable,
+    # __main__ is required on Python 2.6.
+    '-m', 'flake8.__main__',
     p.join( DIR_OF_THIS_SCRIPT, 'ycmd' )
   ] )
 
@@ -208,7 +210,9 @@ def NoseTests( parsed_args, extra_nosetests_args ):
   else:
     nosetests_args.append( p.join( DIR_OF_THIS_SCRIPT, 'ycmd' ) )
 
-  subprocess.check_call( [ 'nosetests' ] + nosetests_args )
+  subprocess.check_call( [ sys.executable,
+                           # __main__ is required on Python 2.6.
+                           '-m', 'nose.__main__' ] + nosetests_args )
 
 
 def Main():


### PR DESCRIPTION
If a user has Python 2 and 3 installed on its system with flake8 and nose available in the PATH for both Pythons, `run_tests.py` may execute flake8 or nose from a different Python that the one used to run the script and build ycmd. For instance, if the script is executed in Python 3 but nose from Python 2 is found in the PATH, the following error occur when running the tests:
```
Failure: ImportError (dynamic module does not define init function (initycm_core)) ... ERROR
```
The solution is to run flake8 and nose as modules using `sys.executable` with [the `-m` option](https://docs.python.org/2.7/using/cmdline.html#cmdoption-m). Due to [a bug (feature?) in Python 2](http://bugs.python.org/issue2751), we need to specifically call the `__main__` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/829)
<!-- Reviewable:end -->
