### PR TITLE
[READY] Use our own packages of libclang to prevent CI flakes

### DIFF
--- a/build.py
+++ b/build.py
@@ -336,6 +336,9 @@ def GetCmakeArgs( parsed_args ):
   use_python2 = 'ON' if PY_MAJOR == 2 else 'OFF'
   cmake_args.append( '-DUSE_PYTHON2=' + use_python2 )
 
+  if OnTravisOrAppVeyor():
+    cmake_args.append( '-DUSE_LIBCLANG_PACKAGE=ON' )
+
   extra_cmake_args = os.environ.get( 'EXTRA_CMAKE_ARGS', '' )
   # We use shlex split to properly parse quoted CMake arguments.
   cmake_args.extend( shlex.split( extra_cmake_args ) )

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -22,6 +22,7 @@ project( ycm_core )
 option( USE_DEV_FLAGS "Use compilation flags meant for YCM developers" OFF )
 option( USE_CLANG_COMPLETER "Use Clang semantic completer for C/C++/ObjC" OFF )
 option( USE_SYSTEM_LIBCLANG "Set to ON to use the system libclang library" OFF )
+option( USE_LIBCLANG_PACKAGE "For ycmd CI only, use packaged libclang, rather than the official LLVM releases" OFF )
 set( PATH_TO_LLVM_ROOT "" CACHE PATH "Path to the root of a LLVM+Clang binary distribution" )
 set( EXTERNAL_LIBCLANG_PATH "" CACHE PATH "Path to the libclang library to use" )
 
