### PR TITLE
[READY] Improve coverage configuration

### DIFF
--- a/ci/appveyor/appveyor_install.bat
+++ b/ci/appveyor/appveyor_install.bat
@@ -34,6 +34,10 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 pip install codecov
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+:: Enable coverage for Python subprocesses. See:
+:: http://coverage.readthedocs.io/en/latest/subprocess.html
+python -c "with open('%python_path%\Lib\site-packages\sitecustomize.py', 'w') as f: f.write('import coverage\ncoverage.process_startup()')"
+
 ::
 :: Typescript configuration
 ::

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -61,7 +61,7 @@ pip install -U pip wheel setuptools
 pip install -r test_requirements.txt
 
 # Enable coverage for Python subprocesses. See:
-# http://coverage.readthedocs.org/en/coverage-4.0.3/subprocess.html
+# http://coverage.readthedocs.io/en/latest/subprocess.html
 echo -e "import coverage\ncoverage.process_startup()" > \
   ${PYENV_ROOT}/versions/${PYENV_VERSION}/lib/python${YCMD_PYTHON_VERSION}/site-packages/sitecustomize.py
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -193,17 +193,24 @@ def BuildYcmdLibs( args ):
 def NoseTests( parsed_args, extra_nosetests_args ):
   # Always passing --with-id to nosetests enables non-surprising usage of
   # its --failed flag.
-  nosetests_args = [ '-v', '--with-id' ]
+  # By default, nose does not include files starting with a underscore in its
+  # report but we want __main__.py to be included. Only ignore files starting
+  # with a dot and setup.py.
+  nosetests_args = [ '-v', '--with-id', '--ignore-files=(^\.|^setup\.py$)' ]
 
   for key in COMPLETERS:
     if key not in parsed_args.completers:
       nosetests_args.extend( COMPLETERS[ key ][ 'test' ] )
 
   if parsed_args.coverage:
-    nosetests_args += [ '--with-coverage',
+    # We need to exclude the ycmd/tests/python/testdata directory since it
+    # contains Python files and its base name starts with "test".
+    nosetests_args += [ '--exclude-dir=ycmd/tests/python/testdata',
+                        '--with-coverage',
                         '--cover-erase',
                         '--cover-package=ycmd',
-                        '--cover-html' ]
+                        '--cover-html',
+                        '--cover-inclusive' ]
 
   if extra_nosetests_args:
     nosetests_args.extend( extra_nosetests_args )


### PR DESCRIPTION
When running the tests locally with coverage enabled, nose will not include the files from subprocesses coverage in its own report and in the HTML report. This is fixed by adding the `--cover-inclusive` option and by specifying the `--ignore-files` option so that nose does not ignore the `__main__.py` file (files starting with a underscore are ignored by default). We also have to exclude the `ycmd/tests/python/testdata` directory because its base name starts with `test` (nose will collect tests in that directory) and it contains Python files.

Another improvement is that we enable subprocesses coverage on AppVeyor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/876)
<!-- Reviewable:end -->
