### PR TITLE
[READY] Fix instructions for C#

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo apt-get install build-essential cmake python-dev
 Next, install the language specific dependencies you need:
 - `sudo apt-get install golang-go` for Go.
 - `sudo apt-get install npm` for JavaScript and TypeScript.
-- `sudo apt-get install mono-xbuild` for C#.
+- `sudo apt-get install mono-devel` for C#.
 - Concerning Rust, install Cargo and rustc with [rustup](https://www.rustup.rs/).
 
 When you first clone the repository you'll need to update the submodules:


### PR DESCRIPTION
`mono-devel` should be installed instead of `mono-xbuild` for C# support.

Closes https://github.com/Valloric/ycmd/issues/928.