@@ -37,17 +38,31 @@ if ( USE_CLANG_COMPLETER AND
     set( CLANG_SHA256
          "c5b105c4960619feb32641ef051fa39ecb913cc0feb6bacebdfa71f8d3cae277" )
     set( CLANG_FILENAME "${CLANG_DIRNAME}.tar.xz" )
+
+    set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-x86_64-apple-darwin" )
+    set( LIBCLANG_FILENAME "${LIBCLANG_DIRNAME}.tar.bz2" )
+    set( LIBCLANG_SHA256
+         "b47661118a4a55e3cfd1a71990ede9e6817d942cd8fabe7185852dfdaf7f01e8" )
   elseif ( WIN32 )
     if( 64_BIT_PLATFORM )
       set( CLANG_DIRNAME "LLVM-${CLANG_VERSION}-win64" )
       set( CLANG_SHA256
            "981543611d719624acb29a2cffd6a479cff36e8ab5ee8a57d8eca4f9c4c6956f" )
+
+      set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-win64" )
+      set( LIBCLANG_SHA256
+           "01f64da1edfa0859f5c63561ba93c0511915f69b9778687dda9ae4b70f68c565" )
     else()
       set( CLANG_DIRNAME "LLVM-${CLANG_VERSION}-win32" )
       set( CLANG_SHA256
            "5de70ab482edb2da7ac20126dc58e23a691498aa644ca23a7b10c32c9ee62157" )
+
+      set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-win32" )
+      set( LIBCLANG_SHA256
+           "b5c7d1c6009599613dd99ec7ebc720bb4be928890e7d46614c8e2adb17c047c7" )
     endif()
     set( CLANG_FILENAME "${CLANG_DIRNAME}.exe" )
+    set( LIBCLANG_FILENAME "${LIBCLANG_DIRNAME}.tar.bz2" )
   elseif ( SYSTEM_IS_FREEBSD )
     if ( 64_BIT_PLATFORM )
       set( CLANG_DIRNAME "clang+llvm-${CLANG_VERSION}-amd64-unknown-freebsd10" )
@@ -75,6 +90,11 @@ if ( USE_CLANG_COMPLETER AND
            "clang+llvm-${CLANG_VERSION}-x86_64-linux-gnu-ubuntu-14.04" )
       set( CLANG_SHA256
            "9e61c6669991e2f0d065348c95917b2c6b697d75098b60ec1c2e9f17093ce012" )
+
+      set( LIBCLANG_DIRNAME
+           "libclang-${CLANG_VERSION}-x86_64-linux-gnu-ubuntu-14.04" )
+      set( LIBCLANG_SHA256
+           "25eeb9183c15ec49eda103ee980569588e8b9c1c690024925a24dedcb9ac94a4" )
     else()
       message( FATAL_ERROR
         "No prebuilt Clang ${CLANG_VERSION} binaries for 32-bit Linux. "
@@ -82,11 +102,26 @@ if ( USE_CLANG_COMPLETER AND
         "See the YCM docs for details on how to use a user-compiled libclang." )
     endif()
     set( CLANG_FILENAME "${CLANG_DIRNAME}.tar.xz" )
+    set( LIBCLANG_FILENAME "${LIBCLANG_DIRNAME}.tar.bz2" )
   endif()
 
-  # Check if the Clang archive is already downloaded and its checksum is correct.
-  # If this is not the case, remove it if needed and download it.
   set( CLANG_DOWNLOAD ON )
+  if ( LIBCLANG_FILENAME AND USE_LIBCLANG_PACKAGE )
+    set( CLANG_FILENAME ${LIBCLANG_FILENAME} )
+    set( CLANG_DIRNAME ${LIBCLANG_DIRNAME} )
+    set( CLANG_SHA256 ${LIBCLANG_SHA256} )
+    set( USING_LIBCLANG_DOWNLOAD ON )
+    set( CLANG_URL
+         "https://bintray.com/puremourning/libclang/download_file?file_path=${CLANG_FILENAME}" )
+    set( CLANG_PACKAGE "libclang" )
+  else()
+    set( CLANG_URL
+         "http://releases.llvm.org/${CLANG_VERSION}/${CLANG_FILENAME}" )
+    set( CLANG_PACKAGE "Clang" )
+  endif()
+
+  # Check if the Clang archive is already downloaded and its checksum is
+  # correct.  If this is not the case, remove it if needed and download it.
   set( CLANG_LOCAL_FILE
        "${CMAKE_SOURCE_DIR}/../clang_archives/${CLANG_FILENAME}" )
 
@@ -101,21 +136,20 @@ if ( USE_CLANG_COMPLETER AND
   endif()
 
   if( CLANG_DOWNLOAD )
-    message( "Downloading Clang ${CLANG_VERSION}" )
+    message( "Downloading ${CLANG_PACKAGE} ${CLANG_VERSION} from ${CLANG_URL}" )
 
-    set( CLANG_URL "http://releases.llvm.org/${CLANG_VERSION}" )
     file(
-      DOWNLOAD "${CLANG_URL}/${CLANG_FILENAME}" "${CLANG_LOCAL_FILE}"
+      DOWNLOAD "${CLANG_URL}" "${CLANG_LOCAL_FILE}"
       SHOW_PROGRESS EXPECTED_HASH SHA256=${CLANG_SHA256}
     )
   else()
-    message( "Using Clang archive: ${CLANG_LOCAL_FILE}" )
+    message( "Using ${CLANG_PACKAGE} archive: ${CLANG_LOCAL_FILE}" )
   endif()
 
   # Copy and extract the Clang archive in the building directory.
   file( COPY "${CLANG_LOCAL_FILE}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/../" )
   if ( CLANG_FILENAME MATCHES ".+bz2" )
-    execute_process( COMMAND tar -xjf ${CLANG_FILENAME} )
+    execute_process( COMMAND ${CMAKE_COMMAND} -E tar -xjf ${CLANG_FILENAME} )
   elseif( CLANG_FILENAME MATCHES ".+xz" )
     execute_process( COMMAND tar -xJf ${CLANG_FILENAME} )
   elseif( CLANG_FILENAME MATCHES ".+exe" )
@@ -177,7 +211,7 @@ else()
            "available" )
 endif()
 
-if ( PATH_TO_LLVM_ROOT )
+if ( NOT USING_LIBCLANG_DOWNLOAD AND PATH_TO_LLVM_ROOT )
   set( CLANG_INCLUDES_DIR "${PATH_TO_LLVM_ROOT}/include" )
 else()
   set( CLANG_INCLUDES_DIR "${CMAKE_SOURCE_DIR}/llvm/include" )

--- a/make_llvm_package.py
+++ b/make_llvm_package.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python
+
+# Passing an environment variable containing unicode literals to a subprocess
+# on Windows and Python2 raises a TypeError. Since there is no unicode
+# string in this script, we don't import unicode_literals to avoid the issue.
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import subprocess
+import contextlib
+import os
+import os.path as p
+import platform
+import shutil
+import sys
+import tempfile
+import tarfile
+import hashlib
+
+try:
+  import lzma
+except:
+  from backports import lzma
+
+DIR_OF_THIS_SCRIPT = p.dirname( p.abspath( __file__ ) )
+sys.path.insert( 0, os.path.join( DIR_OF_THIS_SCRIPT, 'ycmd' ) )
+from ycmd import server_utils
+server_utils.SetUpPythonPath()
+
+# Not installing aliases from python-future; it's unreliable and slow.
+from builtins import *  # noqa
+from future.utils import iteritems
+import argparse
+import requests
+from io import BytesIO
+
+
+def OnWindows():
+  return platform.system() == 'Windows'
+
+
+def OnMac():
+  return platform.system() == 'Darwin'
+
+
+LLVM_DOWNLOAD_DATA = {
+  'win32': {
+    'format': 'nsis',
+    'llvm_package': 'LLVM-{llvm_version}-{os_name}.exe',
+    'ycmd_package': 'libclang-{llvm_version}-{os_name}.tar.bz2',
+    'files_to_copy': [
+      os.path.join( 'bin', 'libclang.dll' ),
+      os.path.join( 'lib', 'libclang.lib' ),
+    ]
+  },
+  'win64': {
+    'format': 'nsis',
+    'llvm_package': 'LLVM-{llvm_version}-{os_name}.exe',
+    'ycmd_package': 'libclang-{llvm_version}-{os_name}.tar.bz2',
+    'files_to_copy': [
+      os.path.join( 'bin', 'libclang.dll' ),
+      os.path.join( 'lib', 'libclang.lib' ),
+    ]
+  },
+  'x86_64-apple-darwin': {
+    'format': 'lzma',
+    'llvm_package': 'clang+llvm-{llvm_version}-{os_name}.tar.xz',
+    'ycmd_package': 'libclang-{llvm_version}-{os_name}.tar.bz2',
+    'files_to_copy': [
+      os.path.join( 'lib', 'libclang.dylib' ),
+    ]
+  },
+  'x86_64-linux-gnu-ubuntu-14.04': {
+    'format': 'lzma',
+    'llvm_package': 'clang+llvm-{llvm_version}-{os_name}.tar.xz',
+    'ycmd_package': 'libclang-{llvm_version}-{os_name}.tar.bz2',
+    'files_to_copy': [
+      os.path.join( 'lib', 'libclang.so' ),
+      os.path.join( 'lib', 'libclang.so.5' ),
+      os.path.join( 'lib', 'libclang.so.5.0' ),
+    ]
+  },
+}
+
+
+@contextlib.contextmanager
+def TemporaryDirectory():
+  temp_dir = tempfile.mkdtemp()
+  try:
+    yield temp_dir
+  finally:
+    shutil.rmtree( temp_dir )
+
+
+def DownloadClangLicense( version, destination ):
+  print( 'Downloading license...' )
+  request = requests.get(
+    'https://releases.llvm.org/{version}/LICENSE.TXT'.format( version=version ),
+    stream = True )
+  request.raise_for_status()
+
+  file_name = os.path.join( destination, 'LICENSE.TXT' )
+  with open( file_name, 'wb' ) as f:
+    f.write( request.content )
+
+  request.close()
+
+  return file_name
+
+
+def DownloadClang( url ):
+  print( 'Downloading {0}'.format( url ) )
+
+  request = requests.get( url, stream=True )
+  request.raise_for_status()
+  content = request.content
+  request.close()
+  return content
+
+
+def ExtractClangLZMA( compressed_data, destination ):
+  uncompressed_data = BytesIO( lzma.decompress( compressed_data ) )
+
+  print( 'Extracting...' )
+  with tarfile.TarFile( fileobj=uncompressed_data, mode='r' ) as tar_file:
+    a_member = tar_file.getmembers()[ 0 ]
+    tar_file.extractall( destination )
+
+  # Determine the directory name
+  return os.path.join( destination,
+                       a_member.name.split( os.path.sep )[ 0 ] )
+
+
+def ExtractClang7Z( llvm_package, archive, destination ):
+  # Extract with appropriate tool
+  if OnWindows():
+    command = [ '7z.exe' ]
+  elif OnMac():
+    command = [ '/Applications/Keka.app/Contents/Resources/keka7z' ]
+  else:
+    raise AssertionError( 'Dont know where to find 7zip on this platform' )
+
+  command.extend( [
+    '-y',
+    'x',
+    archive,
+    '-o' + destination
+  ] )
+
+  subprocess.check_call( command )
+
+  return destination
+
+
+def MakeBundle( files_to_copy,
+                license_file_name,
+                source_dir,
+                bundle_file_name,
+                hashes ):
+  print( "Bundling files from {0}".format( source_dir ) )
+  with tarfile.open( name=bundle_file_name, mode='w:bz2' ) as tar_file:
+    tar_file.add( license_file_name, arcname='LICENSE.TXT' )
+    for file_name in files_to_copy:
+      tar_file.add( name = os.path.join( source_dir, file_name ),
+                    arcname = file_name )
+
+  print( "Calculating checksum: " )
+  with open( bundle_file_name, 'rb' ) as f:
+    hashes[ bundle_file_name ] = hashlib.sha256( f.read() ).hexdigest()
+    print( 'Hash is: {0}'.format( hashes[ bundle_file_name ] ) )
+
+
+def UploadBundleToBintray( user_name,
+                           api_token,
+                           os_name,
+                           version,
+                           bundle_file_name ):
+  print( 'Uploading to bintray...' )
+  with open( bundle_file_name, 'rb' ) as bundle:
+    request = requests.put(
+      'https://api.bintray.com/content/{subject}/{repo}/{file_path}'.format(
+        subject = user_name,
+        repo = 'libclang',
+        file_path = os.path.basename( bundle_file_name ) ),
+      data = bundle,
+      auth = ( user_name, api_token ),
+      headers = {
+        'X-Bintray-Package': 'libclang',
+        'X-Bintray-Version': version,
+        'X-Bintray-Publish': 1,
+        'X-Bintray-Override': 1,
+      } )
+    request.raise_for_status()
+
+
+def ParseArguments():
+  parser = argparse.ArgumentParser()
+
+  parser.add_argument( 'version', action='store',
+                       help = 'The LLVM version' )
+
+  parser.add_argument( '--bt-user', action='store',
+                       help = 'Bintray user name. Defaults to environment '
+                              'variable: YCMD_BINTRAY_USERNAME' )
+  parser.add_argument( '--bt-token', action='store',
+                       help = 'Bintray api token. Defaults to environment '
+                              'variable: YCMD_BINTRAY_API_TOKEN.' )
+  parser.add_argument( '--from-cache', action='store',
+                       help = 'Use the clang packages from this dir. Useful '
+                              'if releases.llvm.org is unreliable.' )
+  parser.add_argument( '--output-dir', action='store',
+                       help = 'For testing, directory to put bundles in.' )
+  parser.add_argument( '--no-upload', action='store_true',
+                       help = "For testing, just build the bundles; don't "
+                              "upload to bintray. Useful with --output-dir." )
+
+  args = parser.parse_args()
+
+  if not args.bt_user:
+    if 'YCMD_BINTRAY_USERNAME' not in os.environ:
+      raise RuntimeError( 'ERROR: Must specify either --bt-user or '
+                          'YCMD_BINTRAY_USERNAME in environment' )
+    args.bt_user = os.environ[ 'YCMD_BINTRAY_USERNAME' ]
+
+  if not args.bt_token:
+    if 'YCMD_BINTRAY_API_TOKEN' not in os.environ:
+      raise RuntimeError( 'ERROR: Must specify either --bt-token or '
+                          'YCMD_BINTRAY_API_TOKEN in environment' )
+    args.bt_token = os.environ[ 'YCMD_BINTRAY_API_TOKEN' ]
+
+  return args
+
+
+def PrepareBundleLZMA( cache_dir, llvm_package, download_url, temp_dir ):
+  package_dir = None
+  if cache_dir:
+    archive = os.path.join( cache_dir, llvm_package )
+    print( 'Loading cached archive: {0}'.format( archive ) )
+    try:
+      with open( archive, 'rb' ) as f:
+        package_dir = ExtractClangLZMA( f.read(), temp_dir )
+    except IOError:
+      pass
+
+  if not package_dir:
+    compressed_data = DownloadClang( download_url )
+    package_dir = ExtractClangLZMA( compressed_data, temp_dir )
+
+  return package_dir
+
+
+def PrepareBundleNSIS( cache_dir, llvm_package, download_url, temp_dir ):
+  if cache_dir:
+    archive = os.path.join( cache_dir, llvm_package )
+    print( 'Loading cached archive: {0}'.format( archive ) )
+  else:
+    compressed_data = DownloadClang( download_url )
+    archive = os.path.join( temp_dir, llvm_package )
+    with open( archive, 'wb' ) as f:
+      f.write( compressed_data )
+
+  return ExtractClang7Z( llvm_package, archive, temp_dir )
+
+
+def BundleAndUpload( args, output_dir, os_name, download_data, hashes ):
+  llvm_package = download_data[ 'llvm_package' ].format(
+    os_name = os_name,
+    llvm_version = args.version )
+  ycmd_package = download_data[ 'ycmd_package' ].format(
+    os_name = os_name,
+    llvm_version = args.version )
+  download_url = (
+    'http://releases.llvm.org/{llvm_version}/{llvm_package}'.format(
+      llvm_version = args.version,
+      llvm_package = llvm_package ) )
+
+  ycmd_package_file = os.path.join( output_dir, ycmd_package )
+  with TemporaryDirectory() as temp_dir:
+    license_file_name = DownloadClangLicense( args.version, temp_dir )
+
+    if download_data[ 'format' ] == 'lzma':
+      package_dir = PrepareBundleLZMA( args.from_cache,
+                                       llvm_package,
+                                       download_url,
+                                       temp_dir )
+    elif download_data[ 'format' ] == 'nsis':
+      package_dir = PrepareBundleNSIS( args.from_cache,
+                                       llvm_package,
+                                       download_url,
+                                       temp_dir )
+    else:
+      raise AssertionError( 'Format not yet implemented: {0}'.format(
+        download_data[ 'format' ] ) )
+
+    MakeBundle( download_data[ 'files_to_copy' ],
+                license_file_name,
+                package_dir,
+                ycmd_package_file,
+                hashes )
+
+    if not args.no_upload:
+      UploadBundleToBintray( args.bt_user,
+                             args.bt_token,
+                             os_name,
+                             args.version,
+                             ycmd_package_file )
+
+
+def Main():
+  args = ParseArguments()
+
+  output_dir = args.output_dir if args.output_dir else tempfile.mkdtemp()
+
+  try:
+    hashes = dict()
+    for os_name, download_data in iteritems( LLVM_DOWNLOAD_DATA ):
+      BundleAndUpload( args, output_dir, os_name, download_data, hashes )
+  finally:
+    if not args.output_dir:
+      shutil.rmtree( output_dir )
+
+  for bundle_file_name, sha256 in iteritems( hashes ):
+    print( "Checksum for {bundle_file_name}: {sha256}".format(
+      bundle_file_name = bundle_file_name,
+      sha256 = sha256 ) )
+
+
+if __name__ == "__main__":
+  Main()


### PR DESCRIPTION
releases.llvm.org is under serious load and is causing CI to flake.

The LLVM people say that CI systems shouldn't continually download clang
from release.llvm.org. We normally wouldn't but the caches in our CI are
full and we seem to fail to cache the LLVM full download.

Instead, we just use a package (created by us) containing only libclang,
and download that from bintray (which is free for OSS usage). There is
some limit to the number of downloads etc., so we only enable this in CI, even if it is cached.

In theory, we could also suggest this to users who are struggling with the download, such as from behind certain national firewalls.

I selected bintray as the hosting as it is free for a limited amount of traffic for open source projects. The packages contain the libraries and the LLVM license.

I have prepared and uploaded packages for the CI platforms that we use, and can see in the CI that they are being used and more importantly, the AppVeyor cache is not full anymore, meaning that the cached versions are being used on repeated runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/897)
<!-- Reviewable:end -->
