### PR TITLE
[READY] Fix empty location extent after missing semicolon

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -167,7 +167,7 @@ Range GetLocationExtent( CXSourceLocation source_location,
   clang_tokenize( translation_unit, range, &tokens, &num_tokens );
 
   Location location( source_location );
-  Range final_range;
+  Range final_range( range );
 
   for ( size_t i = 0; i < num_tokens; ++i ) {
     CXToken token = tokens[ i ];

--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -161,8 +161,7 @@ Range GetLocationExtent( CXSourceLocation source_location,
   // I've tried many simpler ways of doing this and they all fail in various
   // situations.
 
-  CXSourceRange range = clang_getCursorExtent(
-                          clang_getCursor( translation_unit, source_location ) );
+  CXSourceRange range = clang_getRange( source_location, source_location );
   CXToken *tokens;
   unsigned int num_tokens;
   clang_tokenize( translation_unit, range, &tokens, &num_tokens );
@@ -171,15 +170,12 @@ Range GetLocationExtent( CXSourceLocation source_location,
   Range final_range;
 
   for ( size_t i = 0; i < num_tokens; ++i ) {
+    CXToken token = tokens[ i ];
     Location token_location( clang_getTokenLocation( translation_unit,
-                                                     tokens[ i ] ) );
+                                                     token ) );
 
     if ( token_location == location ) {
-      std::string name = CXStringToString(
-                           clang_getTokenSpelling( translation_unit, tokens[ i ] ) );
-      Location end_location = location;
-      end_location.column_number_ += name.length();
-      final_range = Range( location, end_location );
+      final_range = Range( clang_getTokenExtent( translation_unit, token ) );
       break;
     }
   }

--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -171,6 +171,9 @@ Range GetLocationExtent( CXSourceLocation source_location,
 
   for ( size_t i = 0; i < num_tokens; ++i ) {
     CXToken token = tokens[ i ];
+    if ( clang_getTokenKind( token ) == CXToken_Comment )
+      continue;
+
     Location token_location( clang_getTokenLocation( translation_unit,
                                                      token ) );
 

--- a/ycmd/tests/clang/diagnostics_test.py
+++ b/ycmd/tests/clang/diagnostics_test.py
@@ -249,3 +249,117 @@ def Diagnostics_MultipleMissingIncludes_test( app ):
       'fixit_available': False
     } ),
   ) )
+
+
+@IsolatedYcmd()
+def Diagnostics_LocationExtent_MissingSemicolon_test( app ):
+  contents = ReadFile( PathToTestFile( 'location_extent.cc' ) )
+
+  event_data = BuildRequest( contents = contents,
+                             event_name = 'FileReadyToParse',
+                             filetype = 'cpp',
+                             compilation_flags = [ '-x', 'c++' ] )
+
+  response = app.post_json( '/event_notification', event_data ).json
+
+  pprint( response )
+
+  assert_that( response, contains(
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': has_entries( {
+        'line_num': 2,
+        'column_num': 9,
+        'filepath': '/foo'
+      } ),
+      # NOTE: we always return a location extent even if we can't find one since
+      # clients expect this field to always exist.
+      'location_extent': has_entries( {
+        'start': has_entries( {
+          'line_num': 0,
+          'column_num': 0,
+          'filepath': ''
+        } ),
+        'end': has_entries( {
+          'line_num': 0,
+          'column_num': 0,
+          'filepath': ''
+        } ),
+      } ),
+      'ranges': empty(),
+      'text': equal_to( "expected ';' at end of declaration list" ),
+      'fixit_available': True
+    } ),
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': has_entries( {
+        'line_num': 5,
+        'column_num': 1,
+        'filepath': '/foo'
+      } ),
+      'location_extent': has_entries( {
+        'start': has_entries( {
+          'line_num': 5,
+          'column_num': 1,
+          'filepath': '/foo'
+        } ),
+        'end': has_entries( {
+          'line_num': 6,
+          'column_num': 11,
+          'filepath': '/foo'
+        } )
+      } ),
+      'ranges': empty(),
+      'text': equal_to( "unknown type name 'multiline_identifier'" ),
+      'fixit_available': False
+    } ),
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': has_entries( {
+        'line_num': 8,
+        'column_num': 7,
+        'filepath': '/foo'
+      } ),
+      'location_extent': has_entries( {
+        'start': has_entries( {
+          'line_num': 8,
+          'column_num': 7,
+          'filepath': '/foo'
+        } ),
+        'end': has_entries( {
+          'line_num': 8,
+          'column_num': 11,
+          'filepath': '/foo'
+        } )
+      } ),
+      'ranges': contains(
+        # FIXME: empty ranges from libclang should be ignored.
+        has_entries( {
+          'start': has_entries( {
+            'line_num': 0,
+            'column_num': 0,
+            'filepath': ''
+          } ),
+          'end': has_entries( {
+            'line_num': 0,
+            'column_num': 0,
+            'filepath': ''
+          } )
+        } ),
+        has_entries( {
+          'start': has_entries( {
+            'line_num': 8,
+            'column_num': 7,
+            'filepath': '/foo'
+          } ),
+          'end': has_entries( {
+            'line_num': 8,
+            'column_num': 11,
+            'filepath': '/foo'
+          } )
+        } )
+      ),
+      'text': equal_to( 'constructor cannot have a return type' ),
+      'fixit_available': False
+    } )
+  ) )

