### PR TITLE
[READY] Do not try to close stderr in Java completer

### DIFF
--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -390,13 +390,6 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
   def _StopServer( self ):
     with self._server_state_mutex:
       _logger.info( 'Shutting down jdt.ls...' )
-      # We don't use utils.CloseStandardStreams, because the stdin/out is
-      # connected to our server connector. Just close stderr.
-      #
-      # The other streams are closed by the LanguageServerConnection when we
-      # call Close.
-      if self._server_handle and self._server_handle.stderr:
-        self._server_handle.stderr.close()
 
       # Tell the connection to expect the server to disconnect
       if self._connection:


### PR DESCRIPTION
Since `stderr` is redirected to a file in the Java completer, [it is necessarily set to `None`](https://docs.python.org/2.7/library/subprocess.html#subprocess.Popen.stderr) and thus can't be closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/932)
<!-- Reviewable:end -->
