### PR TITLE
[READY] Improve completion of include statements in C-family languages

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -212,38 +212,6 @@ PREPARED_DEFAULT_FILETYPE_TRIGGERS = _FiletypeTriggerDictFromSpec(
     DEFAULT_FILETYPE_TRIGGERS )
 
 
-INCLUDE_REGEX = re.compile( '\s*#\s*(?:include|import)\s*("|<)' )
-
-
-def AtIncludeStatementStart( line ):
-  match = INCLUDE_REGEX.match( line )
-  if not match:
-    return False
-  # Check if the whole string matches the regex
-  return match.end() == len( line )
-
-
-def GetIncludeStatementValue( line, check_closing = True ):
-  """Returns include statement value and boolean indicating whether
-     include statement is quoted.
-     If check_closing is True the string is scanned for statement closing
-     character (" or >) and substring between opening and closing characters is
-     returned. The whole string after opening character is returned otherwise"""
-  match = INCLUDE_REGEX.match( line )
-  include_value = None
-  quoted_include = False
-  if match:
-    quoted_include = ( match.group( 1 ) == '"' )
-    if not check_closing:
-      include_value = line[ match.end(): ]
-    else:
-      close_char = '"' if quoted_include else '>'
-      close_char_pos = line.find( close_char, match.end() )
-      if close_char_pos != -1:
-        include_value = line[ match.end() : close_char_pos ]
-  return include_value, quoted_include
-
-
 def GetFileContents( request_data, filename ):
   """Returns the contents of the absolute path |filename| as a unicode
   string. If the file contents exist in |request_data| (i.e. it is open and

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -25,6 +25,7 @@ from builtins import *  # noqa
 
 from collections import defaultdict
 from future.utils import iteritems
+import logging
 import os.path
 import re
 import textwrap
@@ -34,10 +35,12 @@ import ycm_core
 from ycmd import responses
 from ycmd.utils import ToCppStringCompatible, ToUnicode
 from ycmd.completers.completer import Completer
-from ycmd.completers.completer_utils import GetIncludeStatementValue
 from ycmd.completers.cpp.flags import ( Flags, PrepareFlagsForClang,
-                                        NoCompilationDatabase )
+                                        NoCompilationDatabase,
+                                        UserIncludePaths )
 from ycmd.completers.cpp.ephemeral_values_set import EphemeralValuesSet
+from ycmd.completers.general.filename_completer import (
+    GenerateCandidatesForPaths )
 from ycmd.responses import NoExtraConfDetected, UnknownExtraConf
 
 CLANG_FILETYPES = set( [ 'c', 'cpp', 'objc', 'objcpp' ] )
@@ -49,6 +52,7 @@ NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 PRAGMA_DIAG_TEXT_TO_IGNORE = '#pragma once in main file'
 TOO_MANY_ERRORS_DIAG_TEXT_TO_IGNORE = 'too many errors emitted, stopping now'
 NO_DOCUMENTATION_MESSAGE = 'No documentation available for current context'
+INCLUDE_REGEX = re.compile( '(\s*#\s*(?:include|import)\s*)(:?"[^"]*|<[^>]*)' )
 
 
 class ClangCompleter( Completer ):
@@ -60,6 +64,7 @@ class ClangCompleter( Completer ):
     self._flags = Flags()
     self._diagnostic_store = None
     self._files_being_compiled = EphemeralValuesSet()
+    self._logger = logging.getLogger( __name__ )
 
 
   def SupportedFiletypes( self ):
@@ -85,10 +90,61 @@ class ClangCompleter( Completer ):
     return files
 
 
+  def ShouldCompleteIncludeStatement( self, request_data ):
+    column_codepoint = request_data[ 'column_codepoint' ] - 1
+    current_line = request_data[ 'line_value' ]
+    return INCLUDE_REGEX.match( current_line[ : column_codepoint ] )
+
+
+  def ShouldUseNowInner( self, request_data ):
+    if self.ShouldCompleteIncludeStatement( request_data ):
+      return True
+    return super( ClangCompleter, self ).ShouldUseNowInner( request_data )
+
+
+  def GetIncludePaths( self, request_data ):
+    column_codepoint = request_data[ 'column_codepoint' ] - 1
+    current_line = request_data[ 'line_value' ]
+    line = current_line[ : column_codepoint ]
+    path_dir, quoted_include, start_codepoint = (
+        GetIncludeStatementValue( line, check_closing = False ) )
+    if start_codepoint is None:
+      return None
+
+    request_data[ 'start_codepoint' ] = start_codepoint
+
+    # We do what GCC does for <> versus "":
+    # http://gcc.gnu.org/onlinedocs/cpp/Include-Syntax.html
+    flags = self._FlagsForRequest( request_data )
+    filepath = request_data[ 'filepath' ]
+    quoted_include_paths, include_paths = UserIncludePaths( flags, filepath )
+    if quoted_include:
+      include_paths.extend( quoted_include_paths )
+
+    paths = []
+    for include_path in include_paths:
+      unicode_path = ToUnicode( os.path.join( include_path, path_dir ) )
+      try:
+        # We need to pass a unicode string to get unicode strings out of
+        # listdir.
+        relative_paths = os.listdir( unicode_path )
+      except Exception:
+        self._logger.exception( 'Error while listing %s folder.', unicode_path )
+        relative_paths = []
+
+      paths.extend( os.path.join( include_path, path_dir, relative_path ) for
+                    relative_path in relative_paths  )
+    return paths
+
+
   def ComputeCandidatesInner( self, request_data ):
     filename = request_data[ 'filepath' ]
     if not filename:
       return
+
+    paths = self.GetIncludePaths( request_data )
+    if paths is not None:
+      return GenerateCandidatesForPaths( paths )
 
     if self._completer.UpdatingTranslationUnit(
         ToCppStringCompatible( filename ) ):
@@ -220,18 +276,19 @@ class ClangCompleter( Completer ):
 
   def _ResponseForInclude( self, request_data ):
     """Returns response for include file location if cursor is on the
