### PR TITLE
[READY] Fix Rust debug info test when rustup is installed

### DIFF
--- a/ycmd/tests/rust/debug_info_test.py
+++ b/ycmd/tests/rust/debug_info_test.py
@@ -22,7 +22,8 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from hamcrest import assert_that, contains, has_entries, has_entry, instance_of
+from hamcrest import ( any_of, assert_that, contains, has_entries, has_entry,
+                       instance_of, none )
 
 from ycmd.tests.rust import SharedYcmd
 from ycmd.tests.test_utils import BuildRequest
@@ -47,7 +48,7 @@ def DebugInfo_test( app ):
       } ) ),
       'items': contains( has_entries( {
         'key': 'Rust sources',
-        'value': None
+        'value': any_of( none(), instance_of( str ) )
       } ) )
     } ) )
   )


### PR DESCRIPTION
Since PR https://github.com/Valloric/ycmd/pull/785, the Rust debug info test fails if the Rust sources have been downloaded with rustup on the machine running the tests. We should check that the Rust sources value is either `None` or a string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/850)
<!-- Reviewable:end -->
