### PR TITLE
[READY] Use default macOS image on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 dist: trusty
-osx_image: xcode8
 sudo: false
 before_install:
   - git submodule update --init --recursive

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -3,6 +3,11 @@
 # Exit immediately if a command returns a non-zero status.
 set -e
 
+# RVM overrides the cd, popd, and pushd shell commands, causing the
+# "shell_session_update: command not found" error on macOS when executing those
+# commands.
+unset -f cd popd pushd
+
 ####################
 # OS-specific setup
 ####################


### PR DESCRIPTION
[The `xcode8` image on Travis is deprecated](https://blog.travis-ci.com/2017-11-21-xcode8-3-default-image-announce). Use the default image `xcode8.3` (corresponding to macOS 10.12.6). This image has the RVM bug mentioned in PR https://github.com/Valloric/YouCompleteMe/pull/2840 so we add the same workaround.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/882)
<!-- Reviewable:end -->