-       include statement, None otherwise.
-       Throws RuntimeError if cursor is on include statement and corresponding
-       include file not found."""
+    include statement, None otherwise.
+    Throws RuntimeError if cursor is on include statement and corresponding
+    include file not found."""
     current_line = request_data[ 'line_value' ]
-    include_file_name, quoted_include = GetIncludeStatementValue( current_line )
+    include_file_name, quoted_include, _ = GetIncludeStatementValue(
+        current_line )
     if not include_file_name:
       return None
 
+    flags = self._FlagsForRequest( request_data )
     current_file_path = request_data[ 'filepath' ]
-    client_data = request_data.get( 'extra_conf_data', None )
-    quoted_include_paths, include_paths = (
-            self._flags.UserIncludePaths( current_file_path, client_data ) )
+    quoted_include_paths, include_paths = UserIncludePaths( flags,
+                                                            current_file_path )
     if quoted_include:
       include_file_path = _GetAbsolutePath( include_file_name,
                                             quoted_include_paths )
@@ -429,10 +486,6 @@ def ClangAvailableForFiletypes( filetypes ):
   return any( [ filetype in CLANG_FILETYPES for filetype in filetypes ] )
 
 
-def InCFamilyFile( filetypes ):
-  return ClangAvailableForFiletypes( filetypes )
-
-
 def _FilterDiagnostics( diagnostics ):
   # Clang has an annoying warning that shows up when we try to compile header
   # files if the header has "#pragma once" inside it. The error is not
@@ -523,3 +576,40 @@ def _GetAbsolutePath( include_file_name, include_paths ):
     if os.path.isfile( include_file_path ):
       return include_file_path
   return None
