### PR TITLE
[WIP] Cache includes from system include paths.

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -184,6 +184,8 @@ class ClangCompleter( Completer ):
          self._GoToInclude( request_data ) ),
       'ClearCompilationFlagCache': ( lambda self, request_data, args:
          self._ClearCompilationFlagCache() ),
+      'ClearIncludeCache'        : ( lambda self, request_data, args:
+         self._ClearIncludeCache() ),
       'GetType'                  : ( lambda self, request_data, args:
          self._GetSemanticInfo( request_data, func = 'GetTypeAtLocation' ) ),
       'GetTypeImprecise'         : ( lambda self, request_data, args:
@@ -341,6 +343,7 @@ class ClangCompleter( Completer ):
 
     return response_builder( message )
 
+
   def _ClearCompilationFlagCache( self ):
     self._flags.Clear()
 
@@ -369,6 +372,11 @@ class ClangCompleter( Completer ):
     # in a nice way
 
     return responses.BuildFixItResponse( fixits )
+
+
+  def _ClearIncludeCache( self ):
+    self._include_cache.Clear()
+
 
   def OnFileReadyToParse( self, request_data ):
     filename = request_data[ 'filepath' ]

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -45,8 +45,7 @@ from ycmd.completers.cpp.flags import ( Flags, PrepareFlagsForClang,
                                         NoCompilationDatabase,
                                         UserIncludePaths )
 from ycmd.completers.cpp.ephemeral_values_set import EphemeralValuesSet
-from ycmd.completers.general.filename_completer import (
-    GenerateCandidatesForPaths )
+from ycmd.completers.cpp.include_cache import IncludeCache, IncludeList
 from ycmd.responses import NoExtraConfDetected, UnknownExtraConf
 
 CLANG_FILETYPES = set( [ 'c', 'cpp', 'objc', 'objcpp' ] )
@@ -68,6 +67,7 @@ class ClangCompleter( Completer ):
       'max_diagnostics_to_display' ]
     self._completer = ycm_core.ClangCompleter()
     self._flags = Flags()
+    self._include_cache = IncludeCache()
     self._diagnostic_store = None
     self._files_being_compiled = EphemeralValuesSet()
     self._logger = logging.getLogger( __name__ )
@@ -127,20 +127,13 @@ class ClangCompleter( Completer ):
     if quoted_include:
       include_paths.extend( quoted_include_paths )
 
-    paths = []
-    for include_path in include_paths:
-      unicode_path = ToUnicode( os.path.join( include_path, path_dir ) )
-      try:
-        # We need to pass a unicode string to get unicode strings out of
-        # listdir.
-        relative_paths = os.listdir( unicode_path )
-      except Exception:
-        self._logger.exception( 'Error while listing %s folder.', unicode_path )
-        relative_paths = []
+    includes = IncludeList()
+    for include in include_paths:
+      unicode_path = ToUnicode( os.path.join( include[ 0 ], path_dir ) )
+      includes.AddIncludes(
+        self._include_cache.GetIncludes( unicode_path, include[ 1 ] ) )
 
-      paths.extend( os.path.join( include_path, path_dir, relative_path ) for
-                    relative_path in relative_paths  )
-    return paths
+    return includes.GetIncludes()
 
 
   def ComputeCandidatesInner( self, request_data ):
@@ -148,9 +141,9 @@ class ClangCompleter( Completer ):
     if not filename:
       return
 
-    paths = self.GetIncludePaths( request_data )
-    if paths is not None:
-      return GenerateCandidatesForPaths( paths )
+    includes = self.GetIncludePaths( request_data )
+    if includes is not None:
+      return includes
 
     if self._completer.UpdatingTranslationUnit(
         ToCppStringCompatible( filename ) ):
@@ -575,9 +568,9 @@ def _BuildGetDocResponse( doc_data ):
       ToUnicode( _FormatRawComment( doc_data.raw_comment ) ) ) )
 
 
-def _GetAbsolutePath( include_file_name, include_paths ):
-  for path in include_paths:
-    include_file_path = os.path.join( path, include_file_name )
+def _GetAbsolutePath( include_file_name, includes ):
+  for include in includes:
+    include_file_path = os.path.join( include[ 0 ], include_file_name )
     if os.path.isfile( include_file_path ):
       return include_file_path
   return None

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -589,35 +589,29 @@ def _GetCompilationInfoForFile( database, file_name, file_extension ):
   return None
 
 
