### PR TITLE
[READY] Fix ycm_core_tests incremental builds on Windows

### DIFF
--- a/cpp/BoostParts/CMakeLists.txt
+++ b/cpp/BoostParts/CMakeLists.txt
@@ -36,7 +36,7 @@ include_directories(
   ${PYTHON_INCLUDE_DIRS}
   )
 
-add_library( BoostParts ${SOURCES} )
+add_library( BoostParts STATIC ${SOURCES} )
 
 #############################################################################
 


### PR DESCRIPTION
When building the `ycm_core_tests` target for the first time on Windows, we override the `BUILD_SHARED_LIBS` variable to dynamically link the `gmock` library. The Boost libraries are still statically built because they are compiled before the option is set. However, if we rebuild the `ycm_core_tests` target, `BUILD_SHARED_LIBS` is now set and CMake tries to build dynamic libraries of Boost which fails because the Python dynamic library cannot be found (which is expected since there is no `link_directories` directive to build Boost). To fix that, we need to force building Boost statically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/961)
<!-- Reviewable:end -->
