### PR TITLE
[READY] Allow system boost and system libclang usage

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -181,7 +181,7 @@ else()
   # in corporate environments on RHEL/CentOS, where the default system compiler
   # is too old.
   #
-  # We use lsb_release on linux systems to detect the distro/verseion.
+  # We use lsb_release on linux systems to detect the distro/version.
   # Other platforms (Mac, Windows) won't have this, and it might not be installed
   # on all linux installations, but it is the _most_ portable way.
   find_program( LSB_RELEASE lsb_release )
@@ -216,6 +216,16 @@ else()
 
   message( FATAL_ERROR "Your C++ compiler does NOT fully support C++11." )
 
+endif()
+
+# Gentoo detection. Needed because Gentoo is a special snowflake that puts
+# llvm in weird places.
+set( GENTOO_LINUX FALSE )
+if ( EXISTS /etc/os-release )
+  file( READ /etc/os-release CONTENTS )
+  if ( CONTENTS MATCHES "Gentoo" )
+    set( GENTOO_LINUX TRUE )
+  endif()
 endif()
 
 # Note: build.py always explicitly sets this option, so the default used here

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -204,7 +204,10 @@ endif()
 
 if ( USE_SYSTEM_BOOST )
   set( Boost_COMPONENTS filesystem regex system )
-  if( USE_PYTHON2 )
+  # Gentoo allows a very convenient system-wide python version switching
+  # that handles symlinks of everything needed, including Boost.Python.
+  # Thus, on Gentoo, we want to always link against boost_python.
+  if( USE_PYTHON2 OR GENTOO_LINUX )
     list( APPEND Boost_COMPONENTS python )
   else()
     list( APPEND Boost_COMPONENTS python3 )
@@ -278,6 +281,8 @@ if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
     file( GLOB SYS_LLVM_PATHS "/usr/lib/llvm*/lib" )
     # On FreeBSD , llvm install into /usr/local/llvm-xy
     file ( GLOB FREEBSD_LLVM_PATHS "/usr/local/llvm*/lib")
+    # On Gentoo, llvm installs into /usr/lib/llvm/x/
+    file ( GLOB GENTOO_LLVM_PATHS "/usr/lib*/llvm/*/lib*" )
     # Need TEMP because find_library does not work with an option variable
     # On Debian-based systems only a symlink to libclang.so.1 is created
     find_library( TEMP
@@ -290,6 +295,7 @@ if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
                   /usr/lib/llvm
                   ${SYS_LLVM_PATHS}
                   ${FREEBSD_LLVM_PATHS}
+                  ${GENTOO_LLVM_PATHS}
                   /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib
                   /Library/Developer/CommandLineTools/usr/lib )
     set( EXTERNAL_LIBCLANG_PATH ${TEMP} )


### PR DESCRIPTION
The changes needed for `--system-libclang` and `--system-boost` to work on Gentoo are:

- Always passing `-lboost_python` even on python3
- Looking in a ridiculous path (`/usr/lib/llvm/${MAJOR_VERSION}/lib{64,32}/`) to find libclang.so

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/837)
<!-- Reviewable:end -->