-def UserIncludePaths( flags, filename ):
-  quoted_include_paths = [ os.path.dirname( filename ) ]
+def UserIncludePaths( user_flags, filename ):
+  quoted_include_paths = [ ( ToUnicode( os.path.dirname( filename ) ), False ) ]
   include_paths = []
 
-  if flags:
-    quote_flag = '-iquote'
-    path_flags = [ '-isystem', '-I' ]
+  if user_flags:
+    include_flags = { '-iquote':  ( quoted_include_paths, False ),
+                      '-I':       ( include_paths, False ),
+                      '-isystem': ( include_paths, True ) }
 
     try:
-      it = iter( flags )
-      for flag in it:
-        flag_len = len( flag )
-        if flag.startswith( quote_flag ):
-          quote_flag_len = len( quote_flag )
-          # Add next flag to the include paths if current flag equals to
-          # '-iquote', or add remaining string otherwise.
-          quoted_include_path = ( next( it ) if flag_len == quote_flag_len else
-                                  flag[ quote_flag_len: ] )
-          if quoted_include_path:
-            quoted_include_paths.append( ToUnicode( quoted_include_path ) )
-        else:
-          for path_flag in path_flags:
-            if flag.startswith( path_flag ):
-              path_flag_len = len( path_flag )
-              include_path = ( next( it ) if flag_len == path_flag_len else
-                               flag[ path_flag_len: ] )
-              if include_path:
-                include_paths.append( ToUnicode( include_path ) )
-              break
+      it = iter( user_flags )
+      for user_flag in it:
+        user_flag_len = len( user_flag )
+        for flag in include_flags:
+          if user_flag.startswith( flag ):
+            flag_len = len( flag )
+            include_path = ( next( it ) if user_flag_len == flag_len else
+                             user_flag[ flag_len: ] )
+            if include_path:
+              container = include_flags[ flag ]
+              container[ 0 ].append( ( ToUnicode( include_path ),
+                                       container[ 1 ] ) )
+            break
     except StopIteration:
       pass
 

--- a/ycmd/completers/cpp/include_cache.py
+++ b/ycmd/completers/cpp/include_cache.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2017 Davit Samvelyan davitsamvelyan@gmail.com
+#                    Synopsys.
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
+from builtins import *  # noqa
+
+from future.utils import iteritems
+
+import os
+
+from collections import defaultdict
+from ycmd import responses
+
+EXTRA_INFO_MAP = { 1 : '[File]', 2 : '[Dir]', 3 : '[File&Dir]' }
+
+
+class IncludeEntry( object ):
+
+  def __init__( self, name, entry_type ):
+    self.name = name
+    self.entry_type = entry_type
+
+
+class IncludeList( object ):
+
+  def __init__( self ):
+    self._includes = defaultdict( int )
+
+
+  def AddIncludes( self, includes ):
+    for include in includes:
+      self._includes[ include.name ] |= include.entry_type
+
+
+  def GetIncludes( self ):
+    includes = []
+    for name, include_type in iteritems( self._includes ):
+      includes.append( responses.BuildCompletionData(
+        name, EXTRA_INFO_MAP[ include_type ] ) )
+    return includes
+
+
+class IncludeCache( object ):
+
+  def __init__( self ):
+    self._cache = {}
+
+
+  def GetIncludes( self, path, cache ):
+    includes = None
+    if cache:
+      includes = self._cache.get( path )
+
+    if includes is None:
+      includes = self._GetIncludes( path )
+      if cache:
+        self._cache[ path ] = includes
+    return includes
+
+
+  def _GetIncludes( self, path ):
+    try:
+      names = os.listdir( path )
+    except Exception:
+      names = []
+
+    includes = []
+    for name in names:
+      inc_path = os.path.join(path, name)
+      entry_type = 2 if os.path.isdir( inc_path ) else 1
+      includes.append( IncludeEntry( name, entry_type ) )
+
+    return includes

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -45,6 +45,7 @@ from ycmd.utils import ReadFile
 def Subcommands_DefinedSubcommands_test( app ):
   subcommands_data = BuildRequest( completer_target = 'cpp' )
   eq_( sorted( [ 'ClearCompilationFlagCache',
+                 'ClearIncludeCache',
                  'FixIt',
                  'GetDoc',
                  'GetDocImprecise',


### PR DESCRIPTION
Caches include entries extracted from include paths specified by -isystem flag.
On corporate environments where everything is on NFS drives and there are lot of include paths and headers it reduces include completion from several seconds to instantaneous.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/873)
<!-- Reviewable:end -->
