### PR TITLE
When list duplicated c++/v1 using isystem, include_next will go crazy

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -438,12 +438,17 @@ def _RemoveUnusedFlags( flags, filename ):
 #
 # Most users have xcode installed, but in order to be as compatible as
 # possible we consider both possible installation locations
-MAC_CLANG_TOOLCHAIN_DIRS = [
-  '/Applications/Xcode.app/Contents/Developer/Toolchains/'
-    'XcodeDefault.xctoolchain',
-  '/Library/Developer/CommandLineTools'
-]
-
+try:
+  os.stat('/Applications/Xcode.app/Contents/Developer/Toolchains/'
+    'XcodeDefault.xctoolchain')
+  MAC_CLANG_TOOLCHAIN_DIRS = ['/Applications/Xcode.app/Contents/Developer/Toolchains/'
+    'XcodeDefault.xctoolchain']
+except OSError:
+  try:
+    os.stat('/Library/Developer/CommandLineTools')
+    MAC_CLANG_TOOLCHAIN_DIRS = ['/Library/Developer/CommandLineTools']
+  except OSError:
+    MAC_CLANG_TOOLCHAIN_DIRS = []
 
 # Returns a list containing the supplied path as a suffix of each of the known
 # Mac toolchains

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -456,6 +456,7 @@ except OSError:
   except OSError:
     MAC_CLANG_TOOLCHAIN_DIRS = []
 
+
 # Returns a list containing the supplied path as a suffix of each of the known
 # Mac toolchains
 def _PathsForAllMacToolchains( path ):

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -439,14 +439,20 @@ def _RemoveUnusedFlags( flags, filename ):
 # Most users have xcode installed, but in order to be as compatible as
 # possible we consider both possible installation locations
 try:
-  os.stat('/Applications/Xcode.app/Contents/Developer/Toolchains/'
-    'XcodeDefault.xctoolchain')
-  MAC_CLANG_TOOLCHAIN_DIRS = ['/Applications/Xcode.app/Contents/Developer/Toolchains/'
-    'XcodeDefault.xctoolchain']
+  os.stat(
+    '/Applications/Xcode.app/Contents/Developer/Toolchains/'
+    'XcodeDefault.xctoolchain'
+  )
+  MAC_CLANG_TOOLCHAIN_DIRS = [
+    '/Applications/Xcode.app/Contents/Developer/Toolchains/'
+    'XcodeDefault.xctoolchain'
+  ]
 except OSError:
   try:
     os.stat('/Library/Developer/CommandLineTools')
-    MAC_CLANG_TOOLCHAIN_DIRS = ['/Library/Developer/CommandLineTools']
+    MAC_CLANG_TOOLCHAIN_DIRS = [
+      '/Library/Developer/CommandLineTools'
+    ]
   except OSError:
     MAC_CLANG_TOOLCHAIN_DIRS = []
 

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -34,6 +34,7 @@ from ycmd.responses import NoExtraConfDetected
 from ycmd.tests.clang import TemporaryClangProject, TemporaryClangTestDir
 
 from hamcrest import assert_that, calling, contains, has_item, not_, raises
+from hamcrest import any_of
 
 
 @contextlib.contextmanager
@@ -423,11 +424,10 @@ def Mac_LatestMacClangIncludes_NoSuchDirectory_test():
 
 @MacOnly
 def Mac_PathsForAllMacToolchains_test():
-  assert_that(
-       [ '/Applications/Xcode.app/Contents/Developer/Toolchains/'
-         'XcodeDefault.xctoolchain/test',
-         '/Library/Developer/CommandLineTools/test' ],
-       has_item( flags._PathsForAllMacToolchains( 'test' ) ) )
+  assert_that( flags._PathsForAllMacToolchains( 'test' ),
+    has_item(any_of('/Applications/Xcode.app/Contents/Developer/Toolchains/'
+      'XcodeDefault.xctoolchain/test',
+      '/Library/Developer/CommandLineTools/test' ) ) )
 
 
 def CompilationDatabase_NoDatabase_test():

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -423,10 +423,11 @@ def Mac_LatestMacClangIncludes_NoSuchDirectory_test():
 
 @MacOnly
 def Mac_PathsForAllMacToolchains_test():
-  eq_( flags._PathsForAllMacToolchains( 'test' ),
+  assert_that(
        [ '/Applications/Xcode.app/Contents/Developer/Toolchains/'
          'XcodeDefault.xctoolchain/test',
-         '/Library/Developer/CommandLineTools/test' ] )
+         '/Library/Developer/CommandLineTools/test' ],
+       has_item( flags._PathsForAllMacToolchains( 'test' ) ) )
 
 
 def CompilationDatabase_NoDatabase_test():


### PR DESCRIPTION
If both "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain" and "/Library/Developer/CommandLineTools" exsit, there will be two "c++/v1" directories listed sequentially. The include_next in one c++/v1, stdlib.h for example, will go for stdlib.h in next c++/v1 which should be /usr/include/stdlib.h. Then compilation system will complain dozens of 'unknown type name'.

This bug can be workaround by adding "/usr/include" to ycm_extra_conf.py, which might not the case when using with YCM-generator and cumbersome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/854)
<!-- Reviewable:end -->
