### PR TITLE
[READY] Fix bare except statements

### DIFF
--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -123,7 +123,9 @@ class IdentifierCompleter( GeneralCompleter ):
     for tag_file in tag_files:
       try:
         current_mtime = os.path.getmtime( tag_file )
-      except:
+      except Exception:
+        self._logger.exception(
+            'Error while getting %s last modification time.', tag_file )
         continue
       last_mtime = self._tags_file_last_mtime[ tag_file ]
 

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -30,6 +30,12 @@ import os.path
 import re
 import textwrap
 import xml.etree.ElementTree
+# Python 2.6 raises a different exception when an error occurs while parsing XML
+# from a string (e.g. an empty string).
+try:
+  from xml.etree.ElementTree import ParseError as XmlParseError
+except ImportError:
+  from xml.parsers.expat import ExpatError as XmlParseError
 
 import ycm_core
 from ycmd import responses
@@ -553,7 +559,7 @@ def _BuildGetDocResponse( doc_data ):
   # future, we can use this XML for more interesting things.
   try:
     root = xml.etree.ElementTree.fromstring( doc_data.comment_xml )
-  except:
+  except XmlParseError:
     raise ValueError( NO_DOCUMENTATION_MESSAGE )
 
   # Note: declaration is False-y if it has no child elements, hence the below

--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
+import logging
 import os
 import re
 from collections import defaultdict
@@ -32,6 +33,8 @@ from ycmd.utils import GetCurrentDirectory, OnWindows, ToUnicode
 from ycmd import responses
 
 EXTRA_INFO_MAP = { 1 : '[File]', 2 : '[Dir]', 3 : '[File&Dir]' }
+
+_logger = logging.getLogger( __name__ )
 
 
 class FilenameCompleter( Completer ):
@@ -146,7 +149,8 @@ def _GetAbsolutePaths( path_dir, use_working_dir, filepath, working_dir ):
     # We need to pass a unicode string to get unicode strings out of
     # listdir.
     relative_paths = os.listdir( ToUnicode( absolute_path_dir ) )
-  except:
+  except Exception:
+    _logger.exception( 'Error while listing %s folder.', absolute_path_dir )
     relative_paths = []
 
   return ( os.path.join( absolute_path_dir, relative_path )

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -247,7 +247,7 @@ class TernCompleter( Completer ):
     # empty request just containing the file data
     try:
       self._PostRequest( {}, request_data )
-    except:
+    except Exception:
       # The server might not be ready yet or the server might not be running.
       # in any case, just ignore this we'll hopefully get another parse request
       # soon.


### PR DESCRIPTION
Latest version of Flake8 reports the following errors:
```
ycmd\completers\all\identifier_completer.py:126:7: E722 do not use bare except'
ycmd\completers\cpp\clang_completer.py:556:3: E722 do not use bare except'
ycmd\completers\general\filename_completer.py:149:3: E722 do not use bare except'
ycmd\completers\javascript\tern_completer.py:250:5: E722 do not use bare except'
```
We fix them by catching `Exception` and logging the exception when appropriate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/863)
<!-- Reviewable:end -->
