### PR TITLE
Fix typos in documentation

### DIFF
--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -93,8 +93,8 @@ def BuildDisplayMessageResponse( text ):
 
 
 def BuildDetailedInfoResponse( text ):
-  """ Retuns the response object for displaying detailed information about types
-  and usage, suach as within a preview window"""
+  """ Returns the response object for displaying detailed information about types
+  and usage, such as within a preview window"""
   return {
     'detailed_info': text
   }


### PR DESCRIPTION
Just fixing two typos I noticed in the doc comment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/895)
<!-- Reviewable:end -->
