### PR TITLE
[READY] Rename "translation_unit" to "translation unit" in debug info output

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -441,7 +441,7 @@ class ClangCompleter( Completer ):
     flags_item = responses.DebugInfoItem(
       key = 'flags', value = '{0}'.format( list( flags ) ) )
     filename_item = responses.DebugInfoItem(
-      key = 'translation_unit', value = filename )
+      key = 'translation unit', value = filename )
 
     return responses.BuildDebugInfoResponse( name = 'C-family',
                                              items = [ database_item,

--- a/ycmd/tests/clang/debug_info_test.py
+++ b/ycmd/tests/clang/debug_info_test.py
@@ -52,7 +52,7 @@ def DebugInfo_FlagsWhenExtraConfLoadedAndNoCompilationDatabase_test( app ):
           'value': matches_regexp( "\['-x', 'c\+\+', .*\]" )
         } ),
         has_entries( {
-          'key': 'translation_unit',
+          'key': 'translation unit',
           'value': PathToTestFile( 'basic.cpp' )
         } )
       )
@@ -79,7 +79,7 @@ def DebugInfo_FlagsWhenNoExtraConfAndNoCompilationDatabase_test( app ):
           'value': '[]'
         } ),
         has_entries( {
-          'key': 'translation_unit',
+          'key': 'translation unit',
           'value': instance_of( str )
         } )
       )
@@ -101,7 +101,7 @@ def DebugInfo_FlagsWhenNoExtraConfAndNoCompilationDatabase_test( app ):
           'value': '[]'
         } ),
         has_entries( {
-          'key': 'translation_unit',
+          'key': 'translation unit',
           'value': instance_of( str )
         } )
       )
@@ -130,7 +130,7 @@ def DebugInfo_FlagsWhenExtraConfNotLoadedAndNoCompilationDatabase_test(
           'value': '[]'
         } ),
         has_entries( {
-          'key': 'translation_unit',
+          'key': 'translation unit',
           'value': PathToTestFile( 'basic.cpp' )
         } )
       )
@@ -169,7 +169,7 @@ def DebugInfo_FlagsWhenNoExtraConfAndCompilationDatabaseLoaded_test( app ):
                   "\['clang\+\+', '-x', 'c\+\+', .*, '-Wall', .*\]" )
             } ),
             has_entries( {
-              'key': 'translation_unit',
+              'key': 'translation unit',
               'value': os.path.join( tmp_dir, 'test.cc' ),
             } )
           )
@@ -201,7 +201,7 @@ def DebugInfo_FlagsWhenNoExtraConfAndInvalidCompilationDatabase_test( app ):
               'value': '[]'
             } ),
             has_entries( {
-              'key': 'translation_unit',
+              'key': 'translation unit',
               'value': os.path.join( tmp_dir, 'test.cc' )
             } )
           )
@@ -233,7 +233,7 @@ def DebugInfo_Unity( app ):
             'value': matches_regexp( "\['-x', 'c\+\+', .*\]" )
           } ),
           has_entries( {
-            'key': 'translation_unit',
+            'key': 'translation unit',
             'value': PathToTestFile( 'unity.cpp' )
           } )
         )


### PR DESCRIPTION
I missed that the translation unit was added to the output of `:YcmDebugInfo` in PR https://github.com/Valloric/ycmd/pull/922, which is really neat. Nice job @puremourning. However, what's less nice is the underscore in the key, especially when there are none in the `compilation database path` key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/950)
<!-- Reviewable:end -->
