### PR TITLE
[READY] Use file contents from server state if available when polling asynchronous diagnostics

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -24,11 +24,14 @@ from builtins import *  # noqa
 
 # Must not import ycm_core here! Vim imports completer, which imports this file.
 # We don't want ycm_core inside Vim.
+import logging
 import os
 import re
 from collections import defaultdict
 from future.utils import iteritems
 from ycmd.utils import ToCppStringCompatible, ToUnicode, ReadFile
+
+_logger = logging.getLogger( __name__ )
 
 
 class PreparedTriggers( object ):
@@ -222,4 +225,8 @@ def GetFileContents( request_data, filename ):
   if filename in file_data:
     return ToUnicode( file_data[ filename ][ 'contents' ] )
 
-  return ToUnicode( ReadFile( filename ) )
+  try:
+    return ToUnicode( ReadFile( filename ) )
+  except IOError:
+    _logger.exception( 'Error reading file {}'.format( filename ) )
+    return ''

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -896,10 +896,12 @@ class LanguageServerCompleter( Completer ):
     # However, we _also_ return them here to refresh diagnostics after, say
     # changing the active file in the editor, or for clients not supporting the
     # polling mechanism.
-    uri = lsp.FilePathToUri( request_data[ 'filepath' ] )
+    filepath = request_data[ 'filepath' ]
+    uri = lsp.FilePathToUri( filepath )
+    contents = utils.SplitLines( GetFileContents( request_data, filepath ) )
     with self._server_info_mutex:
       if uri in self._latest_diagnostics:
