### PR TITLE
Do not try to symlink libclang on Windows

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -409,7 +409,7 @@ if( LIBCLANG_TARGET )
       COMMAND ${CMAKE_COMMAND} -E copy "${LIBCLANG_TARGET}" "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
     )
 
-    if( NOT APPLE )
+    if( NOT APPLE AND NOT WIN32 )
       # When loading our library, the dynamic linker may look for
       # libclang.so.x instead of libclang.so.x.y. Create the corresponding
       # symlink.


### PR DESCRIPTION
create_symlink is UNIX specific[1], and it breaks the build
on Windows.

[1]: https://cmake.org/cmake/help/v3.9/manual/cmake.1.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/914)
<!-- Reviewable:end -->
