### PR TITLE
[READY] Handle zero column diagnostic from OmniSharp

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -678,8 +678,12 @@ def _IndexToLineColumn( text, index ):
 
 
 def _BuildLocation( request_data, filename, line_num, column_num ):
-  if line_num <= 0 or column_num <= 0:
+  if line_num <= 0:
     return None
+  # OmniSharp sometimes incorrectly returns 0 for the column number. Assume the
+  # column is 1 in that case.
+  if column_num <= 0:
+    column_num = 1
   contents = utils.SplitLines( GetFileContents( request_data, filename ) )
   line_value = contents[ line_num - 1 ]
   return responses.Location(

--- a/ycmd/tests/cs/testdata/testy/ZeroColumnDiagnostic.cs
+++ b/ycmd/tests/cs/testdata/testy/ZeroColumnDiagnostic.cs
@@ -1,0 +1,3 @@
+class Class{
+    int Method()
+}


### PR DESCRIPTION
The OmniSharp server sometimes incorrectly returns diagnostics with a column number of 0 while lines and columns are supposed to be 1-indexed. This causes the following error:
```
Traceback (most recent call last):
  File "C:\Users\micbou\projects\YouCompleteMe\third_party\ycmd\third_party\bottle\bottle.py", line 862, in _handle
    return route.call(**args)
  File "C:\Users\micbou\projects\YouCompleteMe\third_party\ycmd\third_party\bottle\bottle.py", line 1740, in wrapper
    rv = callback(*a, **ka)
  File "C:\Users\micbou\projects\YouCompleteMe\third_party\ycmd\ycmd\..\ycmd\watchdog_plugin.py", line 108, in wrapper
    return callback( *args, **kwargs )
  File "C:\Users\micbou\projects\YouCompleteMe\third_party\ycmd\ycmd\..\ycmd\hmac_plugin.py", line 70, in wrapper
    body = callback( *args, **kwargs )
  File "C:\Users\micbou\projects\YouCompleteMe\third_party\ycmd\ycmd\..\ycmd\handlers.py", line 70, in EventNotification
    event_handler )( request_data )
  File "C:\Users\micbou\projects\YouCompleteMe\third_party\ycmd\ycmd\..\ycmd\completers\cs\cs_completer.py", line 214, in OnFileReadyToParse
    self._diagnostic_store = DiagnosticsToDiagStructure( diagnostics )
  File "C:\Users\micbou\projects\YouCompleteMe\third_party\ycmd\ycmd\..\ycmd\completers\cs\cs_completer.py", line 611, in DiagnosticsToDiagStructure
    structure[ diagnostic.location_.filename_ ][
AttributeError: 'NoneType' object has no attribute 'filename_'
```
See https://github.com/Valloric/YouCompleteMe/issues/2846#issuecomment-349631372. We assume the column number is 1 in that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/883)
<!-- Reviewable:end -->
