### PR TITLE
[READY] Skip stray Windows paths in flags

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -429,8 +429,7 @@ def _RemoveUnusedFlags( flags, filename, enable_windows_style_flags ):
     # "foo.cpp" when we are compiling "foo.h" because the comp db doesn't have
     # flags for headers. The returned flags include "foo.cpp" and we need to
     # remove that.
-    if _SkipStrayFilenameFlag( flag,
-                               current_flag,
+    if _SkipStrayFilenameFlag( current_flag,
                                previous_flag,
                                enable_windows_style_flags ):
       continue
@@ -440,8 +439,7 @@ def _RemoveUnusedFlags( flags, filename, enable_windows_style_flags ):
   return new_flags
 
 
-def _SkipStrayFilenameFlag( flag,
-                            current_flag,
+def _SkipStrayFilenameFlag( current_flag,
                             previous_flag,
                             enable_windows_style_flags ):
   current_flag_starts_with_slash = current_flag.startswith( '/' )
@@ -452,7 +450,11 @@ def _SkipStrayFilenameFlag( flag,
 
   previous_flag_is_include = ( previous_flag in INCLUDE_FLAGS or
                                ( enable_windows_style_flags and
-                                 flag in INCLUDE_FLAGS_WIN_STYLE ) )
+                                 previous_flag in INCLUDE_FLAGS_WIN_STYLE ) )
+
+  current_flag_may_be_path = ( '/' in current_flag or
+                               ( enable_windows_style_flags and
+                                 '\\' in current_flag ) )
 
   return ( not ( current_flag_starts_with_dash or
                  ( enable_windows_style_flags and
@@ -460,7 +462,7 @@ def _SkipStrayFilenameFlag( flag,
            ( not ( previous_flag_starts_with_dash or
                    ( enable_windows_style_flags and
                      previous_flag_starts_with_slash ) ) or
-             ( not previous_flag_is_include and '/' in flag ) ) )
+             ( not previous_flag_is_include and current_flag_may_be_path ) ) )
 
 
 # Return the path to the macOS toolchain root directory to use for system

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -435,10 +435,45 @@ def RemoveUnusedFlags_RemoveStrayFilenames_CLDriver_test():
                                   expected[ :1 ] + to_remove + expected[ 1: ]
                                 ) ) )
 
-  # clang-cl and --dirver-mode=gcc
+  # clang-cl and --driver-mode=gcc
   expected = [ 'clang-cl', '-foo', '-xc++', '--driver-mode=gcc',
                '-bar', 'include_dir' ]
   to_remove = [ 'unrelated_file', '/I', 'include_dir_other' ]
+  filename = 'file'
+
+  eq_( expected,
+       flags._RemoveUnusedFlags( expected + to_remove,
+                                 filename,
+                                 _ShouldAllowWinStyleFlags(
+                                   expected + to_remove ) ) )
+  eq_( expected,
+       flags._RemoveUnusedFlags( expected[ :1 ] + to_remove + expected[ 1: ],
+                                 filename,
+                                 _ShouldAllowWinStyleFlags(
+                                   expected[ :1 ] + to_remove + expected[ 1: ]
+                                 ) ) )
+
+
+  # cl only with extension
+  expected = [ 'cl.EXE', '-foo', '-xc++', '-bar', 'include_dir' ]
+  to_remove = [ '-c', 'path\\to\\unrelated_file' ]
+  filename = 'file'
+
+  eq_( expected,
+       flags._RemoveUnusedFlags( expected + to_remove,
+                                 filename,
+                                 _ShouldAllowWinStyleFlags(
+                                   expected + to_remove ) ) )
+  eq_( expected,
+       flags._RemoveUnusedFlags( expected[ :1 ] + to_remove + expected[ 1: ],
+                                 filename,
+                                 _ShouldAllowWinStyleFlags(
+                                   expected[ :1 ] + to_remove + expected[ 1: ]
+                                 ) ) )
+
+  # cl path with Windows separators
+  expected = [ 'path\\to\\cl', '-foo', '-xc++', '/I', 'path\\to\\include\\dir' ]
+  to_remove = [ '-c', 'path\\to\\unrelated_file' ]
   filename = 'file'
 
   eq_( expected,


### PR DESCRIPTION
When using a compilation database, the flags generally end with `-c /path/to/file` where `/path/to/file` is the compiled file. Libclang chokes on this if we don't remove the path. We have some logic to handle that case where, in addition to several conditions, we detect that the flag is a path if it contains the `/` separator. However, this doesn't take care of the case where the flag is a Windows path with `\` as separators.

Fixes #937.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/938)
<!-- Reviewable:end -->
