### PR TITLE
[READY] Run 7-Zip in non-interactive mode

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -122,7 +122,8 @@ if ( USE_CLANG_COMPLETER AND
         "7-zip is needed to extract the files from the Clang installer. "
         "Install it and try again." )
     endif()
-    execute_process( COMMAND ${7Z_EXECUTABLE} x ${CLANG_FILENAME} OUTPUT_QUIET )
+    execute_process( COMMAND
+                     ${7Z_EXECUTABLE} -y x ${CLANG_FILENAME} OUTPUT_QUIET )
   else()
     execute_process( COMMAND tar -xzf ${CLANG_FILENAME} )
   endif()


### PR DESCRIPTION
When doing an incremental build on Windows, CMake will be stuck extracting libclang from the installer because 7-Zip asks the user if he want to overwrite existing files. We can avoid that by adding the `-y` option to the 7-Zip command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/870)
<!-- Reviewable:end -->
