### PR TITLE
[READY] Update ycmd extra conf

### DIFF
--- a/cpp/ycm/.ycm_extra_conf.py
+++ b/cpp/ycm/.ycm_extra_conf.py
@@ -28,6 +28,8 @@
 #
 # For more information, please refer to <http://unlicense.org/>
 
+from distutils.sysconfig import get_python_inc
+import platform
 import os
 import ycm_core
 
@@ -45,25 +47,16 @@ flags = [
 # You 100% do NOT need -DUSE_CLANG_COMPLETER in your flags; only the YCM
 # source code needs it.
 '-DUSE_CLANG_COMPLETER',
-# THIS IS IMPORTANT! Without a "-std=<something>" flag, clang won't know which
-# language to use when compiling headers. So it will guess. Badly. So C++
-# headers will be compiled as C headers. You don't want that so ALWAYS specify
-# a "-std=<something>".
-# For a C project, you would set this to something like 'c99' instead of
-# 'c++11'.
-'-std=c++11',
-# ...and the same thing goes for the magic -x option which specifies the
-# language that the files to be compiled are written in. This is mostly
-# relevant for c++ headers.
+# THIS IS IMPORTANT! Without the '-x' flag, Clang won't know which language to
+# use when compiling headers. So it will guess. Badly. So C++ headers will be
+# compiled as C headers. You don't want that so ALWAYS specify the '-x' flag.
 # For a C project, you would set this to 'c' instead of 'c++'.
 '-x',
 'c++',
 '-isystem',
 '../BoostParts',
 '-isystem',
-# This path will only work on OS X, but extra paths that don't exist are not
-# harmful
-'/System/Library/Frameworks/Python.framework/Headers',
+get_python_inc(),
 '-isystem',
 '../llvm/include',
 '-isystem',
@@ -80,7 +73,15 @@ flags = [
 './tests/gmock',
 '-isystem',
 './tests/gmock/include',
+'-isystem',
+'./benchmarks/benchmark/include',
 ]
+
+# Clang automatically sets the '-std=' flag to 'c++14' for MSVC 2015 or later,
+# which is required for compiling the standard library, and to 'c++11' for older
+# versions.
+if platform.system() != 'Windows':
+  flags.append( '-std=c++11' )
 
 
 # Set this to the absolute path to the folder (NOT the file!) containing the


### PR DESCRIPTION
This PR updates the list of flags defined in ycmd `.ycm_extra_conf.py` file by:
 - adding Python include path using [`get_python_inc`](https://docs.python.org/3/distutils/apiref.html?highlight=get_python_inc#distutils.sysconfig.get_python_inc) so that it works on all platforms;
 - adding Google benchmark include path;
 - removing the `-std=c++11` flag on Windows because the standard library in recent versions of MSVC requires at least C++14;
 - removing the comment about `-std=`: only the `-x` flag should be specified to distinguish C++ headers from C ones.

Tested on Ubuntu 16.04, macOS, and Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/833)
<!-- Reviewable:end -->
