### PR TITLE
[READY] Expand environment variables in extra conf options

### DIFF
--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -29,7 +29,8 @@ import re
 from collections import defaultdict
 
 from ycmd.completers.completer import Completer
-from ycmd.utils import GetCurrentDirectory, OnWindows, ToUnicode
+from ycmd.utils import ( ExpandVariablesInPath, GetCurrentDirectory, OnWindows,
+                         ToUnicode )
 from ycmd import responses
 
 EXTRA_INFO_MAP = { 1 : '[File]', 2 : '[Dir]', 3 : '[File&Dir]' }
@@ -98,8 +99,7 @@ class FilenameCompleter( Completer ):
     line = current_line[ : start_codepoint ]
 
     path_match = self._path_regex.search( line )
-    path_dir = os.path.expanduser(
-      os.path.expandvars( path_match.group() ) ) if path_match else ''
+    path_dir = ExpandVariablesInPath( path_match.group() ) if path_match else ''
 
     # If the client supplied its working directory, use that instead of the
     # working directory of ycmd

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -22,8 +22,8 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from ycmd.utils import ( FindExecutable, ToUnicode, ToBytes, SetEnviron,
-                         ProcessIsRunning, urljoin )
+from ycmd.utils import ( ExpandVariablesInPath, FindExecutable, ToUnicode,
+                         ToBytes, SetEnviron, ProcessIsRunning, urljoin )
 from ycmd.completers.completer import Completer
 from ycmd import responses, utils, hmac_utils
 
@@ -146,7 +146,7 @@ class RustCompleter( Completer ):
                       os.environ.get( 'RUST_SRC_PATH' ) )
 
     if rust_src_path:
-      return os.path.expanduser( os.path.expandvars( rust_src_path ) )
+      return ExpandVariablesInPath( rust_src_path )
 
     # Try to figure out the src path using rustup
     rustc_executable = FindExecutable( 'rustc' )

--- a/ycmd/extra_conf_store.py
+++ b/ycmd/extra_conf_store.py
@@ -33,7 +33,8 @@ import logging
 from threading import Lock
 from ycmd import user_options_store
 from ycmd.responses import UnknownExtraConf, YCM_EXTRA_CONF_FILENAME
-from ycmd.utils import LoadPythonSource, PathsToAllParentFolders
+from ycmd.utils import ( ExpandVariablesInPath, LoadPythonSource,
+                         PathsToAllParentFolders )
 from fnmatch import fnmatch
 
 
@@ -191,15 +192,15 @@ def Load( module_file, force = False ):
 
 
 def _MatchesGlobPattern( filename, glob ):
-  """Returns true if a filename matches a given pattern. A '~' in glob will be
-  expanded to the home directory and checking will be performed using absolute
-  paths with symlinks resolved (except on Windows). See the documentation of
-  fnmatch for the supported patterns."""
+  """Returns true if a filename matches a given pattern. Environment variables
+  and a '~' in glob will be expanded and checking will be performed using
+  absolute paths with symlinks resolved (except on Windows). See the
+  documentation of fnmatch for the supported patterns."""
 
   # NOTE: os.path.realpath does not resolve symlinks on Windows.
   # See https://bugs.python.org/issue9949
   realpath = os.path.realpath( filename )
-  return fnmatch( realpath, os.path.realpath( os.path.expanduser( glob ) ) )
+  return fnmatch( realpath, os.path.realpath( ExpandVariablesInPath( glob ) ) )
 
 
 def _ExtraConfModuleSourceFilesForFile( filename ):
@@ -233,5 +234,5 @@ def _RandomName():
 
 
 def _GlobalYcmExtraConfFileLocation():
