### PR TITLE
[READY] Send the full query to the language server when forced

### DIFF
--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -426,6 +426,24 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       self._CleanUp()
 
 
+  def GetCodepointForCompletionRequest( self, request_data ):
+    """Returns the 1-based codepoint offset on the current line at which to make
+    the completion request"""
+    # When the user forces semantic completion, we pass the actual cursor
+    # position to jdt.ls.
+
+    # At the top level (i.e. without a semantic trigger), there are always way
+    # too many possible candidates for jdt.ls to return anything useful. This is
+    # because we don't send the currently typed characters to jdt.ls. The
+    # general idea is that we apply our own post-filter and sort. However, in
+    # practice we never get a full set of possibilities at the top-level. So, as
+    # a compromise, we allow the user to force us to send the "query" to the
+    # semantic engine, and thus get good completion results at the top level,
+    # even if this means the "filtering and sorting" is not 100% ycmd flavor.
+    return ( request_data[ 'column_codepoint' ]
+             if utils.ForceSemanticCompletion( request_data )
+             else request_data[ 'start_codepoint' ] )
+
 
   def HandleNotificationInPollThread( self, notification ):
     if notification[ 'method' ] == 'language/status':

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -597,6 +597,9 @@ class LanguageServerCompleter( Completer ):
   Completions
 
   - The implementation should not require any code to support completions
+  - (optional) Override GetCodepointForCompletionRequest if you wish to change
+    the completion position (e.g. if you want to pass the "query" to the
+    server)
 
   Diagnostics
 
@@ -733,6 +736,12 @@ class LanguageServerCompleter( Completer ):
                request_data ) )
 
 
+  def GetCodepointForCompletionRequest( self, request_data ):
+    """Returns the 1-based codepoint offset on the current line at which to make
+    the completion request"""
+    return request_data[ 'start_codepoint' ]
+
+
   def ComputeCandidatesInner( self, request_data ):
     if not self.ServerIsReady():
       return None
@@ -740,7 +749,11 @@ class LanguageServerCompleter( Completer ):
     self._UpdateServerWithFileContents( request_data )
 
     request_id = self.GetConnection().NextRequestId()
-    msg = lsp.Completion( request_id, request_data )
+
+    msg = lsp.Completion(
+      request_id,
+      request_data,
+      self.GetCodepointForCompletionRequest( request_data ) )
     response = self.GetConnection().GetResponse( request_id,
                                                  msg,
                                                  REQUEST_TIMEOUT_COMPLETION )

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -253,15 +253,14 @@ def DidCloseTextDocument( file_state ):
   } )
 
 
-def Completion( request_id, request_data ):
+def Completion( request_id, request_data, codepoint ):
   return BuildRequest( request_id, 'textDocument/completion', {
     'textDocument': {
       'uri': FilePathToUri( request_data[ 'filepath' ] ),
     },
-    'position': {
-      'line': request_data[ 'line_num' ] - 1,
-      'character': request_data[ 'start_codepoint' ] - 1,
-    }
+    'position': Position( request_data[ 'line_num' ],
+                          request_data[ 'line_value' ],
+                          codepoint ),
   } )
 
 

--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -86,8 +86,10 @@ class RequestWrap( object ):
       'filetypes': ( self._Filetypes, None ),
 
       'first_filetype': ( self._FirstFiletype, None ),
+
+      'force_semantic': ( self._GetForceSemantic, None ),
     }
-    self._cached_computed = {}
+    self._cached_computed = dict()
 
 
   def __getitem__( self, key ):
@@ -205,6 +207,10 @@ class RequestWrap( object ):
   def _Filetypes( self ):
     path = self[ 'filepath' ]
     return self[ 'file_data' ][ path ][ 'filetypes' ]
+
+
+  def _GetForceSemantic( self ):
+    return self._request.get( 'force_semantic', False )
 
 
 def CompletionStartColumn( line_value, column_num, filetype ):

--- a/ycmd/tests/java/diagnostics_test.py
+++ b/ycmd/tests/java/diagnostics_test.py
@@ -143,6 +143,26 @@ DIAG_MATCHERS_PER_FILE = {
       'ranges': contains( RangeMatch( TestWidgetImpl, ( 15, 9 ), ( 15, 10 ) ) ),
       'fixit_available': False
     } ),