+
+
+def GetIncludeStatementValue( line, check_closing = True ):
+  """Returns the tuple |include_value|, |quoted_include|, |start_codepoint|
+  where:
+  - |include_value| is the string from the opening quote or bracket of the
+    include statement in |line|. If |check_closing| is True, the whole string
+    between the quotes or brackets is returned. None if no include statement is
+    found or if |check_closing| is True and there is no closing quote or
+    bracket;
+  - |quoted_include| is True if the statement is a quoted include, False
+    otherwise;
+  - |start_column| is the 1-based column where the completion should start (i.e.
+    at the last path separator '/' or at the opening quote or bracket). None if
+    no include statement is matched or |check_closing| is True."""
+  match = INCLUDE_REGEX.match( line )
+  include_value = None
+  quoted_include = False
+  start_codepoint = None
+  if match:
+    include_start = match.end( 1 ) + 1
+    quoted_include = ( line[ include_start - 1 ] == '"' )
+    if not check_closing:
+      separator_char = '/'
+      separator_char_pos = line.rfind( separator_char, match.end( 1 ) )
+      if separator_char_pos != -1:
+        include_value = line[ include_start : separator_char_pos + 1 ]
+        start_codepoint = separator_char_pos + 2
+      else:
+        include_value = ''
+        start_codepoint = include_start + 1
+    else:
+      close_char = '"' if quoted_include else '>'
+      close_char_pos = line.find( close_char, match.end() )
+      if close_char_pos != -1:
+        include_value = line[ include_start : close_char_pos ]
+  return include_value, quoted_include, start_codepoint

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -141,6 +141,7 @@ class Flags( object ):
 
     if add_extra_clang_flags:
       flags += self.extra_clang_flags
+      flags = _AddMacIncludePaths( flags )
 
     sanitized_flags = PrepareFlagsForClang( flags,
                                             filename,
@@ -277,9 +278,6 @@ def PrepareFlagsForClang( flags, filename, add_extra_clang_flags = True ):
   flags = _RemoveXclangFlags( flags )
   flags = _RemoveUnusedFlags( flags, filename )
   if add_extra_clang_flags:
-    if OnMac() and not _SysRootSpecifedIn( flags ):
-      for path in _MacIncludePaths():
-        flags.extend( [ '-isystem', path ] )
     flags = _EnableTypoCorrection( flags )
 
   vector = ycm_core.StringVector()
@@ -476,9 +474,11 @@ if OnMac():
   )
 
 
-def _MacIncludePaths():
-  # This method exists for testing only
-  return MAC_INCLUDE_PATHS
+def _AddMacIncludePaths( flags ):
+  if OnMac() and not _SysRootSpecifedIn( flags ):
+    for path in MAC_INCLUDE_PATHS:
+      flags.extend( [ '-isystem', path ] )
+  return flags
 
 
 def _ExtraClangFlags():

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -438,36 +438,28 @@ def CompilationDatabase_NoDatabase_test():
 
 
 @MacOnly
-@patch( 'ycmd.completers.cpp.flags._MacIncludePaths',
-        return_value = [ 'sentinel_value_for_testing' ] )
-def PrepareFlagsForClang_NoSysroot_test( *args ):
+@patch( 'ycmd.completers.cpp.flags.MAC_INCLUDE_PATHS',
+        [ 'sentinel_value_for_testing' ] )
+def AddMacIncludePaths_NoSysroot_test():
   assert_that(
-    list( flags.PrepareFlagsForClang( [ '-test', '--test1', '--test2=test' ],
-                                      'test.cc',
-                                      True ) ),
+    flags._AddMacIncludePaths( [ '-test', '--test1', '--test2=test' ] ),
     has_item( 'sentinel_value_for_testing' ) )
 
 
 @MacOnly
-@patch( 'ycmd.completers.cpp.flags._MacIncludePaths',
-        return_value = [ 'sentinel_value_for_testing' ] )
-def PrepareFlagsForClang_Sysroot_test( *args ):
+@patch( 'ycmd.completers.cpp.flags.MAC_INCLUDE_PATHS',
+        [ 'sentinel_value_for_testing' ] )
+def AddIncludePaths_Sysroot_test():
   assert_that(
-    list( flags.PrepareFlagsForClang( [ '-isysroot', 'test1', '--test2=test' ],
-                                      'test.cc',
-                                      True ) ),
+    flags._AddMacIncludePaths( [ '-isysroot', 'test1', '--test2=test' ] ),
     not_( has_item( 'sentinel_value_for_testing' ) ) )
 
   assert_that(
-    list( flags.PrepareFlagsForClang( [ '-test', '--sysroot', 'test1' ],
-                                      'test.cc',
-                                      True ) ),
+    flags._AddMacIncludePaths( [ '-test', '--sysroot', 'test1' ] ),
     not_( has_item( 'sentinel_value_for_testing' ) ) )
 
   assert_that(
-    list( flags.PrepareFlagsForClang( [ '-test', 'test1', '--sysroot=test' ],
-                                      'test.cc',
-                                      True ) ),
+    flags._AddMacIncludePaths( [ '-test', 'test1', '--sysroot=test' ] ),
     not_( has_item( 'sentinel_value_for_testing' ) ) )
 
 

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -483,7 +483,7 @@ def GetCompletions_ClientDataGivenToExtraConf_test( app ):
 
 
 @IsolatedYcmd( { 'max_num_candidates': 0 } )
