### PR TITLE
[READY] Add max_num_candidates option

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -158,6 +158,7 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
             filetype_set = set( self.SupportedFiletypes() ) )
         if user_options[ 'auto_trigger' ] else None )
     self._completions_cache = CompletionsCache()
+    self._max_candidates = user_options[ 'max_num_candidates' ]
 
 
   def CompletionType( self, request_data ):
@@ -299,7 +300,7 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
 
   def FilterAndSortCandidatesInner( self, candidates, sort_property, query ):
     return completer_utils.FilterAndSortCandidatesWrap(
-      candidates, sort_property, query )
+      candidates, sort_property, query, self._max_candidates )
 
 
   def OnFileReadyToParse( self, request_data ):

--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -167,7 +167,8 @@ def FiletypeCompleterExistsForFiletype( filetype ):
   return os.path.exists( PathToFiletypeCompleterPluginLoader( filetype ) )
 
 
-def FilterAndSortCandidatesWrap( candidates, sort_property, query ):
+def FilterAndSortCandidatesWrap( candidates, sort_property, query,
+                                 max_candidates ):
   from ycm_core import FilterAndSortCandidates
 
   # The c++ interface we use only understands the (*native*) 'str' type (i.e.
@@ -180,7 +181,8 @@ def FilterAndSortCandidatesWrap( candidates, sort_property, query ):
   # C++ layer.
   return FilterAndSortCandidates( candidates,
                                   ToCppStringCompatible( sort_property ),
-                                  ToCppStringCompatible( query ) )
+                                  ToCppStringCompatible( query ),
+                                  max_candidates )
 
 
 TRIGGER_REGEX_PREFIX = 're!'

--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -11,6 +11,7 @@
   "collect_identifiers_from_comments_and_strings": 0,
   "collect_identifiers_from_tags_files": 0,
   "max_num_identifier_candidates": 10,
+  "max_num_candidates": 50,
   "extra_conf_globlist": [],
   "global_ycm_extra_conf": "",
   "confirm_extra_conf": 1,

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -135,7 +135,8 @@ def FilterAndSortCandidates():
   return _JsonResponse( FilterAndSortCandidatesWrap(
     request_data[ 'candidates'],
     request_data[ 'sort_property' ],
-    request_data[ 'query' ] ) )
+    request_data[ 'query' ],
+    _server_state.user_options[ 'max_num_candidates' ] ) )
 
 
 @app.get( '/healthy' )

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -482,7 +482,7 @@ def GetCompletions_ClientDataGivenToExtraConf_test( app ):
   assert_that( results, has_item( CompletionEntryMatcher( 'x' ) ) )
 
 
-@SharedYcmd
+@IsolatedYcmd( { 'max_num_candidates': 0 } )
 def GetCompletions_FilenameCompleter_ClientDataGivenToExtraConf_test( app ):
   app.post_json(
     '/load_extra_conf_file',


### PR DESCRIPTION
Add the `max_num_candidates` option to limit the number of non-identifier candidates returned by ycmd. Its default value is set to 50 as this seems a good compromise between performance and the amount of candidates shown to the user (10 candidates like for identifiers would be too low).

Limiting the number of candidates does not only improve performance when sorting them (see PR #825) but also when sending the response to the client as the response is smaller and when clients are populating the completion menu since there are less candidates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/830)
<!-- Reviewable:end -->
