### PR TITLE
[READY] Reset prefix when setting the start column

### DIFF
--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -154,9 +154,10 @@ class RequestWrap( object ):
       self[ 'line_value' ],
       column_num )
 
-    # The same applies to the 'query' (the bit after the start column up to the
-    # cursor column). It's dependent on the 'start_codepoint' so we must reset
-    # it.
+    # The same applies to the 'prefix' (the bit before the start column) and the
+    # 'query' (the bit after the start column up to the cursor column). They are
+    # dependent on the 'start_codepoint' so we must reset them.
+    self._cached_computed.pop( 'prefix', None )
     self._cached_computed.pop( 'query', None )
 
 
@@ -177,9 +178,10 @@ class RequestWrap( object ):
       self[ 'line_value' ],
       codepoint_offset )
 
-    # The same applies to the 'query' (the bit after the start column up to the
-    # cursor column). It's dependent on the 'start_codepoint' so we must reset
-    # it.
+    # The same applies to the 'prefix' (the bit before the start column) and the
+    # 'query' (the bit after the start column up to the cursor column). They are
+    # dependent on the 'start_codepoint' so we must reset them.
+    self._cached_computed.pop( 'prefix', None )
     self._cached_computed.pop( 'query', None )
 
 

--- a/ycmd/tests/request_wrap_test.py
+++ b/ycmd/tests/request_wrap_test.py
@@ -259,11 +259,13 @@ def StartColumn_Set_test():
   eq_( wrap[ 'start_column' ], 7 )
   eq_( wrap[ 'start_codepoint' ], 7 )
   eq_( wrap[ 'query' ], "test" )
+  eq_( wrap[ 'prefix' ], "this '" )
 
   wrap[ 'start_column' ] = 6
   eq_( wrap[ 'start_column' ], 6 )
   eq_( wrap[ 'start_codepoint' ], 6 )
   eq_( wrap[ 'query' ], "'test" )
+  eq_( wrap[ 'prefix' ], "this " )
 
 
 def StartColumn_SetUnicode_test():
@@ -273,11 +275,13 @@ def StartColumn_SetUnicode_test():
   eq_( 7,  wrap[ 'start_codepoint' ] )
   eq_( 12, wrap[ 'start_column' ] )
   eq_( wrap[ 'query' ], "te" )
+  eq_( wrap[ 'prefix' ], "†eß† \'" )
 
   wrap[ 'start_column' ] = 11
   eq_( wrap[ 'start_column' ], 11 )
   eq_( wrap[ 'start_codepoint' ], 6 )
   eq_( wrap[ 'query' ], "'te" )
+  eq_( wrap[ 'prefix' ], "†eß† " )
 
 
 def StartCodepoint_Set_test():
@@ -287,11 +291,13 @@ def StartCodepoint_Set_test():
   eq_( wrap[ 'start_column' ], 7 )
   eq_( wrap[ 'start_codepoint' ], 7 )
   eq_( wrap[ 'query' ], "test" )
+  eq_( wrap[ 'prefix' ], "this '" )
 
   wrap[ 'start_codepoint' ] = 6
   eq_( wrap[ 'start_column' ], 6 )
   eq_( wrap[ 'start_codepoint' ], 6 )
   eq_( wrap[ 'query' ], "'test" )
+  eq_( wrap[ 'prefix' ], "this " )
 
 
 def StartCodepoint_SetUnicode_test():
@@ -301,11 +307,13 @@ def StartCodepoint_SetUnicode_test():
   eq_( 7,  wrap[ 'start_codepoint' ] )
   eq_( 12, wrap[ 'start_column' ] )
   eq_( wrap[ 'query' ], "te" )
+  eq_( wrap[ 'prefix' ], "†eß† \'" )
 
   wrap[ 'start_codepoint' ] = 6
   eq_( wrap[ 'start_column' ], 11 )
   eq_( wrap[ 'start_codepoint' ], 6 )
   eq_( wrap[ 'query' ], "'te" )
+  eq_( wrap[ 'prefix' ], "†eß† " )
 
 
 def Calculated_SetMethod_test():


### PR DESCRIPTION
Like the query, we need to reset the prefix when setting the start column in the request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/954)
<!-- Reviewable:end -->
