### PR TITLE
[READY] Use C++11 enum classes instead of plain enums

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -36,15 +36,15 @@ DiagnosticKind DiagnosticSeverityToType( CXDiagnosticSeverity severity ) {
   switch ( severity ) {
     case CXDiagnostic_Ignored:
     case CXDiagnostic_Note:
-      return INFORMATION;
+      return DiagnosticKind::INFORMATION;
 
     case CXDiagnostic_Warning:
-      return WARNING;
+      return DiagnosticKind::WARNING;
 
     case CXDiagnostic_Error:
     case CXDiagnostic_Fatal:
     default:
-      return ERROR;
+      return DiagnosticKind::ERROR;
   }
 }
 
@@ -265,7 +265,7 @@ Diagnostic BuildDiagnostic( DiagnosticWrap diagnostic_wrap,
 
   // If this is an "ignored" diagnostic, there's no point in continuing since we
   // won't display those to the user
-  if ( diagnostic.kind_ == INFORMATION ) {
+  if ( diagnostic.kind_ == DiagnosticKind::INFORMATION ) {
     return diagnostic;
   }
 

--- a/cpp/ycm/ClangCompleter/CompletionData.cpp
+++ b/cpp/ycm/ClangCompleter/CompletionData.cpp
@@ -27,27 +27,27 @@ namespace {
 CompletionKind CursorKindToCompletionKind( CXCursorKind kind ) {
   switch ( kind ) {
     case CXCursor_StructDecl:
-      return STRUCT;
+      return CompletionKind::STRUCT;
 
     case CXCursor_ClassDecl:
     case CXCursor_ClassTemplate:
     case CXCursor_ObjCInterfaceDecl:
     case CXCursor_ObjCImplementationDecl:
-      return CLASS;
+      return CompletionKind::CLASS;
 
     case CXCursor_EnumDecl:
-      return ENUM;
+      return CompletionKind::ENUM;
 
     case CXCursor_UnexposedDecl:
     case CXCursor_UnionDecl:
     case CXCursor_TypedefDecl:
-      return TYPE;
+      return CompletionKind::TYPE;
 
     case CXCursor_FieldDecl:
     case CXCursor_ObjCIvarDecl:
     case CXCursor_ObjCPropertyDecl:
     case CXCursor_EnumConstantDecl:
-      return MEMBER;
+      return CompletionKind::MEMBER;
 
     case CXCursor_FunctionDecl:
     case CXCursor_CXXMethod:
@@ -57,23 +57,23 @@ CompletionKind CursorKindToCompletionKind( CXCursorKind kind ) {
     case CXCursor_Destructor:
     case CXCursor_ObjCClassMethodDecl:
     case CXCursor_ObjCInstanceMethodDecl:
-      return FUNCTION;
+      return CompletionKind::FUNCTION;
 
     case CXCursor_VarDecl:
-      return VARIABLE;
+      return CompletionKind::VARIABLE;
 
     case CXCursor_MacroDefinition:
-      return MACRO;
+      return CompletionKind::MACRO;
 
     case CXCursor_ParmDecl:
-      return PARAMETER;
+      return CompletionKind::PARAMETER;
 
     case CXCursor_Namespace:
     case CXCursor_NamespaceAlias:
-      return NAMESPACE;
+      return CompletionKind::NAMESPACE;
 
     default:
-      return UNKNOWN;
+      return CompletionKind::UNKNOWN;
   }
 }
 

--- a/cpp/ycm/ClangCompleter/CompletionData.h
+++ b/cpp/ycm/ClangCompleter/CompletionData.h
@@ -23,7 +23,7 @@
 
 namespace YouCompleteMe {
 
-enum CompletionKind {
+enum class CompletionKind {
   STRUCT = 0,
   CLASS,
   ENUM,

--- a/cpp/ycm/ClangCompleter/Diagnostic.h
+++ b/cpp/ycm/ClangCompleter/Diagnostic.h
@@ -26,7 +26,7 @@
 
 namespace YouCompleteMe {
 
-enum DiagnosticKind {
+enum class DiagnosticKind {
   INFORMATION = 0,
   ERROR,
   WARNING

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -415,7 +415,7 @@ void TranslationUnit::UpdateLatestDiagnostics() {
                         clang_disposeDiagnostic ),
         clang_translation_unit_ );
 
-    if ( diagnostic.kind_ != INFORMATION ) {
+    if ( diagnostic.kind_ != DiagnosticKind::INFORMATION ) {
       latest_diagnostics_.push_back( diagnostic );
     }
   }

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -134,18 +134,17 @@ BOOST_PYTHON_MODULE(ycm_core)
           &ClangCompleter::GetDocsForLocationInFile );
 
   enum_< CompletionKind >( "CompletionKind" )
-    .value( "STRUCT", STRUCT )
-    .value( "CLASS", CLASS )
-    .value( "ENUM", ENUM )
-    .value( "TYPE", TYPE )
-    .value( "MEMBER", MEMBER )
-    .value( "FUNCTION", FUNCTION )
-    .value( "VARIABLE", VARIABLE )
-    .value( "MACRO", MACRO )
-    .value( "PARAMETER", PARAMETER )
-    .value( "NAMESPACE", NAMESPACE )
-    .value( "UNKNOWN", UNKNOWN )
-    .export_values();
+    .value( "STRUCT", CompletionKind::STRUCT )
+    .value( "CLASS", CompletionKind::CLASS )
+    .value( "ENUM", CompletionKind::ENUM )
+    .value( "TYPE", CompletionKind::TYPE )
+    .value( "MEMBER", CompletionKind::MEMBER )
+    .value( "FUNCTION", CompletionKind::FUNCTION )
+    .value( "VARIABLE", CompletionKind::VARIABLE )
+    .value( "MACRO", CompletionKind::MACRO )
+    .value( "PARAMETER", CompletionKind::PARAMETER )
+    .value( "NAMESPACE", CompletionKind::NAMESPACE )
+    .value( "UNKNOWN", CompletionKind::UNKNOWN );
 
   class_< CompletionData >( "CompletionData" )
     .def( "TextToInsertInBuffer", &CompletionData::TextToInsertInBuffer )
@@ -189,10 +188,9 @@ BOOST_PYTHON_MODULE(ycm_core)
     .def( vector_indexing_suite< std::vector< FixIt > >() );
 
   enum_< DiagnosticKind >( "DiagnosticKind" )
-    .value( "ERROR", ERROR )
-    .value( "WARNING", WARNING )
-    .value( "INFORMATION", INFORMATION )
-    .export_values();
+    .value( "ERROR", DiagnosticKind::ERROR )
+    .value( "WARNING", DiagnosticKind::WARNING )
+    .value( "INFORMATION", DiagnosticKind::INFORMATION );
 
   class_< Diagnostic >( "Diagnostic" )
     .def_readonly( "ranges_", &Diagnostic::ranges_ )


### PR DESCRIPTION
Enumeration classes are supposed to be safer (read: namespaced), so possible name clashes between different `enum`s are avoided. They also prevent the following:

```c++
#include <iostream>
enum class ec1 { A }; // ok
enum class ec2 { A }; // ok
enum e { A }; // ok
int main(void) {
  // if ( ec1::A == ec2::A ) std::cout<<"Error - different enums.\n";
  // if ( A == ec2::A ) std::cout<<"Error - different enums.\n";
  // if ( ec1::A == 0 ) std::cout<<"Error - different types.\n;
  if ( A == 0 ) std::cout<<"Okay, but considered unsafe.\n";
  return 0;
}
```

Should I bump the `CORE_VERSION`?

NOTE:
I also urge everyone to check what our benchmarks say, because travis reported considerable performance hit compared to current master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/921)
<!-- Reviewable:end -->
