### PR TITLE
[READY] Fix error removing cfamily element if not present

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -150,11 +150,11 @@ def FixupCompleters( parsed_args ):
   elif parsed_args.no_clang_completer:
     print( 'WARNING: The "--no-clang-completer" flag is deprecated. '
            'Please use "--no-completers cfamily" instead.' )
-    completers.remove( 'cfamily' )
+    completers.discard( 'cfamily' )
 
   if 'USE_CLANG_COMPLETER' in os.environ:
     if os.environ[ 'USE_CLANG_COMPLETER' ] == 'false':
-      completers.remove( 'cfamily' )
+      completers.discard( 'cfamily' )
     else:
       completers.add( 'cfamily' )
 


### PR DESCRIPTION
Running the tests with `USE_CLANG_COMPLETER=false ./run_tests.py --no-completers cfamily` raise the following error:
```
Traceback (most recent call last):
  File "./run_tests.py", line 239, in <module>
    Main()
  File "./run_tests.py", line 227, in Main
    parsed_args, nosetests_args = ParseArguments()
  File "./run_tests.py", line 136, in ParseArguments
    parsed_args.completers = FixupCompleters( parsed_args )
  File "./run_tests.py", line 157, in FixupCompleters
    completers.remove( 'cfamily' )
KeyError: 'cfamily'
```
Use `discard` instead of `remove` to remove an element from the set of completers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/934)
<!-- Reviewable:end -->
