### PR TITLE
Download libclang and llvm from https 

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -116,7 +116,7 @@ if ( USE_CLANG_COMPLETER AND
     set( CLANG_PACKAGE "libclang" )
   else()
     set( CLANG_URL
-         "http://releases.llvm.org/${CLANG_VERSION}/${CLANG_FILENAME}" )
+         "https://releases.llvm.org/${CLANG_VERSION}/${CLANG_FILENAME}" )
     set( CLANG_PACKAGE "Clang" )
   endif()
 


### PR DESCRIPTION
Change libclangsource to https to avoid some http hijack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/912)
<!-- Reviewable:end -->