--- a/ycmd/tests/clang/diagnostics_test.py
+++ b/ycmd/tests/clang/diagnostics_test.py
@@ -272,18 +272,16 @@ def Diagnostics_LocationExtent_MissingSemicolon_test( app ):
         'column_num': 9,
         'filepath': '/foo'
       } ),
-      # NOTE: we always return a location extent even if we can't find one since
-      # clients expect this field to always exist.
       'location_extent': has_entries( {
         'start': has_entries( {
-          'line_num': 0,
-          'column_num': 0,
-          'filepath': ''
+          'line_num': 2,
+          'column_num': 9,
+          'filepath': '/foo'
         } ),
         'end': has_entries( {
-          'line_num': 0,
-          'column_num': 0,
-          'filepath': ''
+          'line_num': 2,
+          'column_num': 9,
+          'filepath': '/foo'
         } ),
       } ),
       'ranges': empty(),

--- a/ycmd/tests/clang/testdata/location_extent.cc
+++ b/ycmd/tests/clang/testdata/location_extent.cc
@@ -1,0 +1,9 @@
+class Test {
+  Test()
+};
+
+multiline_\
+identifier
+
+Test::Test() {
+}

--- a/ycmd/tests/clang/testdata/location_extent.cc
+++ b/ycmd/tests/clang/testdata/location_extent.cc
@@ -1,5 +1,5 @@
 class Test {
-  Test()
+  Test()// ignore comment
 };
 
 multiline_\


### PR DESCRIPTION
We currently use the following (convoluted) method to compute the location extent of a diagnostic i.e. the range of the identifier where the diagnostic occurred:
 - obtain a range from [the `clang_getCursorExtent` function](https://clang.llvm.org/doxygen/group__CINDEX__CURSOR__SOURCE.html#ga79f6544534ab73c78a8494c4c0bc2840), which is supposed to contain our identifier;
 - extract all the tokens from that range with [`clang_tokenize`](https://clang.llvm.org/doxygen/group__CINDEX__LEX.html#ga6b315a71102d4f6c95eb68894a3bda8a);
 - find the token with the same starting position as the diagnostic;
 - use the length of that token to get the ending position;
 - compute the range.

Unfortunately, this doesn't always work as shown in issue https://github.com/Valloric/ycmd/issues/859, In that case, `clang_getCursorExtent` returns an empty range for all diagnostics after the missing semicolon.

This PR fixes that issue by extracting the tokens from the diagnostic position to the immediate next character then using `clang_getTokenExtent` to get the range of the identifier (multiline identifiers are supported).

Fixes #859.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/860)
<!-- Reviewable:end -->
