### PR TITLE
[READY] Close options file before starting server

### DIFF
--- a/examples/example_client.py
+++ b/examples/example_client.py
@@ -21,6 +21,7 @@ if sys.version_info[ 0 ] < 3:
             platform.python_version() )
 
 from base64 import b64encode, b64decode
+from tempfile import NamedTemporaryFile
 import collections
 import hashlib
 import hmac
@@ -29,7 +30,6 @@ import os
 import socket
 import subprocess
 import sys
-import tempfile
 import urllib.parse
 import time
 
@@ -77,17 +77,17 @@ class YcmdHandle( object ):
     hmac_secret = os.urandom( HMAC_SECRET_LENGTH )
     prepared_options[ 'hmac_secret' ] = str( b64encode( hmac_secret ), 'utf-8' )
 
-    # The temp options file is deleted by ycmd during startup
-    with tempfile.NamedTemporaryFile( mode = 'w+', delete = False ) \
-        as options_file:
+    # The temp options file is deleted by ycmd during startup.
+    with NamedTemporaryFile( mode = 'w+', delete = False ) as options_file:
       json.dump( prepared_options, options_file )
-      server_port = GetUnusedLocalhostPort()
-      ycmd_args = [ sys.executable,
-                    PATH_TO_YCMD,
-                    '--port={0}'.format( server_port ),
-                    '--options_file={0}'.format( options_file.name ),
-                    '--idle_suicide_seconds={0}'.format(
-                      SERVER_IDLE_SUICIDE_SECONDS ) ]
+
+    server_port = GetUnusedLocalhostPort()
+    ycmd_args = [ sys.executable,
+                  PATH_TO_YCMD,
+                  '--port={0}'.format( server_port ),
+                  '--options_file={0}'.format( options_file.name ),
+                  '--idle_suicide_seconds={0}'.format(
+                    SERVER_IDLE_SUICIDE_SECONDS ) ]
 
     std_handles = None if INCLUDE_YCMD_OUTPUT else subprocess.PIPE
     child_handle = subprocess.Popen( ycmd_args,

--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -81,46 +81,46 @@ class Client_test( object ):
 
   def Start( self, idle_suicide_seconds = 60,
              check_interval_seconds = 60 * 10 ):
-    # The temp options file is deleted by ycmd during startup
+    # The temp options file is deleted by ycmd during startup.
     with NamedTemporaryFile( mode = 'w+', delete = False ) as options_file:
       json.dump( self._options_dict, options_file )
-      options_file.flush()
-      self._port = GetUnusedLocalhostPort()
-      self._location = 'http://127.0.0.1:' + str( self._port )
 
-      # Define environment variable to enable subprocesses coverage. See:
-      # http://coverage.readthedocs.org/en/coverage-4.0.3/subprocess.html
-      env = os.environ.copy()
-      SetEnviron( env, 'COVERAGE_PROCESS_START', '.coveragerc' )
+    self._port = GetUnusedLocalhostPort()
+    self._location = 'http://127.0.0.1:' + str( self._port )
 
-      ycmd_args = [
-        sys.executable,
-        PATH_TO_YCMD,
-        '--port={0}'.format( self._port ),
-        '--options_file={0}'.format( options_file.name ),
-        '--log=debug',
-        '--idle_suicide_seconds={0}'.format( idle_suicide_seconds ),
-        '--check_interval_seconds={0}'.format( check_interval_seconds ),
-      ]
+    # Define environment variable to enable subprocesses coverage. See:
+    # http://coverage.readthedocs.org/en/coverage-4.0.3/subprocess.html
+    env = os.environ.copy()
+    SetEnviron( env, 'COVERAGE_PROCESS_START', '.coveragerc' )
 
-      stdout = CreateLogfile(
-          LOGFILE_FORMAT.format( port = self._port, std = 'stdout' ) )
-      stderr = CreateLogfile(
-          LOGFILE_FORMAT.format( port = self._port, std = 'stderr' ) )
-      self._logfiles.extend( [ stdout, stderr ] )
-      ycmd_args.append( '--stdout={0}'.format( stdout ) )
-      ycmd_args.append( '--stderr={0}'.format( stderr ) )
+    ycmd_args = [
+      sys.executable,
+      PATH_TO_YCMD,
+      '--port={0}'.format( self._port ),
+      '--options_file={0}'.format( options_file.name ),
+      '--log=debug',
+      '--idle_suicide_seconds={0}'.format( idle_suicide_seconds ),
+      '--check_interval_seconds={0}'.format( check_interval_seconds ),
+    ]
 
-      self._popen_handle = SafePopen( ycmd_args,
-                                      stdin_windows = subprocess.PIPE,
-                                      stdout = subprocess.PIPE,
-                                      stderr = subprocess.PIPE,
-                                      env = env )
-      self._servers.append( psutil.Process( self._popen_handle.pid ) )
+    stdout = CreateLogfile(
+        LOGFILE_FORMAT.format( port = self._port, std = 'stdout' ) )
+    stderr = CreateLogfile(
+        LOGFILE_FORMAT.format( port = self._port, std = 'stderr' ) )
+    self._logfiles.extend( [ stdout, stderr ] )
+    ycmd_args.append( '--stdout={0}'.format( stdout ) )
+    ycmd_args.append( '--stderr={0}'.format( stderr ) )
 
-      self._WaitUntilReady()
-      extra_conf = PathToTestFile( 'client', '.ycm_extra_conf.py' )
-      self.PostRequest( 'load_extra_conf_file', { 'filepath': extra_conf } )
+    self._popen_handle = SafePopen( ycmd_args,
+                                    stdin_windows = subprocess.PIPE,
+                                    stdout = subprocess.PIPE,
+                                    stderr = subprocess.PIPE,
+                                    env = env )
+    self._servers.append( psutil.Process( self._popen_handle.pid ) )
+
+    self._WaitUntilReady()
+    extra_conf = PathToTestFile( 'client', '.ycm_extra_conf.py' )
+    self.PostRequest( 'load_extra_conf_file', { 'filepath': extra_conf } )
 
 
   def _IsReady( self, filetype = None ):


### PR DESCRIPTION
When running the shutdown tests on Windows, ycmd is unable to remove the options file that contains the HMAC key. This is because the file is kept open by the tests while the server is started and a file cannot be removed on Windows if another process is holding it open. We fix this by closing the options file as soon as possible.

Also, we don't need to manually flush the file as it is automatically flushed when closing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/841)
<!-- Reviewable:end -->
