### PR TITLE
[READY] Fix codepoint offset computation in code action

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1366,7 +1366,7 @@ class LanguageServerCompleter( Completer ):
               'line': line_num_ls,
               'character': lsp.CodepointsToUTF16CodeUnits(
                 line_value,
-                len( line_value ) ) - 1,
+                len( line_value ) + 1 ) - 1,
             }
           },
           [] ),


### PR DESCRIPTION
`len( line_value )` returns a 0-based code point offset  (`len( '' ) = 0`) while `CodepointsToUTF16CodeUnits` expects a 1-based offset.

Added a test that fails without this change:
```
======================================================================
FAIL: ycmd.tests.language_server.language_server_completer_test.LanguageServerCompleter_GetCodeActions_CursorOnEmptyLine_test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Python36\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "ycmd\tests\language_server\language_server_completer_test.py", line 446, in LanguageServerCompleter_GetCodeActions_CursorOnEmptyLine_test
    'character': 0
AssertionError:
Expected: a dictionary containing {'end': a dictionary containing {'character': <0>, 'line': <0>}, 'start': a dictionary containing {'character': <0>, 'line': <0>}}
     but: value for 'end' value for 'character' was <-1>


----------------------------------------------------------------------
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/926)
<!-- Reviewable:end -->
