### PR TITLE
[READY] Improve Red Hat and CentOS detection

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -56,6 +56,27 @@ endif()
 
 #############################################################################
 
+# Linux distribution detection.
+
+# Red Hat and CentOS detection.
+if ( EXISTS /etc/redhat-release )
+  file( READ /etc/redhat-release CONTENTS )
+  if ( CONTENTS MATCHES "Red Hat" )
+    set( DISTRIBUTION "Red Hat" )
+  elseif ( CONTENTS MATCHES "CentOS" )
+    set( DISTRIBUTION "CentOS" )
+  endif()
+# Gentoo detection. Needed because Gentoo is a special snowflake that puts
+# llvm in weird places.
+elseif ( EXISTS /etc/os-release )
+  file( READ /etc/os-release CONTENTS )
+  if ( CONTENTS MATCHES "Gentoo" )
+    set( DISTRIBUTION "Gentoo" )
+  endif()
+endif()
+
+#############################################################################
+
 # Turning on this flag tells cmake to emit a compile_commands.json file.
 # This file can be used to load compilation flags into YCM. See here for more
 # details: http://clang.llvm.org/docs/JSONCompilationDatabase.html
@@ -180,52 +201,27 @@ else()
   # Platform-specific advice goes here. In particular, we have plenty of users
   # in corporate environments on RHEL/CentOS, where the default system compiler
   # is too old.
-  #
-  # We use lsb_release on linux systems to detect the distro/version.
-  # Other platforms (Mac, Windows) won't have this, and it might not be installed
-  # on all linux installations, but it is the _most_ portable way.
-  find_program( LSB_RELEASE lsb_release )
-  if ( NOT ${LSB_RELEASE} STREQUAL "LSB_RELEASE-NOTFOUND" )
-    execute_process( COMMAND ${LSB_RELEASE} -is
-                     OUTPUT_VARIABLE LSB_RELEASE_ID
-                     OUTPUT_STRIP_TRAILING_WHITESPACE)
-    execute_process( COMMAND ${LSB_RELEASE} -rs
-                     OUTPUT_VARIABLE LSB_RELEASE_VERSION
-                     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-    # on RHEL and CentOS, users require the devtoolset-3
-    # or greater. However, we recommended the devtoolset-6 because it is the
-    # newest at the time of writing. And why not.
-    if ( ${LSB_RELEASE_ID} STREQUAL "CentOS" OR
-         ${LSB_RELEASE_ID} STREQUAL "RedHatEnterpriseServer" )
-      message( STATUS "NOTE: You appear to be on ${LSB_RELEASE_ID} version "
-      "${LSB_RELEASE_VERSION}. In order to use this application, you require a "
-      "more modern compiler than the default compiler on this platform. "
-      "Please install the devtoolset-6 or greater. For example, see this link: "
-      "https://www.softwarecollections.org/en/scls/rhscl/devtoolset-6/" )
+  # on RHEL and CentOS, users require the devtoolset-3 or greater. However, we
+  # recommended the devtoolset-6 because it is the newest at the time of
+  # writing. And why not.
+  if ( DISTRIBUTION STREQUAL "CentOS" OR DISTRIBUTION STREQUAL "Red Hat" )
+    message( STATUS "NOTE: You appear to be on ${DISTRIBUTION}. "
+    "In order to use this application, you require a more modern compiler "
+    "than the default compiler on this platform. "
+    "Please install the devtoolset-6 or greater. For example, see this link: "
+    "https://www.softwarecollections.org/en/scls/rhscl/devtoolset-6/" )
 
-      # Finally, just check if it is installed and they just need to activate it
-      if ( EXISTS /opt/rh/devtoolset-6 )
-        message( STATUS "NOTE: It looks like you have the devtoolset-6 "
-                        "installed in /opt/rh/devtoolset-6, so you probably "
-                        "just need to activate it and re-run the installation. "
-                        "For example: source /opt/rh/devtoolset-6/enable")
-      endif()
+    # Finally, just check if it is installed and they just need to activate it.
+    if ( EXISTS /opt/rh/devtoolset-6 )
+      message( STATUS "NOTE: It looks like you have the devtoolset-6 "
+                      "installed in /opt/rh/devtoolset-6, so you probably "
+                      "just need to activate it and re-run the installation. "
+                      "For example: source /opt/rh/devtoolset-6/enable")
     endif()
   endif()
 
   message( FATAL_ERROR "Your C++ compiler does NOT fully support C++11." )
-
-endif()
-
-# Gentoo detection. Needed because Gentoo is a special snowflake that puts
-# llvm in weird places.
-set( GENTOO_LINUX FALSE )
-if ( EXISTS /etc/os-release )
-  file( READ /etc/os-release CONTENTS )
-  if ( CONTENTS MATCHES "Gentoo" )
-    set( GENTOO_LINUX TRUE )
-  endif()
 endif()
 
 # Note: build.py always explicitly sets this option, so the default used here

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -207,7 +207,7 @@ if ( USE_SYSTEM_BOOST )
   # Gentoo allows a very convenient system-wide python version switching
   # that handles symlinks of everything needed, including Boost.Python.
   # Thus, on Gentoo, we want to always link against boost_python.
-  if( USE_PYTHON2 OR GENTOO_LINUX )
+  if( USE_PYTHON2 OR DISTRIBUTION STREQUAL "Gentoo" )
     list( APPEND Boost_COMPONENTS python )
   else()
     list( APPEND Boost_COMPONENTS python3 )


### PR DESCRIPTION
Detecting that the distribution is Red Hat or CentOS by checking if the `/etc/redhat-release` file contains `Red Hat` (respectively `CentOS`) is more reliable than using `lsb_release` as this tool may not be available on a clean installation (e.g. CentOS 6.5).

Tested on CentOS 6.5 and 7.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/840)
<!-- Reviewable:end -->
