### PR TITLE
[READY] Make constructor style consistent

### DIFF
--- a/cpp/ycm/Candidate.cpp
+++ b/cpp/ycm/Candidate.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2011, 2012 Google Inc.
+// Copyright (C) 2011-2018 ycmd contributors
 //
 // This file is part of ycmd.
 //
@@ -59,13 +59,12 @@ Bitset LetterBitsetFromString( const std::string &text ) {
 
 
 Candidate::Candidate( const std::string &text )
-  :
-  text_( text ),
-  case_swapped_text_( SwapCase( text ) ),
-  word_boundary_chars_( GetWordBoundaryChars( text ) ),
-  text_is_lowercase_( IsLowercase( text ) ),
-  letters_present_( LetterBitsetFromString( text ) ),
-  root_node_( new LetterNode( text ) ) {
+  : text_( text ),
+    case_swapped_text_( SwapCase( text ) ),
+    word_boundary_chars_( GetWordBoundaryChars( text ) ),
+    text_is_lowercase_( IsLowercase( text ) ),
+    letters_present_( LetterBitsetFromString( text ) ),
+    root_node_( new LetterNode( text ) ) {
 }
 
 

--- a/cpp/ycm/ClangCompleter/CompilationDatabase.cpp
+++ b/cpp/ycm/ClangCompleter/CompilationDatabase.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2011, 2012 Google Inc.
+// Copyright (C) 2011-2018 ycmd contributors
 //
 // This file is part of ycmd.
 //
@@ -37,8 +37,8 @@ remove_pointer< CXCompileCommands >::type > CompileCommandsWrap;
 
 CompilationDatabase::CompilationDatabase(
   const boost::python::object &path_to_directory )
-  : is_loaded_( false )
-  , path_to_directory_( GetUtf8String( path_to_directory ) ) {
+  : is_loaded_( false ),
+    path_to_directory_( GetUtf8String( path_to_directory ) ) {
   CXCompilationDatabase_Error status;
   compilation_database_ = clang_CompilationDatabase_fromDirectory(
                             path_to_directory_.c_str(),

--- a/cpp/ycm/ClangCompleter/Documentation.cpp
+++ b/cpp/ycm/ClangCompleter/Documentation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2015 YouCompleteMe Contributors
+// Copyright (C) 2015-2018 ycmd contributors
 //
 // This file is part of ycmd.
 //
@@ -31,13 +31,13 @@ bool CXCommentValid( const CXComment &comment ) {
 }
 
 DocumentationData::DocumentationData( const CXCursor &cursor )
-  : raw_comment( CXStringToString( clang_Cursor_getRawCommentText( cursor ) ) )
-  , brief_comment( CXStringToString(
-                     clang_Cursor_getBriefCommentText( cursor ) ) )
-  , canonical_type( CXStringToString(
-                      clang_getTypeSpelling( clang_getCursorType( cursor ) ) ) )
-  , display_name( CXStringToString( clang_getCursorSpelling( cursor ) ) ) {
-
+  : raw_comment( CXStringToString(
+      clang_Cursor_getRawCommentText( cursor ) ) ),
+    brief_comment( CXStringToString(
+      clang_Cursor_getBriefCommentText( cursor ) ) ),
+    canonical_type( CXStringToString(
+      clang_getTypeSpelling( clang_getCursorType( cursor ) ) ) ),
+    display_name( CXStringToString( clang_getCursorSpelling( cursor ) ) ) {
 
   CXComment parsed_comment = clang_Cursor_getParsedComment( cursor );
 

--- a/cpp/ycm/ClangCompleter/Location.h
+++ b/cpp/ycm/ClangCompleter/Location.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2011, 2012 Google Inc.
+// Copyright (C) 2011-2018 ycmd contributors
 //
 // This file is part of ycmd.
 //
@@ -27,14 +27,19 @@ namespace YouCompleteMe {
 
 struct Location {
   // Creates an invalid location
-  Location() : line_number_( 0 ), column_number_( 0 ), filename_( "" ) {}
+  Location()
+    : line_number_( 0 ),
+      column_number_( 0 ),
+      filename_( "" ) {
+  }
 
   Location( const std::string &filename,
             unsigned int line,
             unsigned int column )
     : line_number_( line ),
       column_number_( column ),
-      filename_( filename ) {}
+      filename_( filename ) {
+  }
 
   Location( const CXSourceLocation &location ) {
     CXFile file;

--- a/cpp/ycm/ClangCompleter/Range.h
+++ b/cpp/ycm/ClangCompleter/Range.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 Google Inc.
+// Copyright (C) 2013-2018 ycmd contributors
 //
 // This file is part of ycmd.
 //
@@ -27,7 +27,9 @@ struct Range {
   Range() {}
 
   Range( const Location &start_location, const Location &end_location )
-    : start_( start_location ), end_( end_location ) {}
+    : start_( start_location ),
+      end_( end_location ) {
+  }
 
   Range( const CXSourceRange &range );
 

--- a/cpp/ycm/LetterNodeListMap.h
+++ b/cpp/ycm/LetterNodeListMap.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2011, 2012 Google Inc.
+// Copyright (C) 2011-2018 ycmd contributors
 //
 // This file is part of ycmd.
 //
@@ -52,8 +52,8 @@ YCM_EXPORT int IndexForLetter( char letter );
 struct NearestLetterNodeIndices {
   NearestLetterNodeIndices()
     : indexOfFirstOccurrence( -1 ),
-      indexOfFirstUppercaseOccurrence( -1 )
-  {}
+      indexOfFirstUppercaseOccurrence( -1 ) {
+  }
 
   short indexOfFirstOccurrence;
   short indexOfFirstUppercaseOccurrence;

--- a/cpp/ycm/Result.cpp
+++ b/cpp/ycm/Result.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2011, 2012 Google Inc.
+// Copyright (C) 2011-2018 ycmd contributors
 //
 // This file is part of ycmd.
 //
@@ -58,17 +58,16 @@ int NumWordBoundaryCharMatches( const std::string &query,
 } // unnamed namespace
 
 Result::Result( bool is_subsequence )
-  :
-  query_is_empty_( true ),
-  is_subsequence_( is_subsequence ),
-  first_char_same_in_query_and_text_( false ),
-  ratio_of_word_boundary_chars_in_query_( 0 ),
-  word_boundary_char_utilization_( 0 ),
-  query_is_candidate_prefix_( false ),
-  text_is_lowercase_( false ),
-  char_match_index_sum_( 0 ),
-  text_( NULL ),
-  case_swapped_text_( NULL ) {
+  : query_is_empty_( true ),
+    is_subsequence_( is_subsequence ),
+    first_char_same_in_query_and_text_( false ),
+    ratio_of_word_boundary_chars_in_query_( 0 ),
+    word_boundary_char_utilization_( 0 ),
+    query_is_candidate_prefix_( false ),
+    text_is_lowercase_( false ),
+    char_match_index_sum_( 0 ),
+    text_( NULL ),
+    case_swapped_text_( NULL ) {
 }
 
 
@@ -79,17 +78,16 @@ Result::Result( bool is_subsequence,
                 int char_match_index_sum,
                 const std::string &word_boundary_chars,
                 const std::string &query )
-  :
-  query_is_empty_( true ),
-  is_subsequence_( is_subsequence ),
-  first_char_same_in_query_and_text_( false ),
-  ratio_of_word_boundary_chars_in_query_( 0 ),
-  word_boundary_char_utilization_( 0 ),
-  query_is_candidate_prefix_( false ),
-  text_is_lowercase_( text_is_lowercase ),
-  char_match_index_sum_( char_match_index_sum ),
-  text_( text ),
-  case_swapped_text_( case_swapped_text ) {
+  : query_is_empty_( true ),
+    is_subsequence_( is_subsequence ),
+    first_char_same_in_query_and_text_( false ),
+    ratio_of_word_boundary_chars_in_query_( 0 ),
+    word_boundary_char_utilization_( 0 ),
+    query_is_candidate_prefix_( false ),
+    text_is_lowercase_( text_is_lowercase ),
+    char_match_index_sum_( char_match_index_sum ),
+    text_( text ),
+    case_swapped_text_( case_swapped_text ) {
   if ( is_subsequence )
     SetResultFeaturesFromQuery( word_boundary_chars, query );
 }

--- a/cpp/ycm/Result.h
+++ b/cpp/ycm/Result.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2011, 2012 Google Inc.
+// Copyright (C) 2011-2018 ycmd contributors
 //
 // This file is part of ycmd.
 //
@@ -96,7 +96,9 @@ private:
 template< class T >
 struct ResultAnd {
   ResultAnd( const Result &result, T extra_object )
-    : extra_object_( extra_object ), result_( result ) {}
+    : extra_object_( extra_object ),
+      result_( result ) {
+  }
 
   bool operator< ( const ResultAnd &other ) const {
     return result_ < other.result_;
@@ -109,7 +111,9 @@ struct ResultAnd {
 template< class T >
 struct ResultAnd<T * > {
   ResultAnd( const Result &result, const T *extra_object )
-    : extra_object_( extra_object ), result_( result ) {}
+    : extra_object_( extra_object ),
+      result_( result ) {
+  }
 
   bool operator< ( const ResultAnd &other ) const {
     return result_ < other.result_;


### PR DESCRIPTION
Consistently use the following style for constructor initialization list:
```C++
Constructor( ... )
  : var1( ... ),
    var2( ... ),
    ...
    varN( ... ) {
  ...
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/899)
<!-- Reviewable:end -->
