### PR TITLE
[READY] Rename completer options

### DIFF
--- a/build.py
+++ b/build.py
@@ -254,25 +254,24 @@ def GetGenerator( args ):
 def ParseArguments():
   parser = argparse.ArgumentParser()
   parser.add_argument( '--clang-completer', action = 'store_true',
-                       help = 'Build C-family semantic completion engine.' )
-  parser.add_argument( '--system-libclang', action = 'store_true',
-                       help = 'Use system libclang instead of downloading one '
-                       'from llvm.org. NOT RECOMMENDED OR SUPPORTED!' )
-  parser.add_argument( '--omnisharp-completer', action = 'store_true',
-                       help = 'Build C# semantic completion engine.' )
-  parser.add_argument( '--gocode-completer', action = 'store_true',
-                       help = 'Build Go semantic completion engine.' )
-  parser.add_argument( '--racer-completer', action = 'store_true',
-                       help = 'Build rust semantic completion engine.' )
+                       help = 'Enable C-family semantic completion engine.' )
+  parser.add_argument( '--cs-completer', action = 'store_true',
+                       help = 'Enable C# semantic completion engine.' )
+  parser.add_argument( '--go-completer', action = 'store_true',
+                       help = 'Enable Go semantic completion engine.' )
+  parser.add_argument( '--rust-completer', action = 'store_true',
+                       help = 'Enable Rust semantic completion engine.' )
+  parser.add_argument( '--js-completer', action = 'store_true',
+                       help = 'Enable JavaScript semantic completion engine.' ),
   parser.add_argument( '--system-boost', action = 'store_true',
                        help = 'Use the system boost instead of bundled one. '
                        'NOT RECOMMENDED OR SUPPORTED!')
+  parser.add_argument( '--system-libclang', action = 'store_true',
+                       help = 'Use system libclang instead of downloading one '
+                       'from llvm.org. NOT RECOMMENDED OR SUPPORTED!' )
   parser.add_argument( '--msvc', type = int, choices = [ 12, 14, 15 ],
                        default = 15, help = 'Choose the Microsoft Visual '
                        'Studio version (default: %(default)s).' )
-  parser.add_argument( '--tern-completer',
-                       action = 'store_true',
-                       help   = 'Enable tern javascript completer' ),
   parser.add_argument( '--all',
                        action = 'store_true',
                        help   = 'Enable all supported completers',
@@ -290,6 +289,16 @@ def ParseArguments():
                                 'specified directory, and do not delete the '
                                 'build output. This is useful for incremental '
                                 'builds, and required for coverage data' )
+
+  # These options are deprecated.
+  parser.add_argument( '--omnisharp-completer', action = 'store_true',
+                       help = argparse.SUPPRESS )
+  parser.add_argument( '--gocode-completer', action = 'store_true',
+                       help = argparse.SUPPRESS )
+  parser.add_argument( '--racer-completer', action = 'store_true',
+                       help = argparse.SUPPRESS )
+  parser.add_argument( '--tern-completer', action = 'store_true',
+                       help = argparse.SUPPRESS ),
 
   args = parser.parse_args()
 
@@ -446,7 +455,7 @@ def BuildYcmdLib( args ):
       rmtree( build_dir, ignore_errors = OnTravisOrAppVeyor() )
 
 
-def BuildOmniSharp():
+def EnableCsCompleter():
   build_command = PathToFirstExistingExecutable(
     [ 'msbuild', 'msbuild.exe', 'xbuild' ] )
   if not build_command:
@@ -457,7 +466,7 @@ def BuildOmniSharp():
                               '/property:TargetFrameworkVersion=v4.5' ] )
 
 
-def BuildGoCode():
+def EnableGoCompleter():
   if not FindExecutable( 'go' ):
     sys.exit( 'ERROR: go is required to build gocode.' )
 
@@ -467,7 +476,7 @@ def BuildGoCode():
   CheckCall( [ 'go', 'build', 'godef.go' ] )
 
 
-def BuildRacerd():
+def EnableRustCompleter():
   """
   Build racerd. This requires a reasonably new version of rustc/cargo.
   """
@@ -483,7 +492,7 @@ def BuildRacerd():
   CheckCall( args )
 
 
-def SetUpTern():
+def EnableJavaScriptCompleter():
   # On Debian-based distributions, node is by default installed as nodejs.
   node = PathToFirstExistingExecutable( [ 'nodejs', 'node' ] )
   if not node:
@@ -526,14 +535,14 @@ def Main():
   ExitIfYcmdLibInUseOnWindows()
   BuildYcmdLib( args )
   WritePythonUsedDuringBuild()
-  if args.omnisharp_completer or args.all_completers:
-    BuildOmniSharp()
-  if args.gocode_completer or args.all_completers:
-    BuildGoCode()
-  if args.tern_completer or args.all_completers:
-    SetUpTern()
-  if args.racer_completer or args.all_completers:
-    BuildRacerd()
+  if args.cs_completer or args.omnisharp_completer or args.all_completers:
+    EnableCsCompleter()
+  if args.go_completer or args.gocode_completer or args.all_completers:
+    EnableGoCompleter()
+  if args.js_completer or args.tern_completer or args.all_completers:
+    EnableJavaScriptCompleter()
+  if args.rust_completer or args.racer_completer or args.all_completers:
+    EnableRustCompleter()
 
 
 if __name__ == '__main__':

--- a/run_tests.py
+++ b/run_tests.py
@@ -56,22 +56,22 @@ COMPLETERS = {
     'aliases': [ 'c', 'cpp', 'c++', 'objc', 'clang', ]
   },
   'cs': {
-    'build': [ '--omnisharp-completer' ],
+    'build': [ '--cs-completer' ],
     'test': [ '--exclude-dir=ycmd/tests/cs' ],
     'aliases': [ 'omnisharp', 'csharp', 'c#' ]
   },
   'javascript': {
-    'build': [ '--tern-completer' ],
+    'build': [ '--js-completer' ],
     'test': [ '--exclude-dir=ycmd/tests/javascript' ],
     'aliases': [ 'js', 'tern' ]
   },
   'go': {
-    'build': [ '--gocode-completer' ],
+    'build': [ '--go-completer' ],
     'test': [ '--exclude-dir=ycmd/tests/go' ],
     'aliases': [ 'gocode' ]
   },
   'rust': {
-    'build': [ '--racer-completer' ],
+    'build': [ '--rust-completer' ],
     'test': [ '--exclude-dir=ycmd/tests/rust' ],
     'aliases': [ 'racer', 'racerd', ]
   },

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -42,7 +42,7 @@ from ycmd import utils
 
 SERVER_NOT_FOUND_MSG = ( 'OmniSharp server binary not found at {0}. ' +
                          'Did you compile it? You can do so by running ' +
-                         '"./install.py --omnisharp-completer".' )
+                         '"./install.py --cs-completer".' )
 INVALID_FILE_MESSAGE = 'File is invalid.'
 NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 PATH_TO_OMNISHARP_BINARY = os.path.abspath(

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -36,7 +36,7 @@ from ycmd.completers.completer import Completer
 
 BINARY_NOT_FOUND_MESSAGE = ( '{0} binary not found. Did you build it? '
                              'You can do so by running '
-                             '"./install.py --gocode-completer".' )
+                             '"./install.py --go-completer".' )
 SHELL_ERROR_MESSAGE = ( 'Command {command} failed with code {code} and error '
                         '"{error}".' )
 COMPUTE_OFFSET_ERROR_MESSAGE = ( 'Go completer could not compute byte offset '

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -63,7 +63,7 @@ LOGFILE_FORMAT = 'tern_{port}_{std}_'
 def ShouldEnableTernCompleter():
   """Returns whether or not the tern completer is 'installed'. That is whether
   or not the tern submodule has a 'node_modules' directory. This is pretty much
-  the only way we can know if the user added '--tern-completer' on
+  the only way we can know if the user added '--js-completer' on
   install or manually ran 'npm install' in the tern submodule directory."""
 
   if not PATH_TO_NODE:

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -56,7 +56,7 @@ HMAC_SECRET_LENGTH = 16
 
 BINARY_NOT_FOUND_MESSAGE = (
   'racerd binary not found. Did you build it? '
-  'You can do so by running "./build.py --racer-completer".' )
+  'You can do so by running "./build.py --rust-completer".' )
 NON_EXISTING_RUST_SOURCES_PATH_MESSAGE = (
   'Rust sources path does not exist. Check the value of the rust_src_path '
   'option or the RUST_SRC_PATH environment variable.' )


### PR DESCRIPTION
It's more intuitive for users if completer options are named after the language and not after the semantic engine e.g. `--rust-completer` instead of `--racer-completer`. To preserve backward compatibility, we keep the old options but deprecate them by hiding them from the `--help` output. We don't rename `--clang-completer` since `clang` is really well known and an appropriate name to designate C-family languages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/851)
<!-- Reviewable:end -->
