### PR TITLE
[READY] Allow switching to a different JavaScript project with RestartServer

### DIFF
--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -90,10 +90,8 @@ def GlobalConfigExists( tern_config ):
 
 
 def FindTernProjectFile( starting_directory ):
-  """Finds the path to either a Tern project file or the user's global Tern
-  configuration file. If found, a tuple is returned containing the path and a
-  boolean indicating if the path is to a .tern-project file. If not found,
-  returns (None, False)."""
+  """Returns the path to either a Tern project file or the user's global Tern
+  configuration file."""
   for folder in utils.PathsToAllParentFolders( starting_directory ):
     tern_project = os.path.join( folder, '.tern-project' )
     if os.path.exists( tern_project ):
@@ -105,7 +103,7 @@ def FindTernProjectFile( starting_directory ):
   # don't warn if we find one. The point is that if the user has a .tern-config
   # set up, then she has deliberately done so and a ycmd warning is unlikely
   # to be anything other than annoying.
-  tern_config = os.path.expanduser( '~/.tern-config' )
+  tern_config = os.path.join( os.path.expanduser( '~' ), '.tern-config' )
   if GlobalConfigExists( tern_config ):
     return tern_config
 
@@ -439,9 +437,9 @@ class TernCompleter( Completer ):
             cwd = self._server_working_dir )
 
       if self._ServerIsRunning():
