### PR TITLE
[READY] Add formatting support to language server completer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
     <h1>ycmd</h1>
     <p class="sw-info">
         
-        Version: <span class="sw-info-version">0.1.0</span>,     <a href="https://github.com/Valloric/ycmd" class="sw-external-doc">ycmd GitHub page</a>
+        Version: <span class="sw-info-version">0.2.0</span>,     <a href="https://github.com/Valloric/ycmd" class="sw-external-doc">ycmd GitHub page</a>
     
     </p>
     <p><p>ycmd is a code-completion &amp; code-comprehension server.</p>
@@ -1747,7 +1747,7 @@
                             <div  class="panel panel-definition">
                                 <div class="panel-body">
                                             <section class="json-schema-example">
-                                                <pre><code class="lang-json">{<br>    &quot;<span class="hljs-attribute">column_num</span>&quot;: <span class="hljs-value"><span class="hljs-number">20</span></span>,<br>    &quot;<span class="hljs-attribute">command_arguments</span>&quot;: <span class="hljs-value">[<br>        <span class="hljs-string">&quot;RefactorRename&quot;</span>,<br>        <span class="hljs-string">&quot;Testing&quot;</span><br>    ]</span>,<br>    &quot;<span class="hljs-attribute">completer_target</span>&quot;: <span class="hljs-value"><span class="hljs-string">&quot;filetype_default&quot;</span></span>,<br>    &quot;<span class="hljs-attribute">file_data</span>&quot;: <span class="hljs-value">{<br>        &quot;<span class="hljs-attribute">/home/test/dev/test.js</span>&quot;: <span class="hljs-value">{<br>            &quot;<span class="hljs-attribute">contents</span>&quot;: <span class="hljs-value"><span class="hljs-string">&quot;&lt;file contents&gt;&quot;</span></span>,<br>            &quot;<span class="hljs-attribute">filetypes</span>&quot;: <span class="hljs-value">[<br>                <span class="hljs-string">&quot;javascript&quot;</span><br>            ]<br>        </span>}<br>    </span>}</span>,<br>    &quot;<span class="hljs-attribute">filepath</span>&quot;: <span class="hljs-value"><span class="hljs-string">&quot;/home/test/dev/test.js&quot;</span></span>,<br>    &quot;<span class="hljs-attribute">line_num</span>&quot;: <span class="hljs-value"><span class="hljs-number">10</span><br></span>}
+                                                <pre><code class="lang-json">{<br>    &quot;<span class="hljs-attribute">column_num</span>&quot;: <span class="hljs-value"><span class="hljs-number">20</span></span>,<br>    &quot;<span class="hljs-attribute">command_arguments</span>&quot;: <span class="hljs-value">[<br>        <span class="hljs-string">&quot;RefactorRename&quot;</span>,<br>        <span class="hljs-string">&quot;Testing&quot;</span><br>    ]</span>,<br>    &quot;<span class="hljs-attribute">completer_target</span>&quot;: <span class="hljs-value"><span class="hljs-string">&quot;filetype_default&quot;</span></span>,<br>    &quot;<span class="hljs-attribute">file_data</span>&quot;: <span class="hljs-value">{<br>        &quot;<span class="hljs-attribute">/home/test/dev/test.js</span>&quot;: <span class="hljs-value">{<br>            &quot;<span class="hljs-attribute">contents</span>&quot;: <span class="hljs-value"><span class="hljs-string">&quot;&lt;file contents&gt;&quot;</span></span>,<br>            &quot;<span class="hljs-attribute">filetypes</span>&quot;: <span class="hljs-value">[<br>                <span class="hljs-string">&quot;javascript&quot;</span><br>            ]<br>        </span>}<br>    </span>}</span>,<br>    &quot;<span class="hljs-attribute">filepath</span>&quot;: <span class="hljs-value"><span class="hljs-string">&quot;/home/test/dev/test.js&quot;</span></span>,<br>    &quot;<span class="hljs-attribute">line_num</span>&quot;: <span class="hljs-value"><span class="hljs-number">10</span></span>,<br>    &quot;<span class="hljs-attribute">options</span>&quot;: <span class="hljs-value">{<br>        &quot;<span class="hljs-attribute">insert_spaces</span>&quot;: <span class="hljs-value"><span class="hljs-literal">true</span></span>,<br>        &quot;<span class="hljs-attribute">tab_size</span>&quot;: <span class="hljs-value"><span class="hljs-number">4</span><br>    </span>}<br></span>}
                                         </code></pre>
                                         
                                             </section>
