### PR TITLE
[READY] Support TypeScript 2.6.1

### DIFF
--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -353,7 +353,7 @@ def Subcommands_GoTo_Fail_test( app ):
                             goto_data,
                             expect_errors = True ).json
   assert_that( response,
-               ErrorMatcher( RuntimeError, 'Could not find definition' ) )
+               ErrorMatcher( RuntimeError, 'Could not find definition.' ) )
 
 
 @SharedYcmd
@@ -409,7 +409,7 @@ def Subcommands_GoToType_fail_test( app ):
                             goto_data,
                             expect_errors = True ).json
   assert_that( response,
-               ErrorMatcher( RuntimeError, 'Could not find type definition' ) )
+               ErrorMatcher( RuntimeError, 'Could not find type definition.' ) )
 
 
 @SharedYcmd


### PR DESCRIPTION
TypeScript 2.6.1 introduced a bug in TSServer where NPM warnings are printed on stdout at startup:
```
npm WARN 2.6 No description
npm WARN 2.6 No repository field.
npm WARN 2.6 No license field.
```
See issue https://github.com/Microsoft/TypeScript/issues/19660. The TypeScript completer chokes on this output as it always expects a HTTP-like response from TSServer and assumes that the server died if not. Though it's a TSServer bug, we can handle it by catching the `ValueError` exception raised when parsing invalid headers and by interrupting the reader loop only if the server is not running.

Also, this new version of TypeScript returns an empty list when no definition is found. Update the `_GoToDefinition` and `_GoToType` functions accordingly.

Fixes https://github.com/Valloric/YouCompleteMe/issues/2818.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/869)
<!-- Reviewable:end -->
