### PR TITLE
[READY] Calculate the start codepoint when we don't resolve items in LSC

### DIFF
--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -79,6 +79,10 @@ class RequestWrap( object ):
       # of the identifier to be completed
       'query': ( self._Query, None ),
 
+      # Unicode string representation of the line value up to the character
+      # before the start of 'query'
+      'prefix': ( self._Prefix, None ),
+
       'filetypes': ( self._Filetypes, None ),
 
       'first_filetype': ( self._FirstFiletype, None ),
@@ -183,6 +187,10 @@ class RequestWrap( object ):
     return self[ 'line_value' ][
         self[ 'start_codepoint' ] - 1 : self[ 'column_codepoint' ] - 1
     ]
+
+
+  def _Prefix( self ):
+    return self[ 'line_value' ][ : ( self[ 'start_codepoint' ] - 1 ) ]
 
 
   def _FirstFiletype( self ):

--- a/ycmd/tests/java/get_completions_test.py
+++ b/ycmd/tests/java/get_completions_test.py
@@ -28,7 +28,8 @@ from hamcrest import ( assert_that,
                        contains_inanyorder,
                        empty,
                        matches_regexp,
-                       has_entries )
+                       has_entries,
+                       has_item )
 from nose.tools import eq_
 
 from pprint import pformat
@@ -506,3 +507,28 @@ def Subcommands_ServerNotReady_test( app ):
         } ),
       }
     } )
+
+
+@SharedYcmd
+def GetCompletions_MoreThan100NoResolve_test( app ):
+  RunTest( app, {
+    'description': 'We guess the right start codepoint without resolving',
+    'request': {
+      'filetype'  : 'java',
+      'filepath'  : ProjectPath( 'TestLauncher.java' ),
+      'line_num'  : 4,
+      'column_num': 15,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completions': has_item(
+          CompletionEntryMatcher( 'com.youcompleteme', None, {
+            'kind': 'Module'
+          } ),
+        ),
+        'completion_start_column': 8,
+        'errors': empty(),
+      } )
+    },
+  } )

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -384,3 +384,32 @@ def LanguageServerCompleter_GetCompletions_List_test():
                                      resolve_responses ):
       assert_that( completer.ComputeCandidatesInner( request_data ),
                    has_items( has_entries( { 'insertion_text': 'test' } ) ) )
+
+
+def FindOverlapLength_test():
+  tests = [
+    ( '', '', 0 ),
+    ( 'a', 'a', 1 ),
+    ( 'a', 'b', 0 ),
+    ( 'abcdef', 'abcdefg', 6 ),
+    ( 'abcdefg', 'abcdef', 0 ),
+    ( 'aaab', 'aaab', 4 ),
+    ( 'abab', 'ab', 2 ),
+    ( 'aab', 'caab', 0 ),
+    ( 'abab', 'abababab', 4 ),
+    ( 'aaab', 'baaa', 1 ),
+    ( 'test.', 'test.test', 5 ),
+    ( 'test.', 'test', 0 ),
+    ( 'test', 'testtest', 4 ),
+    ( '', 'testtest', 0 ),
+    ( 'test', '', 0 ),
+    ( 'Some CoCo', 'CoCo Beans', 4 ),
+    ( 'Have some CoCo and CoCo', 'CoCo and CoCo is here.', 13 ),
+    ( 'TEST xyAzA', 'xyAzA test', 5 ),
+  ]
+
+  def Test( line, text, overlap ):
+    assert_that( lsc.FindOverlapLength( line, text ), equal_to( overlap ) )
+
+  for test in tests:
+    yield Test, test[ 0 ], test[ 1 ], test[ 2 ]

--- a/ycmd/tests/request_wrap_test.py
+++ b/ycmd/tests/request_wrap_test.py
@@ -45,6 +45,27 @@ def PrepareJson( contents = '', line_num = 1, column_num = 1, filetype = '' ):
   }
 
 
+def Prefix_test():
+  tests = [
+    ( 'abc.def', 5, 'abc.' ),
+    ( 'abc.def', 6, 'abc.' ),
+    ( 'abc.def', 8, 'abc.' ),
+    ( 'abc.def', 4, '' ),
+    ( 'abc.', 5, 'abc.' ),
+    ( 'abc.', 4, '' ),
+    ( '', 1, '' ),
+  ]
+
+  def Test( line, col, prefix ):
+    eq_( prefix,
+         RequestWrap( PrepareJson( line_num = 1,
+                                   contents = line,
+                                   column_num = col ) )[ 'prefix' ] )
+
+  for test in tests:
+    yield Test, test[ 0 ], test[ 1 ], test[ 2 ]
+
+
 def LineValue_OneLine_test():
   eq_( 'zoo',
        RequestWrap( PrepareJson( line_num = 1,


### PR DESCRIPTION
Resolving lots of completion items is very slow, so we only do that if
there are 100 or feweer completions.

Most unfortunately Visual Studio Code does some heuristics on completion
items, so that any overlap with existing code is replaced, rather than
appended. This happens to be how jdt.ls returns import completions.

It's common for there to be more than 100 suggestions when typing,
say 'import com.'. This leads to bad behaviour where the insertion ends
up being 'com.com.youcompletme...' which is clearly wrong.

To combad this, when we don't have a textEdit to apply, we detect any
overlap between the insertion_text and the existing text (up to the
completion location) and offset the start_codepoint by that much.

The overlap detection algorithm is efficient (see the link) and simpler
than a dynamic programming one.

Incidentally, we add the 'prefix' key to request_wrap to avoid
recalculating it for each element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/905)
<!-- Reviewable:end -->