-  return os.path.expanduser(
+  return ExpandVariablesInPath(
     user_options_store.Value( 'global_ycm_extra_conf' ) )

--- a/ycmd/tests/extra_conf_store_test.py
+++ b/ycmd/tests/extra_conf_store_test.py
@@ -30,7 +30,7 @@ from hamcrest import ( assert_that, calling, equal_to, has_length, none, raises,
 from ycmd import extra_conf_store
 from ycmd.responses import UnknownExtraConf
 from ycmd.tests import IsolatedYcmd, PathToTestFile
-from ycmd.tests.test_utils import TemporarySymlink, UnixOnly
+from ycmd.tests.test_utils import TemporarySymlink, UnixOnly, WindowsOnly
 
 
 GLOBAL_EXTRA_CONF = PathToTestFile( 'extra_conf', 'global_extra_conf.py' )
@@ -71,6 +71,25 @@ def ExtraConfStore_ModuleForSourceFile_Blacklisted_test( app ):
   assert_that( extra_conf_store.ModuleForSourceFile( filename ), none() )
 
 
+@patch.dict( 'os.environ', { 'YCMD_TEST': PROJECT_EXTRA_CONF } )
+@IsolatedYcmd( { 'extra_conf_globlist': [ '$YCMD_TEST' ] } )
+def ExtraConfStore_ModuleForSourceFile_UnixVarEnv_test( app ):
+  filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
+  module = extra_conf_store.ModuleForSourceFile( filename )
+  assert_that( inspect.ismodule( module ) )
+  assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+
+
+@WindowsOnly
+@patch.dict( 'os.environ', { 'YCMD_TEST': PROJECT_EXTRA_CONF } )
+@IsolatedYcmd( { 'extra_conf_globlist': [ '%YCMD_TEST%' ] } )
+def ExtraConfStore_ModuleForSourceFile_WinVarEnv_test( app ):
+  filename = PathToTestFile( 'extra_conf', 'project', 'some_file' )
+  module = extra_conf_store.ModuleForSourceFile( filename )
+  assert_that( inspect.ismodule( module ) )
+  assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+
+
 @UnixOnly
 @IsolatedYcmd( { 'extra_conf_globlist': [
     PathToTestFile( 'extra_conf', 'symlink', '*' ) ] } )
@@ -85,6 +104,25 @@ def ExtraConfStore_ModuleForSourceFile_SupportSymlink_test( app ):
 
 @IsolatedYcmd( { 'global_ycm_extra_conf': GLOBAL_EXTRA_CONF } )
 def ExtraConfStore_ModuleForSourceFile_GlobalExtraConf_test( app ):
+  filename = PathToTestFile( 'extra_conf', 'some_file' )
+  module = extra_conf_store.ModuleForSourceFile( filename )
+  assert_that( inspect.ismodule( module ) )
+  assert_that( inspect.getfile( module ), equal_to( GLOBAL_EXTRA_CONF ) )
+
+
+@patch.dict( 'os.environ', { 'YCMD_TEST': GLOBAL_EXTRA_CONF } )
+@IsolatedYcmd( { 'global_ycm_extra_conf': '$YCMD_TEST' } )
+def ExtraConfStore_ModuleForSourceFile_GlobalExtraConf_UnixEnvVar_test( app ):
+  filename = PathToTestFile( 'extra_conf', 'some_file' )
+  module = extra_conf_store.ModuleForSourceFile( filename )
+  assert_that( inspect.ismodule( module ) )
+  assert_that( inspect.getfile( module ), equal_to( GLOBAL_EXTRA_CONF ) )
+
+
+@WindowsOnly
+@patch.dict( 'os.environ', { 'YCMD_TEST': GLOBAL_EXTRA_CONF } )
+@IsolatedYcmd( { 'global_ycm_extra_conf': '%YCMD_TEST%' } )
+def ExtraConfStore_ModuleForSourceFile_GlobalExtraConf_WinEnvVar_test( app ):
   filename = PathToTestFile( 'extra_conf', 'some_file' )
   module = extra_conf_store.ModuleForSourceFile( filename )
   assert_that( inspect.ismodule( module ) )

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -282,6 +282,12 @@ def ExecutableName( executable ):
   return executable + ( '.exe' if OnWindows() else '' )
 
 
+def ExpandVariablesInPath( path ):
+  # Replace '~' with the home directory and expand environment variables in
+  # path.
+  return os.path.expanduser( os.path.expandvars( path ) )
+
+
 def OnWindows():
   return sys.platform == 'win32'
 


### PR DESCRIPTION
This PR adds support for environment variables in the `extra_conf_globlist` and `global_ycm_extra_conf` options.

Fixes https://github.com/Valloric/YouCompleteMe/issues/2944.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/951)
<!-- Reviewable:end -->
