### PR TITLE
[READY] Use SYSTEM_IS_FREEBSD variable when downloading Clang binaries

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -48,7 +48,7 @@ if ( USE_CLANG_COMPLETER AND
            "b7a7565680d3aad66c17f789c115b738be4af3bc16e2589923f7a940f32439f6" )
     endif()
     set( CLANG_FILENAME "${CLANG_DIRNAME}.exe" )
-  elseif ( CMAKE_SYSTEM_NAME MATCHES "FreeBSD" )
+  elseif ( SYSTEM_IS_FREEBSD )
     if ( 64_BIT_PLATFORM )
       set( CLANG_DIRNAME "clang+llvm-${CLANG_VERSION}-amd64-unknown-freebsd10" )
       set( CLANG_SHA256


### PR DESCRIPTION
[`SYSTEM_IS_FREEBSD` is defined at the top of `cpp/CMakeLists.txt`](https://github.com/Valloric/ycmd/blob/fd32091dedaf57acce40edc2d7c08950cccfd9b7/cpp/CMakeLists.txt#L39).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/839)
<!-- Reviewable:end -->
