### PR TITLE
[READY] Simplify force_semantic usage

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -24,7 +24,6 @@ from builtins import *  # noqa
 
 import abc
 import threading
-from ycmd.utils import ForceSemanticCompletion
 from ycmd.completers import completer_utils
 from ycmd.responses import NoDiagnosticSupport
 from future.utils import with_metaclass
@@ -229,7 +228,7 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
   # It's highly likely you DON'T want to override this function but the *Inner
   # version of it.
   def ComputeCandidates( self, request_data ):
-    if ( not ForceSemanticCompletion( request_data ) and
+    if ( not request_data[ 'force_semantic' ] and
          not self.ShouldUseNow( request_data ) ):
       return []
 

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -110,7 +110,6 @@ class CsharpCompleter( Completer ):
 
   def ComputeCandidatesInner( self, request_data ):
     solutioncompleter = self._GetSolutionCompleter( request_data )
-    completion_type = self.CompletionType( request_data )
     return [ responses.BuildCompletionData(
                 completion[ 'CompletionText' ],
                 completion[ 'DisplayText' ],
@@ -120,8 +119,7 @@ class CsharpCompleter( Completer ):
                 { "required_namespace_import" :
                    completion[ 'RequiredNamespaceImport' ] } )
              for completion
-             in solutioncompleter._GetCompletions( request_data,
-                                                   completion_type ) ]
+             in solutioncompleter._GetCompletions( request_data ) ]
 
 
   def FilterAndSortCandidates( self, candidates, query ):
@@ -437,11 +435,11 @@ class CsharpSolutionCompleter( object ):
     return request_data[ 'force_semantic' ]
 
 
-  def _GetCompletions( self, request_data, completion_type ):
+  def _GetCompletions( self, request_data ):
     """ Ask server for completions """
     parameters = self._DefaultParameters( request_data )
-    parameters[ 'WantImportableTypes' ] = completion_type
-    parameters[ 'ForceSemanticCompletion' ] = completion_type
+    parameters[ 'WantImportableTypes' ] = request_data[ 'force_semantic' ]
+    parameters[ 'ForceSemanticCompletion' ] = request_data[ 'force_semantic' ]
     parameters[ 'WantDocumentationForEveryCompletionResult' ] = True
     completions = self._GetResponse( '/autocomplete', parameters )
     return completions if completions is not None else []

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -35,8 +35,7 @@ import threading
 from ycmd.completers.completer import Completer
 from ycmd.completers.completer_utils import GetFileContents
 from ycmd.completers.cs import solutiondetection
-from ycmd.utils import ( ForceSemanticCompletion, CodepointOffsetToByteOffset,
-                         urljoin )
+from ycmd.utils import CodepointOffsetToByteOffset, urljoin
 from ycmd import responses
 from ycmd import utils
 
@@ -106,7 +105,7 @@ class CsharpCompleter( Completer ):
 
 
   def CompletionType( self, request_data ):
-    return ForceSemanticCompletion( request_data )
+    return request_data[ 'force_semantic' ]
 
 
   def ComputeCandidatesInner( self, request_data ):
@@ -435,7 +434,7 @@ class CsharpSolutionCompleter( object ):
 
 
   def CompletionType( self, request_data ):
-    return ForceSemanticCompletion( request_data )
+    return request_data[ 'force_semantic' ]
 
 
   def _GetCompletions( self, request_data, completion_type ):

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -441,7 +441,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
     # semantic engine, and thus get good completion results at the top level,
     # even if this means the "filtering and sorting" is not 100% ycmd flavor.
     return ( request_data[ 'column_codepoint' ]
-             if utils.ForceSemanticCompletion( request_data )
+             if request_data[ 'force_semantic' ]
              else request_data[ 'start_codepoint' ] )
 
 

--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -210,7 +210,7 @@ class RequestWrap( object ):
 
 
   def _GetForceSemantic( self ):
-    return self._request.get( 'force_semantic', False )
+    return bool( self._request.get( 'force_semantic', False ) )
 
 
 def CompletionStartColumn( line_value, column_num, filetype ):

--- a/ycmd/server_state.py
+++ b/ycmd/server_state.py
@@ -26,7 +26,7 @@ import os
 import threading
 import logging
 from future.utils import itervalues
-from ycmd.utils import ForceSemanticCompletion, LoadPythonSource
+from ycmd.utils import LoadPythonSource
 from ycmd.completers.general.general_completer_store import (
     GeneralCompleterStore )
 from ycmd.completers.completer_utils import PathToFiletypeCompleterPluginLoader
