### PR TITLE
[READY] Add --quiet to the build as now the output is huge for --all mode 

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -136,14 +136,14 @@ if ( USE_CLANG_COMPLETER AND
   endif()
 
   if( CLANG_DOWNLOAD )
-    message( "Downloading ${CLANG_PACKAGE} ${CLANG_VERSION} from ${CLANG_URL}" )
+    message( STATUS "Downloading ${CLANG_PACKAGE} ${CLANG_VERSION} from ${CLANG_URL}" )
 
     file(
       DOWNLOAD "${CLANG_URL}" "${CLANG_LOCAL_FILE}"
       SHOW_PROGRESS EXPECTED_HASH SHA256=${CLANG_SHA256}
     )
   else()
-    message( "Using ${CLANG_PACKAGE} archive: ${CLANG_LOCAL_FILE}" )
+    message( STATUS "Using ${CLANG_PACKAGE} archive: ${CLANG_LOCAL_FILE}" )
   endif()
 
   # Copy and extract the Clang archive in the building directory.
@@ -205,10 +205,10 @@ if ( USE_CLANG_COMPLETER AND
 endif()
 
 if ( USE_CLANG_COMPLETER )
-  message( "Using libclang to provide semantic completion for C/C++/ObjC" )
+  message( STATUS "Using libclang to provide semantic completion for C/C++/ObjC" )
 else()
-  message( "NOT using libclang, no semantic completion for C/C++/ObjC will be "
-           "available" )
+  message( STATUS "NOT using libclang, no semantic completion for "
+                  "C/C++/ObjC will be available" )
 endif()
 
 if ( NOT USING_LIBCLANG_DOWNLOAD AND PATH_TO_LLVM_ROOT )
@@ -361,7 +361,7 @@ if ( EXTERNAL_LIBCLANG_PATH OR USE_SYSTEM_LIBCLANG )
   # On Linux, the library target is a symlink of the soversion one.  Since it
   # will be copied in the project folder, we need the symlinked library.
   get_filename_component( LIBCLANG_TARGET "${EXTERNAL_LIBCLANG_PATH}" REALPATH )
-  message( "Using external libclang: ${LIBCLANG_TARGET}" )
+  message( STATUS "Using external libclang: ${LIBCLANG_TARGET}" )
 else()
   set( LIBCLANG_TARGET )
 endif()

--- a/run_tests.py
+++ b/run_tests.py
@@ -173,6 +173,7 @@ def BuildYcmdLibs( args ):
     build_cmd = [
       sys.executable,
       p.join( DIR_OF_THIS_SCRIPT, 'build.py' ),
+      '--quiet',
     ]
 
     for key in COMPLETERS:
@@ -232,6 +233,7 @@ def Main():
     RunFlake8()
   BuildYcmdLibs( parsed_args )
   NoseTests( parsed_args, nosetests_args )
+
 
 if __name__ == "__main__":
   Main()


### PR DESCRIPTION
This output of the build on Travis is very large now and can make viewing test failures quite painful in its UI.

This change adds a `--quiet` option to the `build.py` and uses it in `run_tests.py`. It just suppresses stdout (using a temporary file) for the build commands.

We print the stdout on failure, so we can still see build error messages.

We don't suppress the benchmark output, as that is what the benchmark run is for.

As you can see in the example output it isn't perfect, but it might be better than nothing.

Example output:

```
bash-3.2$ ./run_tests.py
Running tests on Python 2.7.14
Running flake8
Generating ycmd build configuration...DONE
Compiling ycmd target: ycm_core...DONE
Compiling ycmd target: ycm_core_tests...DONE
Running ycmd tests...DONE
Building OmniSharp for C=Sharp completion...DONE
Building gocode for go completion...DONE
Building godef for go definintion...DONE
npm WARN tern_runtime No repository field.
npm WARN tern_runtime No license field.

DONE
Building racerd for Rust completion...    Finished release [optimized] target(s) in 0.0 secs
DONE
Using cached jdt.ls: /Users/ben/.vim/bundle/YouCompleteMe/third_party/ycmd/third_party/eclipse.jdt.ls/target/cache/jdt-language-server-0.11.0-201801162212.tar.gz
Extracting jdt.ls to /Users/ben/.vim/bundle/YouCompleteMe/third_party/ycmd/third_party/eclipse.jdt.ls/target/repository...
Done installing jdt.ls
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/924)
<!-- Reviewable:end -->
