### PR TITLE
simplify LetterNode, improve cache behaviour

### DIFF
--- a/cpp/ycm/Candidate.h
+++ b/cpp/ycm/Candidate.h
@@ -62,7 +62,7 @@ private:
   std::string word_boundary_chars_;
   bool text_is_lowercase_;
   Bitset letters_present_;
-  const std::unique_ptr< LetterNode > root_node_;
+  LetterNode root_node_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/LetterNode.cpp
+++ b/cpp/ycm/LetterNode.cpp
@@ -20,41 +20,14 @@
 
 namespace YouCompleteMe {
 
-LetterNode::LetterNode( char letter, int index )
-  : index_( index ),
-    is_uppercase_( IsUppercase( letter ) ) {
-}
-
-
-LetterNode::LetterNode( const std::string &text )
-  : index_( -1 ),
-    is_uppercase_( false ) {
-
-  letternode_per_text_index_.reserve( text.size() );
+LetterNode::LetterNode( const std::string &text ) 
+ : letternodemap_per_text_index_( text.size() ) {
 
   for ( size_t i = 0; i < text.size(); ++i ) {
-    letternode_per_text_index_.push_back( LetterNode( text[ i ], i ) );
-    SetNodeIndexForLetterIfNearest( text[ i ], i );
-  }
-
-  for ( size_t i = 0; i < text.size(); ++i ) {
-    for ( size_t j = i + 1; j < text.size(); ++j ) {
-      letternode_per_text_index_[ i ].SetNodeIndexForLetterIfNearest( text[ j ],
-                                                                      j );
+    for ( size_t j = i; j < text.size(); ++j ) {
+      letternodemap_per_text_index_[ i ].SetNodeIndexForLetterIfNearest( text[ j ],
+                                                                      j + 1 );
     }
-  }
-}
-
-void LetterNode::SetNodeIndexForLetterIfNearest( char letter, short index ) {
-  NearestLetterNodeIndices& currentLetterNodeIndices = letters_[ letter ];
-  if ( IsUppercase( letter ) ) {
-    if ( currentLetterNodeIndices.indexOfFirstUppercaseOccurrence == -1 ) {
-      currentLetterNodeIndices.indexOfFirstUppercaseOccurrence = index;
-    }
-  }
-
-  if ( currentLetterNodeIndices.indexOfFirstOccurrence == -1 ) {
-    currentLetterNodeIndices.indexOfFirstOccurrence = index;
   }
 }
 

--- a/cpp/ycm/LetterNode.h
+++ b/cpp/ycm/LetterNode.h
@@ -27,37 +27,24 @@
 
 namespace YouCompleteMe {
 
+// LetterNodes are indexed by number [0..N], 0 being the root node that doesn't
+// represent a character in the input, N representing the last character
 class LetterNode {
 public:
-  LetterNode( char letter, int index );
-
   YCM_EXPORT explicit LetterNode( const std::string &text );
 
-  inline bool LetterIsUppercase() const {
-    return is_uppercase_;
-  }
+  inline const NearestLetterNodeIndices *NearestLetterNodesForLetter( size_t node_index, char letter ) const {
+    if (node_index >= letternodemap_per_text_index_.size()) {
+      return nullptr;
+    }
 
-  inline const NearestLetterNodeIndices *NearestLetterNodesForLetter(
-    char letter ) {
-
-    return letters_.ListPointerAt( letter );
-  }
-
-  void SetNodeIndexForLetterIfNearest( char letter, short index );
-
-  inline int Index() const {
-    return index_;
-  }
-
-  inline LetterNode *operator[]( int index ) {
-    return &letternode_per_text_index_[ index ];
+    return &letternodemap_per_text_index_[ node_index ].ListPointerAt( letter );
   }
 
 private:
-  LetterNodeListMap letters_;
-  std::vector<LetterNode> letternode_per_text_index_;
-  int index_;
-  bool is_uppercase_;
+  // [0..N) maps, since from the last character you can't find
+  // any other characters anyway
+  std::vector<LetterNodeListMap> letternodemap_per_text_index_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/LetterNodeListMap.cpp
+++ b/cpp/ycm/LetterNodeListMap.cpp
@@ -28,34 +28,22 @@ int IndexForLetter( char letter ) {
 }
 
 
-LetterNodeListMap::LetterNodeListMap() {
+const NearestLetterNodeIndices &LetterNodeListMap::ListPointerAt( char letter ) const {
+  return letters_.at( IndexForLetter( letter ) );
 }
 
 
-LetterNodeListMap::LetterNodeListMap( const LetterNodeListMap &other ) {
-  if ( other.letters_ ) {
-    letters_.reset( new NearestLetterNodeArray( *other.letters_ ) );
-  }
-}
-
-
-NearestLetterNodeIndices &LetterNodeListMap::operator[] ( char letter ) {
-  if ( !letters_ ) {
-    letters_.reset( new NearestLetterNodeArray() );
+void LetterNodeListMap::SetNodeIndexForLetterIfNearest( char letter, uint16_t index ) {
+  NearestLetterNodeIndices& currentLetterNodeIndices = letters_.at( IndexForLetter( letter ) );
+  if ( IsUppercase( letter ) ) {
+    if ( currentLetterNodeIndices.indexOfFirstUppercaseOccurrence == 0 ) {
+      currentLetterNodeIndices.indexOfFirstUppercaseOccurrence = index;
+    }
   }
 
-  int letter_index = IndexForLetter( letter );
-
-  return letters_->at( letter_index );
-}
-
-
-NearestLetterNodeIndices *LetterNodeListMap::ListPointerAt( char letter ) {
-  if ( !letters_ ) {
-    return nullptr;
+  if ( currentLetterNodeIndices.indexOfFirstOccurrence == 0 ) {
+    currentLetterNodeIndices.indexOfFirstOccurrence = index;
   }
-
-  return &letters_->at( IndexForLetter( letter ) );
 }
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/LetterNodeListMap.h
+++ b/cpp/ycm/LetterNodeListMap.h
@@ -50,29 +50,22 @@ YCM_EXPORT int IndexForLetter( char letter );
  * position in the original string.
  */
 struct NearestLetterNodeIndices {
-  NearestLetterNodeIndices()
-    : indexOfFirstOccurrence( -1 ),
-      indexOfFirstUppercaseOccurrence( -1 ) {
-  }
-
-  short indexOfFirstOccurrence;
-  short indexOfFirstUppercaseOccurrence;
+  uint16_t indexOfFirstOccurrence = 0;
+  uint16_t indexOfFirstUppercaseOccurrence = 0;
 };
 
 class LetterNodeListMap {
 public:
-  LetterNodeListMap();
-  LetterNodeListMap( const LetterNodeListMap &other );
+  // export for tests
+  YCM_EXPORT const NearestLetterNodeIndices &ListPointerAt( char letter ) const;
 
-  NearestLetterNodeIndices &operator[] ( char letter );
-
-  YCM_EXPORT NearestLetterNodeIndices *ListPointerAt( char letter );
+  void SetNodeIndexForLetterIfNearest( char letter, uint16_t index );
 
 private:
   using NearestLetterNodeArray = std::array< NearestLetterNodeIndices,
                                              NUM_LETTERS >;
 
-  std::unique_ptr< NearestLetterNodeArray > letters_;
+  NearestLetterNodeArray letters_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/tests/LetterNode_test.cpp
+++ b/cpp/ycm/tests/LetterNode_test.cpp
@@ -29,40 +29,26 @@ using ::testing::StrEq;
 
 TEST( LetterNodeTest, AsciiText ) {
   LetterNode root_node( "ascIi_texT" );
-  EXPECT_THAT( root_node,
-               AllOf( Property( &LetterNode::Index, -1 ),
-                      Property( &LetterNode::LetterIsUppercase, false ) ) );
 
   const NearestLetterNodeIndices *nearest_nodes =
-    root_node.NearestLetterNodesForLetter( 'i' );
+    root_node.NearestLetterNodesForLetter( 0, 'i' );
 
-  EXPECT_THAT( root_node[ nearest_nodes->indexOfFirstOccurrence ],
-               AllOf( Property( &LetterNode::Index, 3 ),
-                      Property( &LetterNode::LetterIsUppercase, true ) ) );
-  EXPECT_THAT(  root_node[ nearest_nodes->indexOfFirstUppercaseOccurrence ],
-                AllOf( Property( &LetterNode::Index, 3 ),
-                       Property( &LetterNode::LetterIsUppercase, true ) ) );
+  EXPECT_EQ( nearest_nodes->indexOfFirstOccurrence, 4 );
+  EXPECT_EQ( nearest_nodes->indexOfFirstUppercaseOccurrence, 4 );
 
-  LetterNode *node = root_node[ nearest_nodes->indexOfFirstOccurrence ];
+  nearest_nodes = root_node.NearestLetterNodesForLetter(nearest_nodes->indexOfFirstOccurrence, 'i');
 
-  nearest_nodes = node->NearestLetterNodesForLetter( 'i' );
-  EXPECT_THAT( root_node[ nearest_nodes->indexOfFirstOccurrence ],
-               AllOf( Property( &LetterNode::Index, 4 ),
-                      Property( &LetterNode::LetterIsUppercase, false ) ) );
-  EXPECT_EQ( nearest_nodes->indexOfFirstUppercaseOccurrence, -1 );
+  EXPECT_EQ( nearest_nodes->indexOfFirstOccurrence, 5 );
+  EXPECT_EQ( nearest_nodes->indexOfFirstUppercaseOccurrence, 0 );
 
+  nearest_nodes = root_node.NearestLetterNodesForLetter(5, 't');
+  
+  EXPECT_EQ( nearest_nodes->indexOfFirstOccurrence, 7 );
+  EXPECT_EQ( nearest_nodes->indexOfFirstUppercaseOccurrence, 10 );
 
-  nearest_nodes = node->NearestLetterNodesForLetter( 't' );
-  EXPECT_THAT( root_node[ nearest_nodes->indexOfFirstOccurrence ],
-               AllOf( Property( &LetterNode::Index, 6 ),
-                      Property( &LetterNode::LetterIsUppercase, false ) ) );
-  EXPECT_THAT( root_node[ nearest_nodes->indexOfFirstUppercaseOccurrence ],
-               AllOf( Property( &LetterNode::Index, 9 ),
-                      Property( &LetterNode::LetterIsUppercase, true ) ) );
-
-  nearest_nodes = node->NearestLetterNodesForLetter( 'c' );
-  EXPECT_EQ( nearest_nodes->indexOfFirstOccurrence, -1 );
-  EXPECT_EQ( nearest_nodes->indexOfFirstUppercaseOccurrence, -1 );
+  nearest_nodes = root_node.NearestLetterNodesForLetter(5, 'c');
+  EXPECT_EQ( nearest_nodes->indexOfFirstOccurrence, 0 );
+  EXPECT_EQ( nearest_nodes->indexOfFirstUppercaseOccurrence, 0 );
 }
 
 


### PR DESCRIPTION
EDIT: I just saw the Unicode PR, which makes this one superfluous. Sorry for taking your time 

I made some changes to LetterNode almost 2 years ago that reduced memory usage and improved performance. There were a few niggles I had about it however: every node had a vector, but only 1 actually used it and we were using indexes in the main algorithm and storing indexes in the data structure at the same time. This PR is intended to fix that. 

The main change is that most of the data is no longer stored: the bool storing case of letters was unused, the indices were already implicit in the indexes used in Candidate and so could be removed as well. In the end, all that is stored is one array of offsets per letter, all in one vector which should improve cache locality.

I've used a similar setup for benchmarking as described [here](https://gist.github.com/dgel/0ee4709015288ead82c14e2c079710bd) for the previous PR. some results (using 1000 samples):

shorthands:

cs: case-sensitive
cis: case-insensitive
lc: lowercase
mc: mixed case

## Speed

 variant | construction | match cis, lc | match cs, lc | match cis, mc | match cs, mc 
---------|--------------|---------------|--------------|---------------|--------------
 original | 11.1 us | 416 ns | 358 ns | 409 ns | 431 ns 
 modified | 7.9 us | 201 ns | 337 ns | 220 ns | 324 ns

## memory usage

variant | 100000 nodes of 4 chars | 10000 nodes of 78 chars
-------|-------------------------|------------------------
original | 220MB | 422MB
modified | 200MB | 383MB

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/935)
<!-- Reviewable:end -->
