### PR TITLE
Allow skipping building of ycm_core. [READY]

### DIFF
--- a/build.py
+++ b/build.py
@@ -349,6 +349,9 @@ def ParseArguments():
                        action = 'store_true',
                        help = 'Quiet installation mode. Just print overall '
                               'progress and errors' )
+  parser.add_argument( '--skip-build',
+                       action = 'store_true',
+                       help = "Don't build ycm_core lib, just install deps" )
 
 
   # These options are deprecated.
@@ -670,9 +673,10 @@ def WritePythonUsedDuringBuild():
 
 def Main():
   args = ParseArguments()
-  ExitIfYcmdLibInUseOnWindows()
-  BuildYcmdLib( args )
-  WritePythonUsedDuringBuild()
+  if not args.skip_build:
+    ExitIfYcmdLibInUseOnWindows()
+    BuildYcmdLib( args )
+    WritePythonUsedDuringBuild()
   if args.cs_completer or args.omnisharp_completer or args.all_completers:
     EnableCsCompleter( args )
   if args.go_completer or args.gocode_completer or args.all_completers:


### PR DESCRIPTION
This makes it easier to use build.py just to install (or add) additional
complters. In particular, this is useful for jdt.ls as install.py is the
only supported mechanism to update it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/945)
<!-- Reviewable:end -->