@@ -1866,6 +1866,72 @@
                                                                                             
                                                                                         </div>
                                                                                     </section>                </div>
+                                                            </dd>
+                                                            <dt data-property-name="range">
+                                                                <span class="json-property-name">range:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/Range">Range</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                            </dt>
+                                                            <dd>
+                                                                <p>The range to which the command is applied (only used by the
+                                                <em>Format</em> command).</p>
+                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="options">
+                                                                <span class="json-property-name">options:</span>
+                                                                
+                                                                <span class="json-property-type">object</span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                                    <span class="json-property-required"></span>
+                                                            </dt>
+                                                            <dd>
+                                                                <p>A set of editor-related options for the current buffer (only
+                                                used by the <em>Format</em> command).</p>
+                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                            <section class="json-schema-properties">
+                                                                                <dl>
+                                                                                        <dt data-property-name="tab_size">
+                                                                                            <span class="json-property-name">tab_size:</span>
+                                                                                            
+                                                                                            <span class="json-property-type">integer</span>
+                                                                                            <span class="json-property-range" title="Value limits"></span>
+                                                                                            
+                                                                                                <span class="json-property-required"></span>
+                                                                                        </dt>
+                                                                                        <dd>
+                                                                                            <p>The size of a tabulation in spaces.</p>
+                                                                            
+                                                                                            <div class="json-inner-schema">
+                                                                                                
+                                                                                            </div>
+                                                                                        </dd>
+                                                                                        <dt data-property-name="insert_spaces">
+                                                                                            <span class="json-property-name">insert_spaces:</span>
+                                                                                            
+                                                                                            <span class="json-property-type">boolean</span>
+                                                                                            <span class="json-property-range" title="Value limits"></span>
+                                                                                            
+                                                                                                <span class="json-property-required"></span>
+                                                                                        </dt>
+                                                                                        <dd>
+                                                                                            <p>Use spaces to represent tabulations.</p>
+                                                                            
+                                                                                            <div class="json-inner-schema">
+                                                                                                
+                                                                                            </div>
+                                                                                        </dd>
+                                                                                </dl>
+                                                                            </section>
+                                                                </div>
                                                             </dd>
                                                     </dl>
                                                 </section>

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -104,7 +104,7 @@ info:
     YCM README.md for the list of filetypes recognized by ycmd for semantic
     completion.
 
-  version: 0.1.0
+  version: 0.2.0
 
 externalDocs:
   description: ycmd GitHub page
@@ -742,6 +742,7 @@ paths:
               - filepath
               - file_data
               - command_arguments
+              - options
             properties:
               line_num:
                 $ref: "#/definitions/LineNumber"
@@ -763,16 +764,39 @@ paths:
                   `GoTo`).
                 items:
                   type: string
+              range:
+                description: |-
+                  The range to which the command is applied (only used by the
+                  *Format* command).
+                $ref: "#/definitions/Range"
+              options:
+                type: object
+                description: |-
+                  A set of editor-related options for the current buffer (only
+                  used by the *Format* command).
+                required:
+                  - tab_size
+                  - insert_spaces
+                properties:
+                  tab_size:
+                    description: The size of a tabulation in spaces.
+                    type: integer
+                  insert_spaces:
+                    description: Use spaces to represent tabulations.
+                    type: boolean
             example:
-                line_num: 10
-                column_num: 20
-                filepath: "/home/test/dev/test.js"
-                file_data:
-                  "/home/test/dev/test.js":
-                    filetypes: [ 'javascript' ]
-                    contents: "<file contents>"
-                completer_target: "filetype_default"
-                command_arguments: [ 'RefactorRename', 'Testing' ]
+              line_num: 10
+              column_num: 20
+              filepath: "/home/test/dev/test.js"
+              file_data:
+                "/home/test/dev/test.js":
+                  filetypes: [ 'javascript' ]
+                  contents: "<file contents>"
+              completer_target: "filetype_default"
+              command_arguments: [ 'RefactorRename', 'Testing' ]
+              options:
+                tab_size: 4
+                insert_spaces: true
       responses:
         200:
           description: |-

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -207,6 +207,9 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
         lambda self, request_data, args: self.RefactorRename( request_data,
                                                               args )
       ),
+      'Format': (
+        lambda self, request_data, args: self.Format( request_data )
+      ),
 
       # Handled by us
       'RestartServer': (

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1379,6 +1379,36 @@ class LanguageServerCompleter( Completer ):
       [ WorkspaceEditToFixIt( request_data, response[ 'result' ] ) ] )
 
 
