### PR TITLE
[READY] Do not delete build directory when running script with --build-dir

### DIFF
--- a/build.py
+++ b/build.py
@@ -396,13 +396,8 @@ def ExitIfYcmdLibInUseOnWindows():
 def BuildYcmdLib( args ):
   if args.build_dir:
     build_dir = os.path.abspath( args.build_dir )
-
-    if os.path.exists( build_dir ):
-      print( 'The supplied build directory ' + build_dir + ' exists, '
-             'deleting it.' )
-      rmtree( build_dir, ignore_errors = OnTravisOrAppVeyor() )
-
-    os.makedirs( build_dir )
+    if not os.path.exists( build_dir ):
+      os.makedirs( build_dir )
   else:
     build_dir = mkdtemp( prefix = 'ycm_build_' )
 


### PR DESCRIPTION
When passing the `--build-dir` option to the build script, we delete the directory if it already exists. Not only this is dangerous (consider running the command `./build.py --build-dir /`), it also defeats the purpose of this option which is to do incremental builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/862)
<!-- Reviewable:end -->
