### PR TITLE
Fix --system-libclang on Gentoo amd64, if llvm is compiled with ABI_X86="32 64"

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -283,12 +283,16 @@ if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
     else ()
       set( ENV_LIB_PATHS "" )
     endif()
+    find_program( LLVM_CONFIG_EXECUTABLE NAMES llvm-config )
+    if ( LLVM_CONFIG_EXECUTABLE )
+      execute_process( COMMAND ${LLVM_CONFIG_EXECUTABLE} --libdir
+                       OUTPUT_VARIABLE LLVM_CONFIG_PATH
+                       OUTPUT_STRIP_TRAILING_WHITESPACE )
+    endif()
     # On Debian-based systems, llvm installs into /usr/lib/llvm-x.y.
     file( GLOB SYS_LLVM_PATHS "/usr/lib/llvm*/lib" )
     # On FreeBSD , llvm install into /usr/local/llvm-xy
     file ( GLOB FREEBSD_LLVM_PATHS "/usr/local/llvm*/lib")
-    # On Gentoo, llvm installs into /usr/lib/llvm/x/
-    file ( GLOB GENTOO_LLVM_PATHS "/usr/lib*/llvm/*/lib*" )
     # Need TEMP because find_library does not work with an option variable
     # On Debian-based systems only a symlink to libclang.so.1 is created
     find_library( TEMP
@@ -297,11 +301,11 @@ if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
                   libclang.so.1
                   PATHS
                   ${ENV_LIB_PATHS}
+                  ${LLVM_CONFIG_PATH}
                   /usr/lib
                   /usr/lib/llvm
                   ${SYS_LLVM_PATHS}
                   ${FREEBSD_LLVM_PATHS}
-                  ${GENTOO_LLVM_PATHS}
                   /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib
                   /Library/Developer/CommandLineTools/usr/lib )
     set( EXTERNAL_LIBCLANG_PATH ${TEMP} )


### PR DESCRIPTION
$ ls -ld /usr/lib64/llvm/4/l*
drwxr-xr-x 3 root root  20K Dec 16 02:37 lib32
drwxr-xr-x 3 root root  20K Dec 16 02:37 lib64
drwxr-xr-x 2 root root 4.0K Dec 16 02:37 libexec

This results in GLOB finding the wrong library.

$ ./install.py --clang-completer --system-libclang
...
Using external libclang: /usr/lib64/llvm/4/lib32/libclang.so.4.0
...
/usr/lib64/llvm/4/lib32/libclang.so.4.0: error adding symbols: File in wrong format

FTR, I had to use --system-libclang because of libtinfo.so.5 issue (https://github.com/Valloric/YouCompleteMe/issues/778)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/891)
<!-- Reviewable:end -->
