### PR TITLE
[READY] Ability to turn off retries when writing new tests

### DIFF
--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -325,6 +325,9 @@ def WithRetry( test ):
   """Decorator to be applied to tests that retries the test over and over
   until it passes or |timeout| seconds have passed."""
 
+  if 'YCM_TEST_NO_RETRY' in os.environ:
+    return test
+
   @functools.wraps( test )
   def wrapper( *args, **kwargs ):
     expiry = time.time() + 30


### PR DESCRIPTION
When writing new tests that use `@WithRetry` (such as those in `java/get_completions_test.py`), or when investigating failures, the output is huge and unmanageable. Normally you want to see the first error.

So we add a way to suppress the retry mechanism. This adds:

* `--no-retry` to `build.py`
* `YCM_TEST_NO_RETRY` environment variable for manually running `nostests` (e.g. in `pdb`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/956)
<!-- Reviewable:end -->
