### PR TITLE
[READY] Lower minimum Python version requirements on Travis and CircleCI

### DIFF
--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -50,11 +50,11 @@ PATH="${PYENV_ROOT}/bin:${PATH}"
 eval "$(pyenv init -)"
 
 if [ "${YCMD_PYTHON_VERSION}" == "2.7" ]; then
-  # We need a recent enough version of Python 2.7 on macOS or an error occurs
-  # when installing the psutil dependency for our tests.
-  PYENV_VERSION="2.7.14"
+  # Prior versions fail to compile with error "ld: library not found for
+  # -lSystemStubs"
+  PYENV_VERSION="2.7.2"
 else
-  PYENV_VERSION="3.4.7"
+  PYENV_VERSION="3.4.0"
 fi
 
 # In order to work with ycmd, python *must* be built as a shared library. The

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -50,9 +50,11 @@ export PATH="${PYENV_ROOT}/bin:${PATH}"
 eval "$(pyenv init -)"
 
 if [ "${YCMD_PYTHON_VERSION}" == "2.7" ]; then
-  PYENV_VERSION="2.7.14"
+  # Tests are failing on Python 2.7.0 with the exception
+  # "TypeError: argument can't be <type 'unicode'>"
+  PYENV_VERSION="2.7.1"
 else
-  PYENV_VERSION="3.4.7"
+  PYENV_VERSION="3.4.0"
 fi
 
 # In order to work with ycmd, python *must* be built as a shared library. This


### PR DESCRIPTION
As discussed on Gitter some time ago, we should try to test for the oldest version of Python that we are supposed to support on Linux and macOS (e.g. RHEL 7 has Python 2.7.5 installed by default so if we test for Python 2.7.14, we are not sure it's going to work on that platform).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/940)
<!-- Reviewable:end -->
