### PR TITLE
[READY] Restore extra_conf_store singleton after isolated tests

### DIFF
--- a/ycmd/extra_conf_store.py
+++ b/ycmd/extra_conf_store.py
@@ -46,6 +46,15 @@ _module_file_for_source_file = {}
 _module_file_for_source_file_lock = Lock()
 
 
+def Get():
+  return _module_for_module_file, _module_file_for_source_file
+
+
+def Set( state ):
+  global _module_for_module_file, _module_file_for_source_file
+  _module_for_module_file, _module_file_for_source_file = state
+
+
 def Reset():
   global _module_for_module_file, _module_file_for_source_file
   _module_for_module_file = {}

--- a/ycmd/tests/__init__.py
+++ b/ycmd/tests/__init__.py
@@ -25,8 +25,7 @@ from builtins import *  # noqa
 import functools
 import os
 
-from ycmd import handlers
-from ycmd.tests.test_utils import ClearCompletionsCache, SetUpApp
+from ycmd.tests.test_utils import ClearCompletionsCache, IsolatedApp, SetUpApp
 
 shared_app = None
 
@@ -81,11 +80,7 @@ def IsolatedYcmd( custom_options = {} ):
   def Decorator( test ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
-      old_server_state = handlers._server_state
-      app = SetUpApp( custom_options )
-      try:
+      with IsolatedApp( custom_options ) as app:
         test( app, *args, **kwargs )
-      finally:
-        handlers._server_state = old_server_state
     return Wrapper
   return Decorator

--- a/ycmd/tests/clang/__init__.py
+++ b/ycmd/tests/clang/__init__.py
@@ -29,9 +29,8 @@ import contextlib
 import json
 import shutil
 
-from ycmd import handlers
 from ycmd.utils import ToUnicode
-from ycmd.tests.test_utils import ClearCompletionsCache, SetUpApp
+from ycmd.tests.test_utils import ClearCompletionsCache, IsolatedApp, SetUpApp
 
 shared_app = None
 
@@ -77,7 +76,7 @@ def IsolatedYcmd( custom_options = {} ):
 
   Example usage:
 
-    from ycmd.tests.python import IsolatedYcmd
+    from ycmd.tests.clang import IsolatedYcmd
 
     @IsolatedYcmd( { 'auto_trigger': 0 } )
     def CustomAutoTrigger_test( app ):
@@ -86,11 +85,8 @@ def IsolatedYcmd( custom_options = {} ):
   def Decorator( test ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
-      old_server_state = handlers._server_state
-      try:
-        test( SetUpApp( custom_options ), *args, **kwargs )
-      finally:
-        handlers._server_state = old_server_state
+      with IsolatedApp( custom_options ) as app:
+        test( app, *args, **kwargs )
     return Wrapper
   return Decorator
 

--- a/ycmd/tests/cs/__init__.py
+++ b/ycmd/tests/cs/__init__.py
@@ -26,9 +26,9 @@ from contextlib import contextmanager
 import functools
 import os
 
-from ycmd import handlers
-from ycmd.tests.test_utils import ( ClearCompletionsCache, SetUpApp,
-                                    StartCompleterServer, StopCompleterServer,
+from ycmd.tests.test_utils import ( ClearCompletionsCache, IsolatedApp,
+                                    SetUpApp, StartCompleterServer,
+                                    StopCompleterServer,
                                     WaitUntilCompleterServerReady )
 
 shared_app = None
@@ -99,7 +99,7 @@ def IsolatedYcmd( custom_options = {} ):
 
   Example usage:
 
-    from ycmd.tests.python import IsolatedYcmd
+    from ycmd.tests.cs import IsolatedYcmd
 
     @IsolatedYcmd( { 'server_keep_logfiles': 1 } )
     def CustomServerKeepLogfiles_test( app ):
@@ -108,14 +108,10 @@ def IsolatedYcmd( custom_options = {} ):
   def Decorator( test ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
-      old_server_state = handlers._server_state
-      app = SetUpApp( custom_options )
-      try:
+      with IsolatedApp( custom_options ) as app:
         app.post_json(
           '/ignore_extra_conf_file',
           { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
         test( app, *args, **kwargs )
-      finally:
-        handlers._server_state = old_server_state
     return Wrapper
   return Decorator

--- a/ycmd/tests/go/__init__.py
+++ b/ycmd/tests/go/__init__.py
@@ -25,9 +25,8 @@ from builtins import *  # noqa
 import functools
 import os
 
-from ycmd import handlers
-from ycmd.tests.test_utils import ( ClearCompletionsCache, SetUpApp,
-                                    StopCompleterServer,
+from ycmd.tests.test_utils import ( ClearCompletionsCache, IsolatedApp,
+                                    SetUpApp, StopCompleterServer,
                                     WaitUntilCompleterServerReady )
 
 shared_app = None
@@ -79,11 +78,9 @@ def IsolatedYcmd( test ):
   Do NOT attach it to test generators but directly to the yielded tests."""
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
-    old_server_state = handlers._server_state
-    app = SetUpApp()
-    try:
-      test( app, *args, **kwargs )
-    finally:
-      StopCompleterServer( app, 'go' )
-      handlers._server_state = old_server_state
+    with IsolatedApp() as app:
+      try:
+        test( app, *args, **kwargs )
+      finally:
+        StopCompleterServer( app, 'go' )
   return Wrapper

--- a/ycmd/tests/javascript/__init__.py
+++ b/ycmd/tests/javascript/__init__.py
@@ -25,11 +25,9 @@ from builtins import *  # noqa
 import functools
 import os
 
-from ycmd import handlers
 from ycmd.tests.test_utils import ( ClearCompletionsCache,
-                                    CurrentWorkingDirectory,
-                                    SetUpApp,
-                                    StopCompleterServer,
+                                    CurrentWorkingDirectory, IsolatedApp,
+                                    SetUpApp, StopCompleterServer,
                                     WaitUntilCompleterServerReady )
 from ycmd.utils import GetCurrentDirectory
 
@@ -101,14 +99,11 @@ def IsolatedYcmdInDirectory( directory ):
   def Decorator( test ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
-      old_server_state = handlers._server_state
-      app = SetUpApp()
-      try:
-        with CurrentWorkingDirectory( directory ):
-          test( app, *args, **kwargs )
-      finally:
-        StopCompleterServer( app, 'javascript' )
-        handlers._server_state = old_server_state
+      with IsolatedApp() as app:
+        try:
+          with CurrentWorkingDirectory( directory ):
+            test( app, *args, **kwargs )
+        finally:
+          StopCompleterServer( app, 'javascript' )
     return Wrapper
-
   return Decorator

--- a/ycmd/tests/python/__init__.py
+++ b/ycmd/tests/python/__init__.py
@@ -25,9 +25,8 @@ from builtins import *  # noqa
 import functools
 import os
 
-from ycmd import handlers
-from ycmd.tests.test_utils import ( ClearCompletionsCache, SetUpApp,
-                                    StopCompleterServer,
+from ycmd.tests.test_utils import ( ClearCompletionsCache, IsolatedApp,
+                                    SetUpApp, StopCompleterServer,
                                     WaitUntilCompleterServerReady )
 
 shared_app = None
@@ -92,12 +91,10 @@ def IsolatedYcmd( custom_options = {} ):
   def Decorator( test ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
-      old_server_state = handlers._server_state
-      app = SetUpApp( custom_options )
-      try:
-        test( app, *args, **kwargs )
-      finally:
-        StopCompleterServer( app, 'python' )
-        handlers._server_state = old_server_state
+      with IsolatedApp( custom_options ) as app:
+        try:
+          test( app, *args, **kwargs )
+        finally:
+          StopCompleterServer( app, 'python' )
     return Wrapper
   return Decorator

--- a/ycmd/tests/rust/__init__.py
+++ b/ycmd/tests/rust/__init__.py
@@ -25,9 +25,8 @@ from builtins import *  # noqa
 import functools
 import os
 
-from ycmd import handlers
-from ycmd.tests.test_utils import ( ClearCompletionsCache, SetUpApp,
-                                    StopCompleterServer,
+from ycmd.tests.test_utils import ( ClearCompletionsCache, IsolatedApp,
+                                    SetUpApp, StopCompleterServer,
                                     WaitUntilCompleterServerReady )
 
 shared_app = None
@@ -92,12 +91,10 @@ def IsolatedYcmd( custom_options = {} ):
   def Decorator( test ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
-      old_server_state = handlers._server_state
-      app = SetUpApp( custom_options )
-      try:
-        test( app, *args, **kwargs )
-      finally:
-        StopCompleterServer( app, 'rust' )
-        handlers._server_state = old_server_state
+      with IsolatedApp( custom_options ) as app:
+        try:
+          test( app, *args, **kwargs )
+        finally:
+          StopCompleterServer( app, 'rust' )
     return Wrapper
   return Decorator

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -191,6 +191,17 @@ def SetUpApp( custom_options = {} ):
   return TestApp( handlers.app )
 
 
+@contextlib.contextmanager
+def IsolatedApp( custom_options = {} ):
+  old_server_state = handlers._server_state
+  old_extra_conf_store_state = extra_conf_store.Get()
+  try:
+    yield SetUpApp( custom_options )
+  finally:
+    handlers._server_state = old_server_state
+    extra_conf_store.Set( old_extra_conf_store_state )
+
+
 def StartCompleterServer( app, filetype, filepath = '/foo' ):
   app.post_json( '/run_completer_command',
                  BuildRequest( command_arguments = [ 'RestartServer' ],

--- a/ycmd/tests/typescript/__init__.py
+++ b/ycmd/tests/typescript/__init__.py
@@ -25,9 +25,8 @@ from builtins import *  # noqa
 import functools
 import os
 
-from ycmd import handlers
-from ycmd.tests.test_utils import ( ClearCompletionsCache, SetUpApp,
-                                    StopCompleterServer,
+from ycmd.tests.test_utils import ( ClearCompletionsCache, IsolatedApp,
+                                    SetUpApp, StopCompleterServer,
                                     WaitUntilCompleterServerReady )
 
 shared_app = None
@@ -79,11 +78,9 @@ def IsolatedYcmd( test ):
   Do NOT attach it to test generators but directly to the yielded tests."""
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
-    old_server_state = handlers._server_state
-    app = SetUpApp()
-    try:
-      test( app, *args, **kwargs )
-    finally:
-      StopCompleterServer( app, 'typescript' )
-      handlers._server_state = old_server_state
+    with IsolatedApp() as app:
+      try:
+        test( app, *args, **kwargs )
+      finally:
+        StopCompleterServer( app, 'typescript' )
   return Wrapper


### PR DESCRIPTION
The `extra_conf_store` module being a singleton, its state is modified when loading or ignoring a `.ycm_extra_conf.py` file during an isolated test, which may affect other tests. To avoid that, we restore its state (more precisely [its singleton variables](https://github.com/Valloric/ycmd/blob/bfe0db9f707e08babdf96bdeadf14708db851163/ycmd/extra_conf_store.py#L43-L46)) at the end of each isolated test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/852)
<!-- Reviewable:end -->