+    has_entries( {
+      'kind': 'ERROR',
+      'text': 'ISR cannot be resolved to a variable',
+      'location': LocationMatcher( TestWidgetImpl, 34, 12 ),
+      'location_extent': RangeMatch( TestWidgetImpl, ( 34, 12 ), ( 34, 15 ) ),
+      'ranges': contains( RangeMatch( TestWidgetImpl,
+                                      ( 34, 12 ),
+                                      ( 34, 15 ) ) ),
+      'fixit_available': False
+    } ),
+    has_entries( {
+      'kind': 'ERROR',
+      'text': 'Syntax error, insert ";" to complete BlockStatements',
+      'location': LocationMatcher( TestWidgetImpl, 34, 12 ),
+      'location_extent': RangeMatch( TestWidgetImpl, ( 34, 12 ), ( 34, 15 ) ),
+      'ranges': contains( RangeMatch( TestWidgetImpl,
+                                      ( 34, 12 ),
+                                      ( 34, 15 ) ) ),
+      'fixit_available': False
+    } ),
   ),
   TestLauncher: contains_inanyorder (
     has_entries( {

--- a/ycmd/tests/java/get_completions_test.py
+++ b/ycmd/tests/java/get_completions_test.py
@@ -534,3 +534,131 @@ def GetCompletions_MoreThan100NoResolve_test( app ):
       } )
     },
   } )
