### PR TITLE
[READY] Do not return canonical type if identical to type

### DIFF
--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -291,9 +291,14 @@ std::string TranslationUnit::GetTypeAtLocation(
   CXType canonical_type = clang_getCanonicalType( type );
 
   if ( !clang_equalTypes( type, canonical_type ) ) {
-    type_description += " => ";
-    type_description += CXStringToString(
-                          clang_getTypeSpelling( canonical_type ) );
+    std::string canonical_type_description = CXStringToString(
+      clang_getTypeSpelling( canonical_type ) );
+
+    // Clang may return that the canonical type of a symbol is distinct from its
+    // type even though they result in the same string. Only append the
+    // canonical type if the strings are different.
+    if ( type_description != canonical_type_description )
+      type_description += " => " + canonical_type_description;
   }
 
   return type_description;

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -371,26 +371,26 @@ def Subcommands_GetType_test():
     [{'line_num': 44, 'column_num': 12}, 'Foo *'],
     [{'line_num': 44, 'column_num': 18}, 'int'],
 
-    # Auto in declaration (canonical types apparently differ)
-    [{'line_num': 24, 'column_num':  3}, 'Foo & => Foo &'], # sic
-    [{'line_num': 24, 'column_num': 11}, 'Foo & => Foo &'], # sic
+    # Auto in declaration
+    [{'line_num': 24, 'column_num':  3}, 'Foo &'],
+    [{'line_num': 24, 'column_num': 11}, 'Foo &'],
     [{'line_num': 24, 'column_num': 18}, 'Foo'],
-    [{'line_num': 25, 'column_num':  3}, 'Foo * => Foo *'], # sic
-    [{'line_num': 25, 'column_num': 11}, 'Foo * => Foo *'], # sic
+    [{'line_num': 25, 'column_num':  3}, 'Foo *'],
+    [{'line_num': 25, 'column_num': 11}, 'Foo *'],
     [{'line_num': 25, 'column_num': 18}, 'Foo'],
-    [{'line_num': 27, 'column_num':  3}, 'const Foo & => const Foo &'], # sic
-    [{'line_num': 27, 'column_num': 16}, 'const Foo & => const Foo &'], # sic
-    [{'line_num': 28, 'column_num':  3}, 'const Foo * => const Foo *'], # sic
-    [{'line_num': 28, 'column_num': 16}, 'const Foo * => const Foo *'], # sic
+    [{'line_num': 27, 'column_num':  3}, 'const Foo &'],
+    [{'line_num': 27, 'column_num': 16}, 'const Foo &'],
+    [{'line_num': 28, 'column_num':  3}, 'const Foo *'],
+    [{'line_num': 28, 'column_num': 16}, 'const Foo *'],
 
-    # Auto in usage (canonical types apparently differ)
-    [{'line_num': 30, 'column_num': 14}, 'const Foo => const Foo'], # sic
+    # Auto in usage
+    [{'line_num': 30, 'column_num': 14}, 'const Foo'],
     [{'line_num': 30, 'column_num': 21}, 'const int'],
-    [{'line_num': 31, 'column_num': 14}, 'const Foo * => const Foo *'], # sic
+    [{'line_num': 31, 'column_num': 14}, 'const Foo *'],
     [{'line_num': 31, 'column_num': 22}, 'const int'],
-    [{'line_num': 32, 'column_num': 13}, 'Foo => Foo'], # sic
+    [{'line_num': 32, 'column_num': 13}, 'Foo'],
     [{'line_num': 32, 'column_num': 19}, 'int'],
-    [{'line_num': 33, 'column_num': 13}, 'Foo * => Foo *'], # sic
+    [{'line_num': 33, 'column_num': 13}, 'Foo *'],
     [{'line_num': 33, 'column_num': 20}, 'int'],
 
     # Unicode


### PR DESCRIPTION
The `GetType` subcommand from the Clang completer is supposed to return the canonical type of a symbol if it differs from its type. However, in some cases, both types are displayed even if identical. For instance, `GetType` on `bar` in the following code:
```c++
char *foo
auto bar = foo
```
returns `char * => char *` instead of simply `char *`.

This happens because Clang returns that the canonical type is different from the actual type even though they result in the same string. The solution is to only return the canonical type if the strings are different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/835)
<!-- Reviewable:end -->
