### PR TITLE
[READY] Fix link about Windows dynamic library in build script

### DIFF
--- a/build.py
+++ b/build.py
@@ -63,7 +63,7 @@ NO_PYTHON_LIBRARY_ERROR = 'ERROR: unable to find an appropriate Python library.'
 #  - the linker name (the soname without the version) does not always
 #    exist so we look for the versioned names too;
 #  - on Windows, the .lib extension is used instead of the .dll one. See
-#    http://xenophilia.org/winvunix.html to understand why.
+#    https://en.wikipedia.org/wiki/Dynamic-link_library#Import_libraries
 STATIC_PYTHON_LIBRARY_REGEX = '^libpython{major}\.{minor}m?\.a$'
 DYNAMIC_PYTHON_LIBRARY_REGEX = """
   ^(?:


### PR DESCRIPTION
The link explaining why we are looking for a Python library with the `.lib` extension (and not a `.dll` one) on Windows is broken.

This PR can be merged without triggering zzbot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/907)
<!-- Reviewable:end -->