+
+
+@SharedYcmd
+def GetCompletions_MoreThan100ForceSemantic_test( app ):
+  RunTest( app, {
+    'description': 'When forcing we pass the query, which reduces candidates',
+    'request': {
+      'filetype'  : 'java',
+      'filepath'  : ProjectPath( 'TestLauncher.java' ),
+      'line_num'  : 4,
+      'column_num': 15,
+      'force_semantic': True
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completions': contains(
+          CompletionEntryMatcher( 'com.youcompleteme.*;', None, {
+            'kind': 'Module',
+            'detailed_info': 'com.youcompleteme\n\n',
+          } ),
+          CompletionEntryMatcher( 'com.youcompleteme.testing.*;', None, {
+            'kind': 'Module',
+            'detailed_info': 'com.youcompleteme.testing\n\n',
+          } ),
+        ),
+        'completion_start_column': 8,
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_ForceAtTopLevel_NoImport_test( app ):
+  RunTest( app, {
+    'description': 'When forcing semantic completion, pass the query to server',
+    'request': {
+      'filetype'  : 'java',
+      'filepath'  : ProjectPath( 'TestWidgetImpl.java' ),
+      'line_num'  : 30,
+      'column_num': 20,
+      'force_semantic': True,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completions': contains(
+          CompletionEntryMatcher( 'TestFactory', None, {
+            'kind': 'Class',
+            'menu_text': 'TestFactory - com.test',
+          } ),
+        ),
+        'completion_start_column': 12,
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_NoForceAtTopLevel_NoImport_test( app ):
+  RunTest( app, {
+    'description': 'When not forcing semantic completion, use no context',
+    'request': {
+      'filetype'  : 'java',
+      'filepath'  : ProjectPath( 'TestWidgetImpl.java' ),
+      'line_num'  : 30,
+      'column_num': 20,
+      'force_semantic': False,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completions': contains(
+          CompletionEntryMatcher( 'TestFactory', '[ID]', {} ),
+        ),
+        'completion_start_column': 12,
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
+def GetCompletions_ForceAtTopLevel_WithImport_test( app ):
+  filepath = ProjectPath( 'TestWidgetImpl.java' )
+  RunTest( app, {
+    'description': 'Top level completions have import FixIts',
+    'request': {
+      'filetype'  : 'java',
+      'filepath'  : filepath,
+      'line_num'  : 34,
+      'column_num': 15,
+      'force_semantic': True,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completions': has_item(
+          CompletionEntryMatcher( 'InputStreamReader', None, {
+            'kind': 'Class',
+            'menu_text': 'InputStreamReader - java.io',
+            'extra_data': has_entries( {
+              'fixits': contains( has_entries( {
+                'chunks': contains(
+                  ChunkMatcher( '\n\n',
+                                LocationMatcher( filepath, 1, 18 ),
+                                LocationMatcher( filepath, 1, 18 ) ),
+                  ChunkMatcher( 'import java.io.InputStreamReader;',
+                                LocationMatcher( filepath, 1, 18 ),
+                                LocationMatcher( filepath, 1, 18 ) ),
+                  ChunkMatcher( '\n\n',
+                                LocationMatcher( filepath, 1, 18 ),
+                                LocationMatcher( filepath, 1, 18 ) ),
+                  ChunkMatcher( '',
+                                LocationMatcher( filepath, 1, 18 ),
+                                LocationMatcher( filepath, 3, 1 ) ),
+                ),
+              } ) ),
+            } ),
+          } ),
+        ),
+        'completion_start_column': 12,
+        'errors': empty(),
+      } )
+    },
+  } )

--- a/ycmd/tests/java/testdata/simple_eclipse_project/src/com/test/TestWidgetImpl.java
+++ b/ycmd/tests/java/testdata/simple_eclipse_project/src/com/test/TestWidgetImpl.java
@@ -25,4 +25,12 @@ class TestWidgetImpl implements AbstractTestWidget {
   public String getWidgetInfo() {
     return this.info;
   }
+
+  public Class<?> TestTopLevel() {
+    return TestFactory.class;
+  }
+
+  public Class<?> testTopLevelImport() {
+    return ISR
+  }
 }

--- a/ycmd/tests/request_wrap_test.py
+++ b/ycmd/tests/request_wrap_test.py
@@ -27,12 +27,16 @@ from builtins import *  # noqa
 from hamcrest import assert_that, calling, equal_to, raises
 from nose.tools import eq_
 
-from ycmd.utils import ToBytes
+from ycmd.utils import ForceSemanticCompletion, ToBytes
 from ycmd.request_wrap import RequestWrap
 
 
-def PrepareJson( contents = '', line_num = 1, column_num = 1, filetype = '' ):
-  return {
+def PrepareJson( contents = '',
+                 line_num = 1,
+                 column_num = 1,
+                 filetype = '',
+                 force_semantic = None ):
+  message = {
     'line_num': line_num,
     'column_num': column_num,
     'filepath': '/foo',
@@ -43,6 +47,10 @@ def PrepareJson( contents = '', line_num = 1, column_num = 1, filetype = '' ):
       }
     }
   }
+  if force_semantic is not None:
+    message[ 'force_semantic' ] = force_semantic
+
+  return message
 
 
 def Prefix_test():
@@ -347,3 +355,25 @@ def NonCalculated_Set_test():
                  equal_to( 'Key "column_num" is read-only' ) )
   else:
     raise AssertionError( 'Expected setting "column_num" to fail' )
+
+
+def ForceSemanticCompletion_test():
+  wrap = RequestWrap( PrepareJson() )
+  assert_that( wrap[ 'force_semantic' ], equal_to( False ) )
+  assert_that( ForceSemanticCompletion( wrap ), equal_to( False ) )
+
+  wrap = RequestWrap( PrepareJson( force_semantic = True ) )
+  assert_that( wrap[ 'force_semantic' ], equal_to( True ) )
+  assert_that( ForceSemanticCompletion( wrap ), equal_to( True ) )
+
+  wrap = RequestWrap( PrepareJson( force_semantic = 1 ) )
+  assert_that( wrap[ 'force_semantic' ], equal_to( 1 ) )
+  assert_that( ForceSemanticCompletion( wrap ), equal_to( True ) )
+
+  wrap = RequestWrap( PrepareJson( force_semantic = 0 ) )
+  assert_that( wrap[ 'force_semantic' ], equal_to( 0 ) )
+  assert_that( ForceSemanticCompletion( wrap ), equal_to( False ) )
+
+  wrap = RequestWrap( PrepareJson( force_semantic = 'No' ) )
+  assert_that( wrap[ 'force_semantic' ], equal_to( 'No' ) )
+  assert_that( ForceSemanticCompletion( wrap ), equal_to( True ) )

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -336,8 +336,7 @@ def PathsToAllParentFolders( path ):
 
 
 def ForceSemanticCompletion( request_data ):
-  return ( 'force_semantic' in request_data and
-           bool( request_data[ 'force_semantic' ] ) )
+  return bool( request_data[ 'force_semantic' ] )
 
 
 # A wrapper for subprocess.Popen that fixes quirks on Windows.


### PR DESCRIPTION
jdt.ls does not return anything useful for top-level completions,
presumably because with no query to work from it has no way to filter
the almost infinite set of possible suggestions.

However it does provide useful completion at the top level (including
automatic imports) when it is given the query string to work with. The
main drawback of this is that the filtering that gets applied is done by
whatever algorithm jdt.ls applies, not what ycmd applies. This can lead
to confusion and breaking the user's mental model of how ycmd completion
works.

Automatic imports are particularly useful for top-level completions,
which are (in general) forced by the user.

So as a compromise, we use the column_codepoint (i.e. including the
'query') when the user forces semantic completion and use the
start_codepoint (i.e. first char after trigger/beginning of identifier),
when 'triggered'.

This allows for powerful features and a simple mental model: if you
force completion, you might get more relevant results, but the filtering
is necessarily different.

As this won't necessarily be universal, it is provided as an API hook.

If we find that multiple language servers behave this way, we can promote the override to the base implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/957)
<!-- Reviewable:end -->
