### PR TITLE
[READY] Update JediHTTP

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -398,12 +398,12 @@ class CsharpSolutionCompleter( object ):
       if self._ServerIsRunning():
         self._logger.info( 'Stopping OmniSharp server with PID {0}'.format(
                                self._omnisharp_phandle.pid ) )
-        self._GetResponse( '/stopserver' )
         try:
+          self._GetResponse( '/stopserver' )
           utils.WaitUntilProcessIsTerminated( self._omnisharp_phandle,
                                               timeout = 5 )
           self._logger.info( 'OmniSharp server stopped' )
-        except RuntimeError:
+        except Exception:
           self._logger.exception( 'Error while stopping OmniSharp server' )
 
       self._CleanUp()

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -235,14 +235,14 @@ class GoCompleter( Completer ):
       if self._ServerIsRunning():
         _logger.info( 'Stopping Gocode server with PID {0}'.format(
                           self._gocode_handle.pid ) )
-        self._ExecuteCommand( [ self._gocode_binary_path,
-                                '-sock', 'tcp',
-                                '-addr', self._gocode_host,
-                                'close' ] )
         try:
+          self._ExecuteCommand( [ self._gocode_binary_path,
+                                  '-sock', 'tcp',
+                                  '-addr', self._gocode_host,
+                                  'close' ] )
           utils.WaitUntilProcessIsTerminated( self._gocode_handle, timeout = 5 )
           _logger.info( 'Gocode server stopped' )
-        except RuntimeError:
+        except Exception:
           _logger.exception( 'Error while stopping Gocode server' )
 
       self._CleanUp()

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -480,10 +480,12 @@ class TernCompleter( Completer ):
     self._server_handle = None
     self._server_port = None
     if not self._server_keep_logfiles:
-      utils.RemoveIfExists( self._server_stdout )
-      self._server_stdout = None
-      utils.RemoveIfExists( self._server_stderr )
-      self._server_stderr = None
+      if self._server_stdout:
+        utils.RemoveIfExists( self._server_stdout )
+        self._server_stdout = None
+      if self._server_stderr:
+        utils.RemoveIfExists( self._server_stderr )
+        self._server_stderr = None
 
 
   def _ServerIsRunning( self ):

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -130,12 +130,12 @@ class JediCompleter( Completer ):
       if self._ServerIsRunning():
         self._logger.info( 'Stopping JediHTTP server with PID {0}'.format(
                                self._jedihttp_phandle.pid ) )
-        self._jedihttp_phandle.terminate()
         try:
+          self._GetResponse( '/shutdown' )
           utils.WaitUntilProcessIsTerminated( self._jedihttp_phandle,
                                               timeout = 5 )
           self._logger.info( 'JediHTTP server stopped' )
-        except RuntimeError:
+        except Exception:
           self._logger.exception( 'Error while stopping JediHTTP server' )
 
       self._CleanUp()
@@ -145,10 +145,12 @@ class JediCompleter( Completer ):
     self._jedihttp_phandle = None
     self._jedihttp_port = None
     if not self._keep_logfiles:
-      utils.RemoveIfExists( self._logfile_stdout )
-      self._logfile_stdout = None
-      utils.RemoveIfExists( self._logfile_stderr )
-      self._logfile_stderr = None
+      if self._logfile_stdout:
+        utils.RemoveIfExists( self._logfile_stdout )
+        self._logfile_stdout = None
+      if self._logfile_stderr:
+        utils.RemoveIfExists( self._logfile_stderr )
+        self._logfile_stderr = None
 
 
   def _StartServer( self ):

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -699,12 +699,12 @@ class TypeScriptCompleter( Completer ):
       if self._ServerIsRunning():
         _logger.info( 'Stopping TSServer with PID {0}'.format(
                           self._tsserver_handle.pid ) )
-        self._SendCommand( 'exit' )
         try:
+          self._SendCommand( 'exit' )
           utils.WaitUntilProcessIsTerminated( self._tsserver_handle,
                                               timeout = 5 )
           _logger.info( 'TSServer stopped' )
-        except RuntimeError:
+        except Exception:
           _logger.exception( 'Error while stopping TSServer' )
 
       self._CleanUp()
@@ -713,7 +713,7 @@ class TypeScriptCompleter( Completer ):
   def _CleanUp( self ):
     utils.CloseStandardStreams( self._tsserver_handle )
     self._tsserver_handle = None
-    if not self.user_options[ 'server_keep_logfiles' ]:
+    if not self.user_options[ 'server_keep_logfiles' ] and self._logfile:
       utils.RemoveIfExists( self._logfile )
       self._logfile = None
 

--- a/ycmd/tests/python/subcommands_test.py
+++ b/ycmd/tests/python/subcommands_test.py
@@ -208,18 +208,18 @@ def Subcommands_GoToReferences_test( app ):
     {
       'filepath': PathToTestFile( 'goto_references.py' ),
       'column_num': 5,
-      'description': 'a = f()',
+      'description': 'f',
       'line_num': 4
     },
     {
       'filepath': PathToTestFile( 'goto_references.py' ),
       'column_num': 5,
-      'description': 'b = f()',
+      'description': 'f',
       'line_num': 5
     },
     {
       'filepath': PathToTestFile( 'goto_references.py' ),
       'column_num': 5,
-      'description': 'c = f()',
+      'description': 'f',
       'line_num': 6
     } ] )


### PR DESCRIPTION
Include [Jedi 0.11.0](https://github.com/davidhalter/jedi/blob/master/CHANGELOG.rst#0110-2017-09-20).

Update descriptions in `GoToReferences` test.

Use the new shutdown handler introduced in PR https://github.com/vheon/JediHTTP/pull/39 to stop JediHTTP.

Catch exception from shutdown request in semantic completers (when appropriate) so that cleaning up is done even if the request failed.

Fix `TypeError` exception trying to remove the `None` logfile when stopping the server with the `StopServer` subcommand then restarting it with `RestartServer`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/856)
<!-- Reviewable:end -->
