### PR TITLE
[READY] Test against Python 2.7.2 on Travis

### DIFF
--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -50,9 +50,10 @@ export PATH="${PYENV_ROOT}/bin:${PATH}"
 eval "$(pyenv init -)"
 
 if [ "${YCMD_PYTHON_VERSION}" == "2.7" ]; then
-  # Tests are failing on Python 2.7.0 with the exception
-  # "TypeError: argument can't be <type 'unicode'>"
-  PYENV_VERSION="2.7.1"
+  # Tests are failing on Python 2.7.0 with the exception "TypeError: argument
+  # can't be <type 'unicode'>" and importing the coverage module fails on Python
+  # 2.7.1.
+  PYENV_VERSION="2.7.2"
 else
   PYENV_VERSION="3.4.0"
 fi


### PR DESCRIPTION
In order to cover Python subprocesses, we add the following lines to [the `sitecustomize.py` file](https://docs.python.org/2/library/site.html):
```python
import coverage
coverage.process_startup()
```
This fails on Python 2.7.1 with the following error:
```
Traceback (most recent call last):
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site.py", line 500, in execsitecustomize
    import sitecustomize
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/sitecustomize.py", line 1, in <module>
    import coverage
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/coverage/__init__.py", line 13, in <module>
    from coverage.control import Coverage, process_startup
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/coverage/control.py", line 14, in <module>
    from coverage import env, files
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/coverage/files.py", line 16, in <module>
    from coverage.misc import contract, CoverageException, join_regex, isolate_module
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/coverage/misc.py", line 16, in <module>
    from coverage.backunittest import unittest
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/coverage/backunittest.py", line 9, in <module>
    import unittest2 as unittest
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/unittest2/__init__.py", line 40, in <module>
    from unittest2.collector import collector
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/unittest2/collector.py", line 3, in <module>
    from unittest2.loader import defaultTestLoader
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/unittest2/loader.py", line 13, in <module>
    from unittest2 import case, suite, util
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/unittest2/case.py", line 18, in <module>
    from unittest2 import result
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/unittest2/result.py", line 10, in <module>
    from unittest2.compatibility import wraps
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/unittest2/compatibility.py", line 143, in <module>
    class ChainMap(collections.MutableMapping):
  File "/home/travis/.pyenv/versions/2.7.1/lib/python2.7/site-packages/unittest2/compatibility.py", line 190, in ChainMap
    @collections._recursive_repr()
TypeError: _recursive_repr() takes exactly 1 argument (0 given)
```
resulting in the messages `'import sitecustomize' failed; use -v for traceback` on Travis. We avoid the issue by testing with Python 2.7.2 instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/948)
<!-- Reviewable:end -->