-        return [ _BuildDiagnostic( request_data, uri, diag )
+        return [ _BuildDiagnostic( contents, uri, diag )
                  for diag in self._latest_diagnostics[ uri ] ]
 
 
@@ -1010,7 +1012,30 @@ class LanguageServerCompleter( Completer ):
     if notification[ 'method' ] == 'window/showMessage':
       return responses.BuildDisplayMessageResponse(
         notification[ 'params' ][ 'message' ] )
-    elif notification[ 'method' ] == 'window/logMessage':
+
+    if notification[ 'method' ] == 'textDocument/publishDiagnostics':
+      params = notification[ 'params' ]
+      uri = params[ 'uri' ]
+
+      try:
+        filepath = lsp.UriToFilePath( uri )
+      except lsp.InvalidUriException:
+        _logger.exception( 'Ignoring diagnostics for unrecognized URI' )
+        return None
+
+      with self._server_info_mutex:
+        if filepath in self._server_file_state:
+          contents = self._server_file_state[ filepath ].contents
+        else:
+          contents = GetFileContents( request_data, filepath )
+      contents = utils.SplitLines( contents )
+      return {
+        'diagnostics': [ _BuildDiagnostic( contents, uri, x )
+                         for x in params[ 'diagnostics' ] ],
+        'filepath': filepath
+      }
+
+    if notification[ 'method' ] == 'window/logMessage':
       log_level = [
         None, # 1-based enum from LSP
         logging.ERROR,
@@ -1022,20 +1047,6 @@ class LanguageServerCompleter( Completer ):
       params = notification[ 'params' ]
       _logger.log( log_level[ int( params[ 'type' ] ) ],
                    SERVER_LOG_PREFIX + params[ 'message' ] )
-    elif notification[ 'method' ] == 'textDocument/publishDiagnostics':
-      params = notification[ 'params' ]
-      uri = params[ 'uri' ]
-      try:
-        filepath = lsp.UriToFilePath( uri )
-        response = {
-          'diagnostics': [ _BuildDiagnostic( request_data, uri, x )
-                           for x in params[ 'diagnostics' ] ],
-          'filepath': filepath
-        }
-        return response
-      except lsp.InvalidUriException:
-        _logger.exception( 'Ignoring diagnostics for unrecognized URI' )
-        pass
 
     return None
 
@@ -1420,9 +1431,11 @@ class LanguageServerCompleter( Completer ):
     response = self.GetConnection().GetResponse( request_id,
                                                  message,
                                                  REQUEST_TIMEOUT_COMMAND )
+    filepath = request_data[ 'filepath' ]
+    contents = utils.SplitLines( GetFileContents( request_data, filepath ) )
     chunks = [ responses.FixItChunk( text_edit[ 'newText' ],
-                                     _BuildRange( request_data,
-                                                  request_data[ 'filepath' ],
+                                     _BuildRange( contents,
+                                                  filepath,
                                                   text_edit[ 'range' ] ) )
                for text_edit in response[ 'result' ] or [] ]
 
@@ -1544,9 +1557,11 @@ def _InsertionTextForItem( request_data, item ):
   additional_text_edits.extend( item.get( 'additionalTextEdits', [] ) )
 
   if additional_text_edits:
+    filepath = request_data[ 'filepath' ]
+    contents = utils.SplitLines( GetFileContents( request_data, filepath ) )
     chunks = [ responses.FixItChunk( e[ 'newText' ],
-                                     _BuildRange( request_data,
-                                                  request_data[ 'filepath' ],
+                                     _BuildRange( contents,
+                                                  filepath,
                                                   e[ 'range' ] ) )
                for e in additional_text_edits ]
 
@@ -1701,13 +1716,12 @@ def _PositionToLocationAndDescription( request_data, position ):
                        "GoTo location" )
     file_contents = []
 
-  return _BuildLocationAndDescription( request_data,
-                                       filename,
+  return _BuildLocationAndDescription( filename,
                                        file_contents,
                                        position[ 'range' ][ 'start' ] )
 
 
-def _BuildLocationAndDescription( request_data, filename, file_contents, loc ):
+def _BuildLocationAndDescription( filename, file_contents, loc ):
   """Returns a tuple of (
     - ycmd Location for the supplied filename and LSP location
     - contents of the line at that location
@@ -1731,29 +1745,17 @@ def _BuildLocationAndDescription( request_data, filename, file_contents, loc ):
            line_value )
 
 
-def _BuildRange( request_data, filename, r ):
+def _BuildRange( contents, filename, r ):
   """Returns a ycmd range from a LSP range |r|."""
-  try:
-    file_contents = utils.SplitLines( GetFileContents( request_data,
-                                                       filename ) )
-  except IOError:
-    # It's possible to receive positions for files which no longer exist (due to
-    # race condition).
-    _logger.exception( "A file could not be found when determining a "
-                       "range location" )
-    file_contents = []
-
-  return responses.Range( _BuildLocationAndDescription( request_data,
-                                                        filename,
-                                                        file_contents,
+  return responses.Range( _BuildLocationAndDescription( filename,
+                                                        contents,
                                                         r[ 'start' ] )[ 0 ],
-                          _BuildLocationAndDescription( request_data,
-                                                        filename,
-                                                        file_contents,
+                          _BuildLocationAndDescription( filename,
+                                                        contents,
                                                         r[ 'end' ] )[ 0 ] )
 
 
-def _BuildDiagnostic( request_data, uri, diag ):
+def _BuildDiagnostic( contents, uri, diag ):
   """Return a ycmd diagnostic from a LSP diagnostic."""
   try:
     filename = lsp.UriToFilePath( uri )
@@ -1761,7 +1763,7 @@ def _BuildDiagnostic( request_data, uri, diag ):
     _logger.debug( 'Invalid URI received for diagnostic' )
     filename = ''
 
-  r = _BuildRange( request_data, filename, diag[ 'range' ] )
+  r = _BuildRange( contents, filename, diag[ 'range' ] )
 
   return responses.BuildDiagnosticData( responses.Diagnostic(
     ranges = [ r ],
@@ -1779,9 +1781,10 @@ def TextEditToChunks( request_data, uri, text_edit ):
     _logger.debug( 'Invalid filepath received in TextEdit' )
     filepath = ''
 
+  contents = utils.SplitLines( GetFileContents( request_data, filepath ) )
   return [
     responses.FixItChunk( change[ 'newText' ],
-                          _BuildRange( request_data,
+                          _BuildRange( contents,
                                        filepath,
                                        change[ 'range' ] ) )
     for change in text_edit

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -106,6 +106,7 @@ class ServerFileState( object ):
     self.version = 0
     self.state = ServerFileState.CLOSED
     self.checksum = None
+    self.contents = ''
 
 
   def GetDirtyFileAction( self, contents ):
@@ -122,7 +123,7 @@ class ServerFileState( object ):
     else:
       action = ServerFileState.CHANGE_FILE
 
-    return self._SendNewVersion( new_checksum, action )
+    return self._SendNewVersion( new_checksum, action, contents )
 
 
   def GetSavedFileAction( self, contents ):
@@ -137,7 +138,9 @@ class ServerFileState( object ):
     if self.checksum.digest() == new_checksum.digest():
       return ServerFileState.NO_ACTION
 
-    return self._SendNewVersion( new_checksum, ServerFileState.CHANGE_FILE )
+    return self._SendNewVersion( new_checksum,
+                                 ServerFileState.CHANGE_FILE,
+                                 contents )
 
 
   def GetFileCloseAction( self ):
@@ -151,10 +154,11 @@ class ServerFileState( object ):
     return ServerFileState.NO_ACTION
 
 
-  def _SendNewVersion( self, new_checksum, action ):
+  def _SendNewVersion( self, new_checksum, action, contents ):
     self.checksum = new_checksum
     self.version = self.version + 1
     self.state = ServerFileState.OPEN
+    self.contents = contents
 
     return action
 


### PR DESCRIPTION
While I was playing with the Java completer, I noticed that matches from asynchronous diagnostics are sometimes incorrectly displayed:

![file-contents-change-diagnostics-issue](https://user-images.githubusercontent.com/10026824/36354406-16398a80-14d4-11e8-838a-33b1998bd566.gif)

This is due to the file contents from the `/receive_messages` request not being up to date anymore when the language server are publishing new diagnostics. In the example above, when inserting the second `public String test;`, the diagnostic offsets are converted from UTF-16 to UTF-8 using the contents:
```java
package com.youcompleteme;
  
public class Test {
  public String test;
}
```
instead of
```java
package com.youcompleteme;
  
public class Test {
  public String test;
  public String test;
}
```

The solution is to store new file contents in the `ServerFileState` object and use that contents (if available) when polling asynchronous diagnostics:

![file-contents-change-diagnostics-fix](https://user-images.githubusercontent.com/10026824/36354449-f20a23e4-14d4-11e8-8c91-75f5bbd1ee05.gif)

Added a test that fails without this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/931)
<!-- Reviewable:end -->
