### PR TITLE
[READY] Do not check if server is running immediately after starting it

### DIFF
--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -361,12 +361,6 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
                                                stdout = PIPE,
                                                stderr = stderr )
 
-      if not self._ServerIsRunning():
-        _logger.error( 'jdt.ls Language Server failed to start' )
-        return
-
-      _logger.info( 'jdt.ls Language Server started' )
-
       self._connection = (
         language_server_completer.StandardIOLanguageServerConnection(
           self._server_handle.stdin,
@@ -383,6 +377,8 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
                        'successfully' )
         self._StopServer()
         return
+
+    _logger.info( 'jdt.ls Language Server started' )
 
     self.SendInitialize( request_data )
 


### PR DESCRIPTION
Given that `Popen` is returning immediately, the process will always be running at the `_ServerIsRunning` call even if it's going to crash. A simple way to confirm this is to comment the `-jar` argument in the command used to start jdt.ls: `_ServerIsRunning` still returns `True` in that scenario.