### PR TITLE
[READY] Only include one of the possible mac toolchains in the include paths

### DIFF
--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -407,9 +407,8 @@ def ExtraClangFlags_test():
 @patch( 'ycmd.completers.cpp.flags._MacClangIncludeDirExists',
         side_effect = [ False, True, True, True ] )
 def Mac_LatestMacClangIncludes_test( *args ):
-  eq_( flags._LatestMacClangIncludes(),
-       [ '/Applications/Xcode.app/Contents/Developer/Toolchains/'
-         'XcodeDefault.xctoolchain/usr/lib/clang/7.0.2/include' ] )
+  eq_( flags._LatestMacClangIncludes( '/tmp' ),
+       [ '/tmp/usr/lib/clang/7.0.2/include' ] )
 
 
 @MacOnly
@@ -418,15 +417,30 @@ def Mac_LatestMacClangIncludes_NoSuchDirectory_test():
     raise OSError( x )
 
   with patch( 'os.listdir', side_effect = RaiseOSError ):
-    eq_( flags._LatestMacClangIncludes(), [] )
+    eq_( flags._LatestMacClangIncludes( '/tmp' ), [] )
 
 
 @MacOnly
-def Mac_PathsForAllMacToolchains_test():
-  eq_( flags._PathsForAllMacToolchains( 'test' ),
-       [ '/Applications/Xcode.app/Contents/Developer/Toolchains/'
-         'XcodeDefault.xctoolchain/test',
-         '/Library/Developer/CommandLineTools/test' ] )
+@patch( 'ycmd.completers.cpp.flags._MacClangIncludeDirExists',
+        side_effect = [ False, False ] )
+def Mac_SelectMacToolchain_None_test( *args ):
+  eq_( flags._SelectMacToolchain(), None )
+
+
+@MacOnly
+@patch( 'ycmd.completers.cpp.flags._MacClangIncludeDirExists',
+        side_effect = [ True, False ] )
+def Mac_SelectMacToolchain_XCode_test( *args ):
+  eq_( flags._SelectMacToolchain(),
+       '/Applications/Xcode.app/Contents/Developer/Toolchains/'
+       'XcodeDefault.xctoolchain' )
+
+
+@MacOnly
+@patch( 'ycmd.completers.cpp.flags._MacClangIncludeDirExists',
+        side_effect = [ False, True ] )
+def Mac_SelectMacToolchain_CommandLineTools_test( *args ):
+  eq_( flags._SelectMacToolchain(), '/Library/Developer/CommandLineTools' )
 
 
 def CompilationDatabase_NoDatabase_test():


### PR DESCRIPTION
This is the yearly update to fix the latest macOS incompatibilities.

It seems with Xcode 9 (for reasons I really don't understand), having both the Xcode "command line tools" _and_ Xcode in your include paths leads to errors being raised in standard headers.

This change simply only adds a single set of system headers from a single toolchain on macOS.

Fixes https://github.com/Valloric/YouCompleteMe/issues/2790
Fixes https://github.com/Valloric/ycmd/issues/844
Fixes https://github.com/Valloric/YouCompleteMe/issues/2536

This is a quicker and probably less contentious solution than https://github.com/Valloric/ycmd/pull/853

This is sort of equivalent to https://github.com/Valloric/ycmd/pull/854, but the implementation is simpler and has working tests.

# Testing

Repro steps:

* with both Xcode and CLT installed create a trivial .ycm_extra_conf.py (flags -x c++ -Wall)
* create a trivial c++ file and `#include <sys/types.h>` and some other c++ headers.
* `:YcmDiags`

I've tested this:

* with both Xcode and CLT
* with just Xcode
* with just CLT

All work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/855)
<!-- Reviewable:end -->