@@ -122,7 +122,7 @@ class ServerState( object ):
     """
     filetypes = request_data[ 'filetypes' ]
     if self.FiletypeCompletionUsable( filetypes ):
-      if ForceSemanticCompletion( request_data ):
+      if request_data[ 'force_semantic' ]:
         # use semantic, and it was forced
         return ( True, True )
       else:

--- a/ycmd/server_state.py
+++ b/ycmd/server_state.py
@@ -110,31 +110,20 @@ class ServerState( object ):
 
 
   def ShouldUseFiletypeCompleter( self, request_data ):
-    """
-    Determines whether or not the semantic completer should be called, and
-    returns an indication of the reason why. Specifically, returns a tuple:
-    ( should_use_completer_now, was_semantic_completion_forced ), where:
-     - should_use_completer_now: if True, the semantic engine should be used
-     - was_semantic_completion_forced: if True, the user requested "forced"
-                                       semantic completion
-    was_semantic_completion_forced is always False if should_use_completer_now
-    is False
-    """
+    """Determines whether or not the semantic completer should be called."""
     filetypes = request_data[ 'filetypes' ]
-    if self.FiletypeCompletionUsable( filetypes ):
-      if request_data[ 'force_semantic' ]:
-        # use semantic, and it was forced
-        return ( True, True )
-      else:
-        # was not forced. check the conditions for triggering
-        return (
-          self.GetFiletypeCompleter( filetypes ).ShouldUseNow( request_data ),
-          False
-        )
+    if not self.FiletypeCompletionUsable( filetypes ):
+      # don't use semantic, ignore whether or not the user requested forced
+      # completion
+      return False
 
-    # don't use semantic, ignore whether or not the user requested forced
-    # completion
-    return ( False, False )
+    if request_data[ 'force_semantic' ]:
+      # use semantic, and it was forced
+      return True
+
+    # was not forced. check the conditions for triggering
+    return self.GetFiletypeCompleter( filetypes ).ShouldUseNow(
+      request_data )
 
 
   def GetGeneralCompleter( self ):

--- a/ycmd/tests/request_wrap_test.py
+++ b/ycmd/tests/request_wrap_test.py
@@ -27,7 +27,7 @@ from builtins import *  # noqa
 from hamcrest import assert_that, calling, equal_to, raises
 from nose.tools import eq_
 
-from ycmd.utils import ForceSemanticCompletion, ToBytes
+from ycmd.utils import ToBytes
 from ycmd.request_wrap import RequestWrap
 
 
@@ -360,20 +360,15 @@ def NonCalculated_Set_test():
 def ForceSemanticCompletion_test():
   wrap = RequestWrap( PrepareJson() )
   assert_that( wrap[ 'force_semantic' ], equal_to( False ) )
-  assert_that( ForceSemanticCompletion( wrap ), equal_to( False ) )
 
   wrap = RequestWrap( PrepareJson( force_semantic = True ) )
   assert_that( wrap[ 'force_semantic' ], equal_to( True ) )
-  assert_that( ForceSemanticCompletion( wrap ), equal_to( True ) )
 
   wrap = RequestWrap( PrepareJson( force_semantic = 1 ) )
-  assert_that( wrap[ 'force_semantic' ], equal_to( 1 ) )
-  assert_that( ForceSemanticCompletion( wrap ), equal_to( True ) )
+  assert_that( wrap[ 'force_semantic' ], equal_to( True ) )
 
   wrap = RequestWrap( PrepareJson( force_semantic = 0 ) )
-  assert_that( wrap[ 'force_semantic' ], equal_to( 0 ) )
-  assert_that( ForceSemanticCompletion( wrap ), equal_to( False ) )
+  assert_that( wrap[ 'force_semantic' ], equal_to( False ) )
 
   wrap = RequestWrap( PrepareJson( force_semantic = 'No' ) )
-  assert_that( wrap[ 'force_semantic' ], equal_to( 'No' ) )
-  assert_that( ForceSemanticCompletion( wrap ), equal_to( True ) )
+  assert_that( wrap[ 'force_semantic' ], equal_to( True ) )

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -335,10 +335,6 @@ def PathsToAllParentFolders( path ):
     yield folder
 
 
-def ForceSemanticCompletion( request_data ):
-  return bool( request_data[ 'force_semantic' ] )
-
-
 # A wrapper for subprocess.Popen that fixes quirks on Windows.
 def SafePopen( args, **kwargs ):
   if OnWindows():


### PR DESCRIPTION
After PR #957, we now have access to the `force_semantic` key consistently from `RequestWrap`. As commented by @micbou this makes `utils.ForceSemanticCompletion` pretty redundant.

This change is actually 3 commits which all make non-functional changes:

1. Remove `utils.ForceSemanticCompletion`
2. Simplify `cs_completer` a little (this is not the whole job, we need to remove `CompletionType`, but that is done by #958 
3. Refactor the `/completion` handler (in particular `ShouldUseFiletypeCompleter`) to use `force_semantic` from the `RequestWrap`, as previously the return was a tuple and it was all a bit messy.

If you want me to do 3 separate PRs for the  3 commits, just shout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/960)
<!-- Reviewable:end -->
