### PR TITLE
[READY] Use current working directory in JavaScript completer

### DIFF
--- a/ycmd/tests/javascript/debug_info_test.py
+++ b/ycmd/tests/javascript/debug_info_test.py
@@ -45,10 +45,16 @@ def DebugInfo_test( app ):
         'port': instance_of( int ),
         'logfiles': contains( instance_of( str ),
                               instance_of( str ) ),
-        'extras': contains( has_entries( {
-          'key': 'configuration file',
-          'value': instance_of( str )
-        } ) )
+        'extras': contains(
+          has_entries( {
+            'key': 'configuration file',
+            'value': instance_of( str )
+          } ),
+          has_entries( {
+            'key': 'working directory',
+            'value': instance_of( str )
+          } )
+        ),
       } ) ),
       'items': empty()
     } ) )


### PR DESCRIPTION
Use the Client working directory instead of the home directory when no `.tern-project` file is found. If no working directory is given (no `working_dir` field in the request), we fall back to ycmd working directory. See issue https://github.com/Valloric/YouCompleteMe/issues/2857.

Once this is merged, we'll update YCM to always include the working directory in the request as done in PR https://github.com/Valloric/YouCompleteMe/pull/2827.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/886)
<!-- Reviewable:end -->
