### PR TITLE
[READY] Specify Platform property when compiling OmniSharp

### DIFF
--- a/build.py
+++ b/build.py
@@ -458,6 +458,7 @@ def EnableCsCompleter():
 
   os.chdir( p.join( DIR_OF_THIS_SCRIPT, 'third_party', 'OmniSharpServer' ) )
   CheckCall( [ build_command, '/property:Configuration=Release',
+                              '/property:Platform=Any CPU',
                               '/property:TargetFrameworkVersion=v4.5' ] )
 
 


### PR DESCRIPTION
The `build.py` script may fail to build the OmniSharp server because of MSBuild picking an invalid configuration (e.g. `Release|mac`). See issue https://github.com/Valloric/YouCompleteMe/issues/2845. This is fixed by setting the `Platform` property to `Any CPU` when building OmniSharp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/884)
<!-- Reviewable:end -->