-        _logger.info( 'Tern Server started with pid: %s listening on port %s',
+        _logger.info( 'Tern Server started with pid %d listening on port %d',
                       self._server_handle.pid, self._server_port )
-        _logger.info( 'Tern Server log files are: %s and %s',
+        _logger.info( 'Tern Server log files are %s and %s',
                       self._server_stdout, self._server_stderr )
 
         self._do_tern_project_check = True
@@ -473,6 +471,8 @@ class TernCompleter( Completer ):
 
   def _CleanUp( self ):
     utils.CloseStandardStreams( self._server_handle )
+
+    self._do_tern_project_check = False
 
     self._server_handle = None
     self._server_port = None

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -97,7 +97,7 @@ def FindTernProjectFile( starting_directory ):
   for folder in utils.PathsToAllParentFolders( starting_directory ):
     tern_project = os.path.join( folder, '.tern-project' )
     if os.path.exists( tern_project ):
-      return ( tern_project, True )
+      return tern_project
 
   # As described here: http://ternjs.net/doc/manual.html#server a global
   # .tern-config file is also supported for the Tern server. This can provide
@@ -107,9 +107,9 @@ def FindTernProjectFile( starting_directory ):
   # to be anything other than annoying.
   tern_config = os.path.expanduser( '~/.tern-config' )
   if GlobalConfigExists( tern_config ):
-    return ( tern_config, False )
+    return tern_config
 
-  return ( None, False )
+  return None
 
 
 class TernCompleter( Completer ):
@@ -127,21 +127,17 @@ class TernCompleter( Completer ):
 
     self._do_tern_project_check = False
 
-    # Used to determine the absolute path of files returned by the tern server.
-    # When a .tern_project file exists, paths are returned relative to it.
-    # Otherwise, they are returned relative to the working directory of the tern
-    # server.
-    self._server_paths_relative_to = None
-
     self._server_handle = None
     self._server_port = None
     self._server_stdout = None
     self._server_stderr = None
 
-    self._StartServer()
+    self._server_started = False
+    self._server_working_dir = None
+    self._server_project_file = None
 
 
-  def _WarnIfMissingTernProject( self ):
+  def _WarnIfMissingTernProject( self, request_data ):
     # The Tern server will operate without a .tern-project file. However, it
     # does not operate optimally, and will likely lead to issues reported that
     # JavaScript completion is not working properly. So we raise a warning if we
@@ -150,34 +146,19 @@ class TernCompleter( Completer ):
     # We do this check after the server has started because the server does
     # have nonzero use without a project file, however limited. We only do this
     # check once, though because the server can only handle one project at a
-    # time. This doesn't catch opening a file which is not part of the project
-    # or any of those things, but we can only do so much. We'd like to enhance
-    # ycmd to handle this better, but that is a FIXME for now.
-    if self._ServerIsRunning() and self._do_tern_project_check:
-      self._do_tern_project_check = False
+    # time.
+    if not self._ServerIsRunning() or not self._do_tern_project_check:
+      return
 
-      current_dir = utils.GetCurrentDirectory()
-      ( tern_project, is_project ) = FindTernProjectFile( current_dir )
-      if not tern_project:
-        _logger.warning( 'No .tern-project file detected: ' + current_dir )
-        raise RuntimeError( 'Warning: Unable to detect a .tern-project file '
-                            'in the hierarchy before ' + current_dir +
-                            ' and no global .tern-config file was found. '
-                            'This is required for accurate JavaScript '
-                            'completion. Please see the User Guide for '
-                            'details.' )
-      else:
-        _logger.info( 'Detected Tern configuration file at: ' + tern_project )
-
-        # Paths are relative to the project file if it exists, otherwise they
-        # are relative to the working directory of Tern server (which is the
-        # same as the working directory of ycmd).
-        self._server_paths_relative_to = (
-          os.path.dirname( tern_project ) if is_project else current_dir )
-
-        _logger.info( 'Tern paths are relative to: '
-                      + self._server_paths_relative_to )
-
+    self._do_tern_project_check = False
+    filepath = request_data[ 'filepath' ]
+    if not FindTernProjectFile( filepath ):
+      raise RuntimeError( 'Warning: Unable to detect a .tern-project file '
+                          'in the hierarchy before ' + filepath +
+                          ' and no global .tern-config file was found. '
+                          'This is required for accurate JavaScript '
+                          'completion. Please see the User Guide for '
+                          'details.' )
 
 
   def _GetServerAddress( self ):
@@ -241,7 +222,9 @@ class TernCompleter( Completer ):
 
 
   def OnFileReadyToParse( self, request_data ):
-    self._WarnIfMissingTernProject()
+    self._StartServer( request_data )
+
+    self._WarnIfMissingTernProject( request_data )
 
     # Keep tern server up to date with the file data. We do this by sending an
     # empty request just containing the file data
@@ -257,7 +240,7 @@ class TernCompleter( Completer ):
   def GetSubcommandsMap( self ):
     return {
       'RestartServer':  ( lambda self, request_data, args:
-                                         self._RestartServer() ),
+                                         self._RestartServer( request_data ) ),
       'StopServer':     ( lambda self, request_data, args:
                                          self._StopServer() ),
       'GoToDefinition': ( lambda self, request_data, args:
@@ -281,13 +264,19 @@ class TernCompleter( Completer ):
 
   def DebugInfo( self, request_data ):
     with self._server_state_mutex:
+      extras = [
+        responses.DebugInfoItem( key = 'configuration file',
+                                 value = self._server_project_file )
+      ]
+
       tern_server = responses.DebugInfoServer(
         name = 'Tern',
         handle = self._server_handle,
         executable = PATH_TO_TERN_BINARY,
         address = SERVER_HOST,
         port = self._server_port,
-        logfiles = [ self._server_stdout, self._server_stderr ] )
+        logfiles = [ self._server_stdout, self._server_stderr ],
+        extras = extras )
 
       return responses.BuildDebugInfoResponse( name = 'JavaScript',
                                                servers = [ tern_server ] )
@@ -380,23 +369,35 @@ class TernCompleter( Completer ):
 
   def _ServerPathToAbsolute( self, path ):
     """Given a path returned from the tern server, return it as an absolute
-    path.
-
-    In particular, if the path is a relative path, return an absolute path
-    assuming that it is relative to the location of the .tern-project file."""
+    path. In particular, if the path is a relative path, return an absolute path
+    assuming that it is relative to the working directory of the Tern server
+    (which is the location of the .tern-project file if there is one)."""
     if os.path.isabs( path ):
       return path
 
-    return os.path.join( self._server_paths_relative_to, path )
+    return os.path.join( self._server_working_dir, path )
 
 
   # TODO: this function is way too long. Consider refactoring it.
-  def _StartServer( self ):
+  def _StartServer( self, request_data ):
     with self._server_state_mutex:
-      if self._ServerIsRunning():
+      if self._server_started:
         return
 
+      self._server_started = True
+
       _logger.info( 'Starting Tern server...' )
+
+      filepath = request_data[ 'filepath' ]
+      self._server_project_file = FindTernProjectFile( filepath )
+      if not self._server_project_file:
+        _logger.warning( 'No .tern-project file detected: %s', filepath )
+        self._server_working_dir = os.path.dirname( filepath )
+      else:
+        _logger.info( 'Detected Tern configuration file at: %s',
+                      self._server_project_file )
+        self._server_working_dir = os.path.dirname( self._server_project_file )
+      _logger.info( 'Tern paths are relative to: %s', self._server_working_dir )
 
       self._server_port = utils.GetUnusedLocalhostPort()
 
@@ -430,10 +431,12 @@ class TernCompleter( Completer ):
         # 3.4+ on other platforms.
         with utils.OpenForStdHandle( self._server_stdout ) as stdout:
           with utils.OpenForStdHandle( self._server_stderr ) as stderr:
-            self._server_handle = utils.SafePopen( command,
-                                                  stdin = PIPE,
-                                                  stdout = stdout,
-                                                  stderr = stderr )
+            self._server_handle = utils.SafePopen(
+              command,
+              stdin = PIPE,
+              stdout = stdout,
+              stderr = stderr,
+              cwd = self._server_working_dir )
       except Exception:
         _logger.exception( 'Unable to start Tern server' )
         self._CleanUp()
@@ -453,10 +456,10 @@ class TernCompleter( Completer ):
         _logger.warning( 'Tern server did not start successfully' )
 
 
-  def _RestartServer( self ):
+  def _RestartServer( self, request_data ):
     with self._server_state_mutex:
       self._StopServer()
-      self._StartServer()
+      self._StartServer( request_data )
 
 
   def _StopServer( self ):
@@ -477,6 +480,7 @@ class TernCompleter( Completer ):
 
   def _CleanUp( self ):
     utils.CloseStandardStreams( self._server_handle )
+
     self._server_handle = None
     self._server_port = None
     if not self._server_keep_logfiles:
@@ -486,6 +490,10 @@ class TernCompleter( Completer ):
       if self._server_stderr:
         utils.RemoveIfExists( self._server_stderr )
         self._server_stderr = None
+
+    self._server_started = False
+    self._server_working_dir = None
+    self._server_project_file = None
 
 
   def _ServerIsRunning( self ):

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -382,11 +382,10 @@ class TernCompleter( Completer ):
     if not self._server_project_file:
       _logger.warning( 'No .tern-project file detected: %s', filepath )
       self._server_working_dir = os.path.dirname( filepath )
-      return
-
-    _logger.info( 'Detected Tern configuration file at: %s',
-                  self._server_project_file )
-    self._server_working_dir = os.path.dirname( self._server_project_file )
+    else:
+      _logger.info( 'Detected Tern configuration file at: %s',
+                    self._server_project_file )
+      self._server_working_dir = os.path.dirname( self._server_project_file )
     _logger.info( 'Tern paths are relative to: %s', self._server_working_dir )
 
 

--- a/ycmd/tests/javascript/debug_info_test.py
+++ b/ycmd/tests/javascript/debug_info_test.py
@@ -44,7 +44,11 @@ def DebugInfo_test( app ):
         'address': instance_of( str ),
         'port': instance_of( int ),
         'logfiles': contains( instance_of( str ),
-                              instance_of( str ) )
+                              instance_of( str ) ),
+        'extras': contains( has_entries( {
+          'key': 'configuration file',
+          'value': instance_of( str )
+        } ) )
       } ) ),
       'items': empty()
     } ) )

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -22,72 +22,76 @@ from __future__ import division
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from hamcrest import assert_that, empty
+from hamcrest import assert_that, contains, empty, has_entries, none
 from mock import patch
 from nose.tools import eq_
 from pprint import pformat
-import requests
 import os
+import requests
 
-from ycmd.tests.test_utils import ( BuildRequest, ErrorMatcher,
-                                    WaitUntilCompleterServerReady )
+from ycmd.tests.test_utils import BuildRequest, ErrorMatcher
 from ycmd.tests.javascript import IsolatedYcmd, PathToTestFile
-from ycmd.utils import GetCurrentDirectory, ReadFile
 
 
 @IsolatedYcmd
 def EventNotification_OnFileReadyToParse_ProjectFile_cwd_test( app ):
-  WaitUntilCompleterServerReady( app, 'javascript' )
-
-  contents = ReadFile( PathToTestFile( 'simple_test.js' ) )
-
   response = app.post_json( '/event_notification',
                             BuildRequest(
+                              filepath = PathToTestFile(),
                               event_name = 'FileReadyToParse',
-                              contents = contents,
                               filetype = 'javascript' ),
-                            expect_errors = True)
+                            expect_errors = True )
 
   eq_( response.status_code, requests.codes.ok )
   assert_that( response.json, empty() )
+
+  debug_info = app.post_json( '/debug_info',
+                              BuildRequest( filetype = 'javascript' ) ).json
+  assert_that(
+    debug_info[ 'completer' ][ 'servers' ][ 0 ][ 'extras' ],
+    contains( has_entries( {
+      'key': 'configuration file',
+      'value': PathToTestFile( '.tern-project' )
+    } ) )
+  )
 
 
 @IsolatedYcmd
 def EventNotification_OnFileReadyToParse_ProjectFile_parentdir_test( app ):
-  WaitUntilCompleterServerReady( app, 'javascript' )
-
-  os.chdir( PathToTestFile( 'lamelib' ) )
-  contents = ReadFile( PathToTestFile( 'simple_test.js' ) )
-
   response = app.post_json( '/event_notification',
                             BuildRequest(
+                              filepath = PathToTestFile( 'lamelib' ),
                               event_name = 'FileReadyToParse',
-                              contents = contents,
                               filetype = 'javascript' ),
-                            expect_errors = True)
+                            expect_errors = True )
 
   eq_( response.status_code, requests.codes.ok )
   assert_that( response.json, empty() )
+
+  debug_info = app.post_json( '/debug_info',
+                              BuildRequest( filetype = 'javascript' ) ).json
+  assert_that(
+    debug_info[ 'completer' ][ 'servers' ][ 0 ][ 'extras' ],
+    contains( has_entries( {
+      'key': 'configuration file',
+      'value': PathToTestFile( '.tern-project' )
+    } ) )
+  )
 
 
 @IsolatedYcmd
 @patch( 'ycmd.completers.javascript.tern_completer.GlobalConfigExists',
         return_value = False )
 def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
-  WaitUntilCompleterServerReady( app, 'javascript' )
-
   # We raise an error if we can't detect a .tern-project file.
   # We only do this on the first OnFileReadyToParse event after a
   # server startup.
-  os.chdir( PathToTestFile( '..' ) )
-  contents = ReadFile( PathToTestFile( 'simple_test.js' ) )
-
   response = app.post_json( '/event_notification',
-                            BuildRequest(
-                              event_name = 'FileReadyToParse',
-                              contents = contents,
-                              filetype = 'javascript' ),
+                            BuildRequest( filepath = PathToTestFile( '..' ),
+                                          event_name = 'FileReadyToParse',
+                                          filetype = 'javascript' ),
                             expect_errors = True )
+
 
   print( 'event response: {0}'.format( pformat( response.json ) ) )
 
@@ -97,20 +101,27 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
     response.json,
     ErrorMatcher( RuntimeError,
                   'Warning: Unable to detect a .tern-project file '
-                  'in the hierarchy before ' + GetCurrentDirectory() +
+                  'in the hierarchy before ' + PathToTestFile( '..' ) +
                   ' and no global .tern-config file was found. '
                   'This is required for accurate JavaScript '
                   'completion. Please see the User Guide for '
                   'details.' )
   )
 
-  # Check that a subsequent call does *not* raise the error
+  debug_info = app.post_json( '/debug_info',
+                              BuildRequest( filetype = 'javascript' ) ).json
+  assert_that(
+    debug_info[ 'completer' ][ 'servers' ][ 0 ][ 'extras' ],
+    contains( has_entries( {
+      'key': 'configuration file',
+      'value': none()
+    } ) )
+  )
 
+  # Check that a subsequent call does *not* raise the error.
   response = app.post_json( '/event_notification',
-                            BuildRequest(
-                              event_name = 'FileReadyToParse',
-                              contents = contents,
-                              filetype = 'javascript' ),
+                            BuildRequest( event_name = 'FileReadyToParse',
+                                          filetype = 'javascript' ),
                             expect_errors = True )
 
   print( 'event response: {0}'.format( pformat( response.json ) ) )
@@ -118,19 +129,15 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
   eq_( response.status_code, requests.codes.ok )
   assert_that( response.json, empty() )
 
-  # Restart the server and check that it raises it again
-
+  # Restart the server and check that it raises it again.
   app.post_json( '/run_completer_command',
-                 BuildRequest( command_arguments = [ 'RestartServer' ],
-                               filetype = 'javascript',
-                               contents = contents,
-                               completer_target = 'filetype_default' ) )
-
-  WaitUntilCompleterServerReady( app, 'javascript' )
+                 BuildRequest( filepath = PathToTestFile( '..' ),
+                               command_arguments = [ 'RestartServer' ],
+                               filetype = 'javascript' ) )
 
   response = app.post_json( '/event_notification',
-                            BuildRequest( event_name = 'FileReadyToParse',
-                                          contents = contents,
+                            BuildRequest( filepath = PathToTestFile( '..' ),
+                                          event_name = 'FileReadyToParse',
                                           filetype = 'javascript' ),
                             expect_errors = True )
 
@@ -142,11 +149,39 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
     response.json,
     ErrorMatcher( RuntimeError,
                   'Warning: Unable to detect a .tern-project file '
-                  'in the hierarchy before ' + GetCurrentDirectory() +
+                  'in the hierarchy before ' + PathToTestFile( '..' ) +
                   ' and no global .tern-config file was found. '
                   'This is required for accurate JavaScript '
                   'completion. Please see the User Guide for '
                   'details.' )
+  )
+
+  # Finally, restart the server in a folder containing a .tern-project file. We
+  # expect no error in that case.
+  app.post_json( '/run_completer_command',
+                 BuildRequest( filepath = PathToTestFile(),
+                               command_arguments = [ 'RestartServer' ],
+                               filetype = 'javascript' ) )
+
+  response = app.post_json( '/event_notification',
+                            BuildRequest( filepath = PathToTestFile(),
+                                          event_name = 'FileReadyToParse',
+                                          filetype = 'javascript' ),
+                            expect_errors = True )
+
+  print( 'event response: {0}'.format( pformat( response.json ) ) )
+
+  eq_( response.status_code, requests.codes.ok )
+  assert_that( response.json, empty() )
+
+  debug_info = app.post_json( '/debug_info',
+                              BuildRequest( filetype = 'javascript' ) ).json
+  assert_that(
+    debug_info[ 'completer' ][ 'servers' ][ 0 ][ 'extras' ],
+    contains( has_entries( {
+      'key': 'configuration file',
+      'value': PathToTestFile( '.tern-project' )
+    } ) )
   )
 
 
@@ -154,17 +189,23 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test( app, *args ):
 @patch( 'ycmd.completers.javascript.tern_completer.GlobalConfigExists',
         return_value = True )
 def EventNotification_OnFileReadyToParse_UseGlobalConfig_test( app, *args ):
-  WaitUntilCompleterServerReady( app, 'javascript' )
-
-  os.chdir( PathToTestFile( '..' ) )
-  contents = ReadFile( PathToTestFile( 'simple_test.js' ) )
-
   response = app.post_json( '/event_notification',
-                            BuildRequest( event_name = 'FileReadyToParse',
-                                          contents = contents,
+                            BuildRequest( filepath = PathToTestFile( '..' ),
+                                          event_name = 'FileReadyToParse',
                                           filetype = 'javascript' ),
                             expect_errors = True )
 
   print( 'event response: {0}'.format( pformat( response.json ) ) )
 
   eq_( response.status_code, requests.codes.ok )
+  assert_that( response.json, empty() )
+
+  debug_info = app.post_json( '/debug_info',
+                              BuildRequest( filetype = 'javascript' ) ).json
+  assert_that(
+    debug_info[ 'completer' ][ 'servers' ][ 0 ][ 'extras' ],
+    contains( has_entries( {
+      'key': 'configuration file',
+      'value': os.path.expanduser( '~/.tern-config' )
+    } ) )
+  )

--- a/ycmd/tests/javascript/event_notification_test.py
+++ b/ycmd/tests/javascript/event_notification_test.py
@@ -206,6 +206,6 @@ def EventNotification_OnFileReadyToParse_UseGlobalConfig_test( app, *args ):
     debug_info[ 'completer' ][ 'servers' ][ 0 ][ 'extras' ],
     contains( has_entries( {
       'key': 'configuration file',
-      'value': os.path.expanduser( '~/.tern-config' )
+      'value': os.path.join( os.path.expanduser( '~' ), '.tern-config' )
     } ) )
   )

--- a/ycmd/tests/javascript/get_completions_test.py
+++ b/ycmd/tests/javascript/get_completions_test.py
@@ -28,10 +28,9 @@ from nose.tools import eq_
 from pprint import pformat
 import requests
 
-from ycmd.tests.javascript import ( PathToTestFile, SharedYcmd,
-                                    IsolatedYcmdInDirectory )
-from ycmd.tests.test_utils import ( BuildRequest, CompletionEntryMatcher,
-                                    WaitUntilCompleterServerReady )
+from ycmd.tests.javascript import ( IsolatedYcmd, PathToTestFile, SharedYcmd,
+                                    StartJavaScriptCompleterServerInDirectory )
+from ycmd.tests.test_utils import BuildRequest, CompletionEntryMatcher
 from ycmd.utils import ReadFile
 
 # The following properties/methods are in Object.prototype, so are present
@@ -484,9 +483,9 @@ def GetCompletions_Unicode_InFile_test( app ):
   } )
 
 
-@IsolatedYcmdInDirectory( PathToTestFile( 'node' ) )
+@IsolatedYcmd
 def GetCompletions_ChangeStartColumn_test( app ):
-  WaitUntilCompleterServerReady( app, 'javascript' )
+  StartJavaScriptCompleterServerInDirectory( app, PathToTestFile( 'node' ) )
   RunTest( app, {
     'description': 'the completion_start_column is updated by tern',
     'request': {

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -28,12 +28,12 @@ from nose.tools import eq_
 from pprint import pformat
 import requests
 
-from ycmd.tests.javascript import IsolatedYcmd, PathToTestFile, SharedYcmd
+from ycmd.tests.javascript import ( IsolatedYcmd, PathToTestFile, SharedYcmd,
+                                    StartJavaScriptCompleterServerInDirectory )
 from ycmd.tests.test_utils import ( BuildRequest,
                                     ChunkMatcher,
                                     ErrorMatcher,
-                                    LocationMatcher,
-                                    WaitUntilCompleterServerReady )
+                                    LocationMatcher )
 from ycmd.utils import ReadFile
 
 
@@ -159,7 +159,7 @@ def Subcommands_GoTo_test( app ):
 
 @IsolatedYcmd
 def Subcommands_GoTo_RelativePath_test( app ):
-  WaitUntilCompleterServerReady( app, 'javascript' )
+  StartJavaScriptCompleterServerInDirectory( app, PathToTestFile() )
   RunTest(
     app,
     {
@@ -397,7 +397,7 @@ def Subcommands_RefactorRename_MultipleFiles_test( app ):
 # an extra file into tern's project memory)
 @IsolatedYcmd
 def Subcommands_RefactorRename_MultipleFiles_OnFileReadyToParse_test( app ):
-  WaitUntilCompleterServerReady( app, 'javascript' )
+  StartJavaScriptCompleterServerInDirectory( app, PathToTestFile() )
 
   file1 = PathToTestFile( 'file1.js' )
   file2 = PathToTestFile( 'file2.js' )


### PR DESCRIPTION
Contrarily to what the YCM docs say, issuing the `:YcmCompleter RestartServer` command to switch to a different JavaScript project doesn't work. The reason is that we don't set the working directory when starting the Tern server. Same issue if the user starts the client outside a project and then open a file in that project. It's even worse in that case because no warning will be displayed to the user.

I considered passing the `request_data` object when initializing the completer but that doesn't work because the request is not always available. I also considered adding support for multiple projects similarly to what the C# completer does but I felt it was too much work. Finally, I went for starting the server on the `FileReadyToParse` event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/875)
<!-- Reviewable:end -->