-def GetCompletions_FilenameCompleter_ClientDataGivenToExtraConf_test( app ):
+def GetCompletions_Include_ClientDataGivenToExtraConf_test( app ):
   app.post_json(
     '/load_extra_conf_file',
     { 'filepath': PathToTestFile( 'client_data',
@@ -561,6 +561,403 @@ def GetCompletions_UnicodeInLineFilter_test( app ):
         'completions': contains_inanyorder(
           CompletionEntryMatcher( 'member_with_å_unicøde', 'int' ),
         ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_QuotedInclude_AtStart_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include "',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 9,
+      'column_num': 11,
+      'compilation_flags': [ '-x', 'cpp' ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 11,
+        'completions': contains(
+          CompletionEntryMatcher( '.ycm_extra_conf.py', '[File]' ),
+          CompletionEntryMatcher( 'a.hpp',              '[File]' ),
+          CompletionEntryMatcher( 'dir with spaces',    '[Dir]'  ),
+          CompletionEntryMatcher( 'main.cpp',           '[File]' ),
+          CompletionEntryMatcher( 'quote',              '[Dir]' ),
+          CompletionEntryMatcher( 'system',             '[Dir]' )
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_QuotedInclude_UserIncludeFlag_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include " with a -I flag',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 9,
+      'column_num': 11,
+      'compilation_flags': [
+        '-x', 'cpp',
+        '-I', PathToTestFile( 'test-include', 'system' )
+      ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 11,
+        'completions': contains(
+          CompletionEntryMatcher( '.ycm_extra_conf.py', '[File]' ),
+          CompletionEntryMatcher( 'a.hpp',              '[File]' ),
+          CompletionEntryMatcher( 'c.hpp',              '[File]' ),
+          CompletionEntryMatcher( 'dir with spaces',    '[Dir]'  ),
+          CompletionEntryMatcher( 'main.cpp',           '[File]' ),
+          CompletionEntryMatcher( 'quote',              '[Dir]'  ),
+          CompletionEntryMatcher( 'system',             '[Dir]'  )
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_QuotedInclude_SystemIncludeFlag_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include " with a -isystem flag',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 9,
+      'column_num': 11,
+      'compilation_flags': [
+        '-x', 'cpp',
+        '-isystem', PathToTestFile( 'test-include', 'system' )
+      ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 11,
+        'completions': contains(
+          CompletionEntryMatcher( '.ycm_extra_conf.py', '[File]' ),
+          CompletionEntryMatcher( 'a.hpp',              '[File]' ),
+          CompletionEntryMatcher( 'c.hpp',              '[File]' ),
+          CompletionEntryMatcher( 'dir with spaces',    '[Dir]'  ),
+          CompletionEntryMatcher( 'main.cpp',           '[File]' ),
+          CompletionEntryMatcher( 'quote',              '[Dir]'  ),
+          CompletionEntryMatcher( 'system',             '[Dir]'  )
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_QuotedInclude_QuoteIncludeFlag_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include " with a -iquote flag',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 9,
+      'column_num': 11,
+      'compilation_flags': [
+        '-x', 'cpp',
+        '-iquote', PathToTestFile( 'test-include', 'quote' )
+      ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 11,
+        'completions': contains(
+          CompletionEntryMatcher( '.ycm_extra_conf.py', '[File]' ),
+          CompletionEntryMatcher( 'a.hpp',              '[File]' ),
+          CompletionEntryMatcher( 'b.hpp',              '[File]' ),
+          CompletionEntryMatcher( 'dir with spaces',    '[Dir]'  ),
+          CompletionEntryMatcher( 'main.cpp',           '[File]' ),
+          CompletionEntryMatcher( 'quote',              '[Dir]'  ),
+          CompletionEntryMatcher( 'system',             '[Dir]'  )
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_QuotedInclude_MultipleIncludeFlags_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include " with multiple -I flags',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 9,
+      'column_num': 11,
+      'compilation_flags': [
+        '-x', 'cpp',
+        '-I', PathToTestFile( 'test-include', 'dir with spaces' ),
+        '-I', PathToTestFile( 'test-include', 'quote' ),
+        '-I', PathToTestFile( 'test-include', 'system' )
+      ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 11,
+        'completions': contains(
+          CompletionEntryMatcher( '.ycm_extra_conf.py', '[File]' ),
+          CompletionEntryMatcher( 'a.hpp',              '[File]' ),
+          CompletionEntryMatcher( 'b.hpp',              '[File]' ),
+          CompletionEntryMatcher( 'c.hpp',              '[File]' ),
+          CompletionEntryMatcher( 'd.hpp',              '[File]' ),
+          CompletionEntryMatcher( 'dir with spaces',    '[Dir]' ),
+          CompletionEntryMatcher( 'main.cpp',           '[File]' ),
+          CompletionEntryMatcher( 'quote',              '[Dir]'  ),
+          CompletionEntryMatcher( 'system',             '[Dir]'  )
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_QuotedInclude_AfterDirectorySeparator_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include "quote/',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 9,
+      'column_num': 27,
+      'compilation_flags': [ '-x', 'cpp' ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 27,
+        'completions': contains(
+          CompletionEntryMatcher( 'd.hpp', '[File]' )
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_QuotedInclude_AfterDot_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include "quote/b.',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 9,
+      'column_num': 28,
+      'compilation_flags': [ '-x', 'cpp' ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 27,
+        'completions': contains(
+          CompletionEntryMatcher( 'd.hpp', '[File]' )
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_QuotedInclude_AfterSpace_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include "dir with ',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 9,
+      'column_num': 20,
+      'compilation_flags': [ '-x', 'cpp' ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 11,
+        'completions': contains(
+          CompletionEntryMatcher( 'dir with spaces', '[Dir]' )
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_BracketInclude_AtStart_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include <',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 10,
+      'column_num': 11,
+      'compilation_flags': [ '-x', 'cpp' ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 11,
+        'completions': empty(),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_BracketInclude_UserIncludeFlag_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include < with a -I flag',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 10,
+      'column_num': 11,
+      'compilation_flags': [
+        '-x', 'cpp',
+        '-I', PathToTestFile( 'test-include', 'system' )
+      ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 11,
+        'completions': contains(
+          CompletionEntryMatcher( 'a.hpp', '[File]' ),
+          CompletionEntryMatcher( 'c.hpp', '[File]' )
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_BracketInclude_SystemIncludeFlag_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include < with a -isystem flag',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 10,
+      'column_num': 11,
+      'compilation_flags': [
+        '-x', 'cpp',
+        '-isystem', PathToTestFile( 'test-include', 'system' )
+      ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 11,
+        'completions': contains(
+          CompletionEntryMatcher( 'a.hpp', '[File]' ),
+          CompletionEntryMatcher( 'c.hpp', '[File]' )
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_BracketInclude_QuoteIncludeFlag_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include < with a -iquote flag',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 10,
+      'column_num': 11,
+      'compilation_flags': [
+        '-x', 'cpp',
+        '-iquote', PathToTestFile( 'test-include', 'quote' )
+      ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 11,
+        'completions': empty(),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_BracketInclude_MultipleIncludeFlags_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include < with multiple -I flags',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 10,
+      'column_num': 11,
+      'compilation_flags': [
+        '-x', 'cpp',
+        '-I', PathToTestFile( 'test-include', 'dir with spaces' ),
+        '-I', PathToTestFile( 'test-include', 'quote' ),
+        '-I', PathToTestFile( 'test-include', 'system' )
+      ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 11,
+        'completions': contains(
+          CompletionEntryMatcher( 'a.hpp', '[File]' ),
+          CompletionEntryMatcher( 'b.hpp', '[File]' ),
+          CompletionEntryMatcher( 'c.hpp', '[File]' ),
+          CompletionEntryMatcher( 'd.hpp', '[File]' )
+        ),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_BracketInclude_AtDirectorySeparator_test( app ):
+  RunTest( app, {
+    'description': 'completion of #include <system/',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 10,
+      'column_num': 18,
+      'compilation_flags': [ '-x', 'cpp' ],
+      # NOTE: when not forcing semantic, it falls back to the filename
+      # completer and returns the root folder entries.
+      'force_semantic': True
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 18,
+        'completions': empty(),
         'errors': empty(),
       } )
     },

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -287,6 +287,18 @@ def Subcommands_GoToInclude_Fail_test():
     calling( RunGoToIncludeTest ).with_args( 'GoToImprecise', test ),
     raises( AppError, r'Can\\\'t jump to definition or declaration.' ) )
 
+  # Unclosed #include statement.
+  test = { 'request': [ 10, 13 ], 'response': '' }
+  assert_that(
+    calling( RunGoToIncludeTest ).with_args( 'GoToInclude', test ),
+    raises( AppError, 'Not an include/import line.' ) )
+  assert_that(
+    calling( RunGoToIncludeTest ).with_args( 'GoTo', test ),
+    raises( AppError, r'Can\\\'t jump to definition or declaration.' ) )
+  assert_that(
+    calling( RunGoToIncludeTest ).with_args( 'GoToImprecise', test ),
+    raises( AppError, r'Can\\\'t jump to definition or declaration.' ) )
+
 
 @SharedYcmd
 def RunGetSemanticTest( app, filename, test, command):

--- a/ycmd/tests/clang/testdata/test-include/main.cpp
+++ b/ycmd/tests/clang/testdata/test-include/main.cpp
@@ -5,3 +5,6 @@
 #include "c.hpp" // system/c.hpp
 #include <c.hpp> // system/c.hpp
 // not an #include line
+
+#include "dir with spaces/d.hpp"
+#include <system/

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -284,6 +284,18 @@ def GetCompletions_IdentifierCompleter_IgnoreCursorIdentifierInString_test(
 
 
 @SharedYcmd
+def GetCompletions_FilenameCompleter_Works_test( app ):
+  filepath = PathToTestFile( 'filename_completer', 'test.foo' )
+  completion_data = BuildRequest( filepath = filepath,
+                                  contents = './',
+                                  column_num = 3 )
+  results = app.post_json( '/completions',
+                           completion_data ).json[ 'completions' ]
+  assert_that( results,
+               has_items( CompletionEntryMatcher( 'inner_dir', '[Dir]' ) ) )
+
+
+@SharedYcmd
 def GetCompletions_UltiSnipsCompleter_Works_test( app ):
   event_data = BuildRequest(
     event_name = 'BufferVisit',


### PR DESCRIPTION
This PR fixes the issue where completion is interrupted after inserting a non-identifier character in include statements. See issues https://github.com/Valloric/YouCompleteMe/issues/281 and https://github.com/Valloric/YouCompleteMe/issues/1553.

This is done by moving the include completion logic from the filename completer to the Clang one and by setting the start column to the right position thanks to PR https://github.com/Valloric/ycmd/pull/681. A benefit of moving the logic to the Clang completer is that `<C-Space>` now works in include statements.

Here's a demo before the changes:

![include-statement-before](https://user-images.githubusercontent.com/10026824/30808129-1c03f634-a1fd-11e7-8de3-0fcc84424d89.gif)

and after:

![include-statement-after](https://user-images.githubusercontent.com/10026824/30808134-1e8446e8-a1fd-11e7-9cbe-7bf9b7583fb2.gif)

You'll notice that no error is shown to the user after inserting the dot.





Fixes https://github.com/Valloric/YouCompleteMe/issues/281.
Fixes https://github.com/Valloric/YouCompleteMe/issues/1553.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/843)
<!-- Reviewable:end -->