+  def Format( self, request_data ):
+    """Issues the formatting or rangeFormatting request (depending on the
+    presence of a range) and returns the result as a FixIt response."""
+    if not self.ServerIsReady():
+      raise RuntimeError( 'Server is initializing. Please wait.' )
+
+    self._UpdateServerWithFileContents( request_data )
+
+    request_id = self.GetConnection().NextRequestId()
+    if 'range' in request_data:
+      message = lsp.RangeFormatting( request_id, request_data )
+    else:
+      message = lsp.Formatting( request_id, request_data )
+
+    response = self.GetConnection().GetResponse( request_id,
+                                                 message,
+                                                 REQUEST_TIMEOUT_COMMAND )
+    chunks = [ responses.FixItChunk( text_edit[ 'newText' ],
+                                     _BuildRange( request_data,
+                                                  request_data[ 'filepath' ],
+                                                  text_edit[ 'range' ] ) )
+               for text_edit in response[ 'result' ] or [] ]
+
+    return responses.BuildFixItResponse( [ responses.FixIt(
+      responses.Location( request_data[ 'line_num' ],
+                          request_data[ 'column_num' ],
+                          request_data[ 'filepath' ] ),
+      chunks ) ] )
+
+
 def _CompletionItemToCompletionData( insertion_text, item, fixits ):
   return responses.BuildCompletionData(
     insertion_text,

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -59,6 +59,7 @@ def Subcommands_DefinedSubcommands_test( app ):
   subcommands_data = BuildRequest( completer_target = 'java' )
 
   eq_( sorted( [ 'FixIt',
+                 'Format',
                  'GoToDeclaration',
                  'GoToDefinition',
                  'GoTo',
@@ -105,6 +106,7 @@ def Subcommands_ServerNotReady_test():
   yield Test, 'GetType', []
   yield Test, 'GetDoc', []
   yield Test, 'FixIt', []
+  yield Test, 'Format', []
   yield Test, 'RefactorRename', [ 'test' ]
 
 
@@ -1080,6 +1082,302 @@ def Subcommands_FixIt_InvalidURI_test( app ):
 
 
 @SharedYcmd
+def Subcommands_Format_WholeFile_Spaces_test( app ):
+  filepath = PathToTestFile( 'simple_eclipse_project',
+                             'src',
+                             'com',
+                             'youcompleteme',
+                             'Test.java' )
+  RunTest( app, {
+    'description': 'Formatting is applied on the whole file '
+                   'with tabs composed of 4 spaces by default',
+    'request': {
+      'command': 'Format',
+      'filepath': filepath,
+      'options': {
+        'tab_size': 4,
+        'insert_spaces': True
+      }
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+            ChunkMatcher( '\n    ',
+                          LocationMatcher( filepath,  3, 20 ),
+                          LocationMatcher( filepath,  4,  3 ) ),
+            ChunkMatcher( '\n\n    ',
+                          LocationMatcher( filepath,  4, 22 ),
+                          LocationMatcher( filepath,  6,  3 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath,  6, 34 ),
+                          LocationMatcher( filepath,  7,  5 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath,  7, 35 ),
+                          LocationMatcher( filepath,  8,  5 ) ),
+            ChunkMatcher( '',
+                          LocationMatcher( filepath,  8, 25 ),
+                          LocationMatcher( filepath,  8, 26 ) ),
+            ChunkMatcher( '\n    ',
+                          LocationMatcher( filepath,  8, 27 ),
+                          LocationMatcher( filepath,  9,  3 ) ),
+            ChunkMatcher( '\n\n    ',
+                          LocationMatcher( filepath,  9,  4 ),
+                          LocationMatcher( filepath, 11,  3 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath, 11, 29 ),
+                          LocationMatcher( filepath, 12,  5 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath, 12, 26 ),
+                          LocationMatcher( filepath, 13,  5 ) ),
+            ChunkMatcher( '',
+                          LocationMatcher( filepath, 13, 24 ),
+                          LocationMatcher( filepath, 13, 25 ) ),
+            ChunkMatcher( '',
+                          LocationMatcher( filepath, 13, 29 ),
+                          LocationMatcher( filepath, 13, 30 ) ),
+            ChunkMatcher( '\n\n        ',
+                          LocationMatcher( filepath, 13, 32 ),
+                          LocationMatcher( filepath, 15,  5 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath, 15, 58 ),
+                          LocationMatcher( filepath, 16,  5 ) ),
+            ChunkMatcher( '\n    ',
+                          LocationMatcher( filepath, 16, 42 ),
+                          LocationMatcher( filepath, 17,  3 ) ),
+            ChunkMatcher( '\n\n    ',
+                          LocationMatcher( filepath, 17,  4 ),
+                          LocationMatcher( filepath, 20,  3 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath, 20, 28 ),
+                          LocationMatcher( filepath, 21,  5 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath, 21, 28 ),
+                          LocationMatcher( filepath, 22,  5 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath, 22, 30 ),
+                          LocationMatcher( filepath, 23,  5 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath, 23, 23 ),
+                          LocationMatcher( filepath, 24,  5 ) ),
+            ChunkMatcher( '\n    ',
+                          LocationMatcher( filepath, 24, 27 ),
+                          LocationMatcher( filepath, 25,  3 ) ),
+          )
+        } ) )
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_Format_WholeFile_Tabs_test( app ):
+  filepath = PathToTestFile( 'simple_eclipse_project',
+                             'src',
+                             'com',
+                             'youcompleteme',
+                             'Test.java' )
+  RunTest( app, {
+    'description': 'Formatting is applied on the whole file '
+                   'with tabs composed of 2 spaces',
+    'request': {
+      'command': 'Format',
+      'filepath': filepath,
+      'options': {
+        'tab_size': 4,
+        'insert_spaces': False
+      }
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+            ChunkMatcher( '\n\t',
+                          LocationMatcher( filepath,  3, 20 ),
+                          LocationMatcher( filepath,  4,  3 ) ),
+            ChunkMatcher( '\n\n\t',
+                          LocationMatcher( filepath,  4, 22 ),
+                          LocationMatcher( filepath,  6,  3 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath,  6, 34 ),
+                          LocationMatcher( filepath,  7,  5 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath,  7, 35 ),
+                          LocationMatcher( filepath,  8,  5 ) ),
+            ChunkMatcher( '',
+                          LocationMatcher( filepath,  8, 25 ),
+                          LocationMatcher( filepath,  8, 26 ) ),
+            ChunkMatcher( '\n\t',
+                          LocationMatcher( filepath,  8, 27 ),
+                          LocationMatcher( filepath,  9,  3 ) ),
+            ChunkMatcher( '\n\n\t',
+                          LocationMatcher( filepath,  9,  4 ),
+                          LocationMatcher( filepath, 11,  3 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath, 11, 29 ),
+                          LocationMatcher( filepath, 12,  5 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath, 12, 26 ),
+                          LocationMatcher( filepath, 13,  5 ) ),
+            ChunkMatcher( '',
+                          LocationMatcher( filepath, 13, 24 ),
+                          LocationMatcher( filepath, 13, 25 ) ),
+            ChunkMatcher( '',
+                          LocationMatcher( filepath, 13, 29 ),
+                          LocationMatcher( filepath, 13, 30 ) ),
+            ChunkMatcher( '\n\n\t\t',
+                          LocationMatcher( filepath, 13, 32 ),
+                          LocationMatcher( filepath, 15,  5 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath, 15, 58 ),
+                          LocationMatcher( filepath, 16,  5 ) ),
+            ChunkMatcher( '\n\t',
+                          LocationMatcher( filepath, 16, 42 ),
+                          LocationMatcher( filepath, 17,  3 ) ),
+            ChunkMatcher( '\n\n\t',
+                          LocationMatcher( filepath, 17,  4 ),
+                          LocationMatcher( filepath, 20,  3 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath, 20, 28 ),
+                          LocationMatcher( filepath, 21,  5 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath, 21, 28 ),
+                          LocationMatcher( filepath, 22,  5 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath, 22, 30 ),
+                          LocationMatcher( filepath, 23,  5 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath, 23, 23 ),
+                          LocationMatcher( filepath, 24,  5 ) ),
+            ChunkMatcher( '\n\t',
+                          LocationMatcher( filepath, 24, 27 ),
+                          LocationMatcher( filepath, 25,  3 ) ),
+          )
+        } ) )
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_Format_Range_Spaces_test( app ):
+  filepath = PathToTestFile( 'simple_eclipse_project',
+                             'src',
+                             'com',
+                             'youcompleteme',
+                             'Test.java' )
+  RunTest( app, {
+    'description': 'Formatting is applied on some part of the file '
+                   'with tabs composed of 4 spaces by default',
+    'request': {
+      'command': 'Format',
+      'filepath': filepath,
+      'range': {
+        'start': {
+          'line_num': 20,
+          'column_num': 1,
+        },
+        'end': {
+          'line_num': 25,
+          'column_num': 4
+        }
+      },
+      'options': {
+        'tab_size': 4,
+        'insert_spaces': True
+      }
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+            ChunkMatcher( '    ',
+                          LocationMatcher( filepath, 20,  1 ),
+                          LocationMatcher( filepath, 20,  3 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath, 20, 28 ),
+                          LocationMatcher( filepath, 21,  5 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath, 21, 28 ),
+                          LocationMatcher( filepath, 22,  5 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath, 22, 30 ),
+                          LocationMatcher( filepath, 23,  5 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath, 23, 23 ),
+                          LocationMatcher( filepath, 24,  5 ) ),
+            ChunkMatcher( '\n    ',
+                          LocationMatcher( filepath, 24, 27 ),
+                          LocationMatcher( filepath, 25,  3 ) ),
+          )
+        } ) )
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_Format_Range_Tabs_test( app ):
+  filepath = PathToTestFile( 'simple_eclipse_project',
+                             'src',
+                             'com',
+                             'youcompleteme',
+                             'Test.java' )
+  RunTest( app, {
+    'description': 'Formatting is applied on some part of the file '
+                   'with tabs instead of spaces',
+    'request': {
+      'command': 'Format',
+      'filepath': filepath,
+      'range': {
+        'start': {
+          'line_num': 20,
+          'column_num': 1,
+        },
+        'end': {
+          'line_num': 25,
+          'column_num': 4
+        }
+      },
+      'options': {
+        'tab_size': 4,
+        'insert_spaces': False
+      }
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+            ChunkMatcher( '\t',
+                          LocationMatcher( filepath, 20,  1 ),
+                          LocationMatcher( filepath, 20,  3 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath, 20, 28 ),
+                          LocationMatcher( filepath, 21,  5 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath, 21, 28 ),
+                          LocationMatcher( filepath, 22,  5 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath, 22, 30 ),
+                          LocationMatcher( filepath, 23,  5 ) ),
+            ChunkMatcher( '\n\t\t',
+                          LocationMatcher( filepath, 23, 23 ),
+                          LocationMatcher( filepath, 24,  5 ) ),
+            ChunkMatcher( '\n\t',
+                          LocationMatcher( filepath, 24, 27 ),
+                          LocationMatcher( filepath, 25,  3 ) ),
+          )
+        } ) )
+      } )
+    }
+  } )
+
+
+@SharedYcmd
 def RunGoToTest( app, description, filepath, line, col, cmd, goto_response ):
   RunTest( app, {
     'description': description,
@@ -1253,7 +1551,7 @@ def Subcommands_IndexOutOfRange_test( app ):
 
 
 @SharedYcmd
-def Subcommands_DifferntFileTypesUpdate_test( app ):
+def Subcommands_DifferentFileTypesUpdate_test( app ):
   filepath = PathToTestFile( 'simple_eclipse_project',
                              'src',
                              'com',


### PR DESCRIPTION
Add support for the [`formatting`](https://microsoft.github.io/language-server-protocol/specification#textDocument_formatting) and [`rangeFormatting`](https://microsoft.github.io/language-server-protocol/specification#textDocument_rangeFormatting) requests to the language server completer through the new command `Format`. Update the API by adding two optional fields to the `run_completer_command` endpoint:
 - `range`: the range to which the formatting is applied. If given, the `rangeFormatting` LSP endpoint is used; otherwise, the `formatting` one is called. This makes more sense than having a separate command for each LSP endpoint;
 - `options`: a set of editor-related options for the current buffer. Available options are `tab_size` and `insert_spaces` which correspond to the options in [the `FormattingOptions` structure](https://microsoft.github.io/language-server-protocol/specification#textDocument_formatting). This is generic enough so that we can add more options later.

The feature is added to the Java completer (since this is the only completer that supports it). Here's a demo:

![java-format](https://user-images.githubusercontent.com/10026824/36004561-9891af6a-0d33-11e8-9efb-f492b631c94c.gif)

Some changes in YCM are needed to support the formatting options and range formatting but formatting the whole buffer should work out of the box.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/920)
<!-- Reviewable:end -->
