### PR TITLE
[READY] Add OrganizeImports command to Java completer

### DIFF
--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 ycmd contributors
+# Copyright (C) 2017-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -33,6 +33,7 @@ from subprocess import PIPE
 
 from ycmd import utils, responses
 from ycmd.completers.language_server import language_server_completer
+from ycmd.completers.language_server import language_server_protocol as lsp
 
 NO_DOCUMENTATION_MESSAGE = 'No documentation available for current context'
 
@@ -223,6 +224,9 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       ),
       'GetType': (
         lambda self, request_data, args: self.GetType( request_data )
+      ),
+      'OrganizeImports': (
+        lambda self, request_data, args: self.OrganizeImports( request_data )
       ),
     }
 
@@ -544,6 +548,17 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       raise RuntimeError( NO_DOCUMENTATION_MESSAGE )
 
     return responses.BuildDetailedInfoResponse( documentation )
+
+
+  def OrganizeImports( self, request_data ):
+    workspace_edit = self.GetCommandResponse(
+      request_data,
+      'java.edit.organizeImports',
+      [ lsp.FilePathToUri( request_data[ 'filepath' ] ) ] )
+
+    fixit = language_server_completer.WorkspaceEditToFixIt( request_data,
+                                                            workspace_edit )
+    return responses.BuildFixItResponse( [ fixit ] )
 
 
   def HandleServerCommand( self, request_data, command ):

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 ycmd contributors
+# Copyright (C) 2017-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -1468,6 +1468,20 @@ class LanguageServerCompleter( Completer ):
                           request_data[ 'column_num' ],
                           request_data[ 'filepath' ] ),
       chunks ) ] )
+
+
+  def GetCommandResponse( self, request_data, command, arguments ):
+    if not self.ServerIsReady():
+      raise RuntimeError( 'Server is initializing. Please wait.' )
+
+    self._UpdateServerWithFileContents( request_data )
+
+    request_id = self.GetConnection().NextRequestId()
+    message = lsp.ExecuteCommand( request_id, command, arguments )
+    response = self.GetConnection().GetResponse( request_id,
+                                                 message,
+                                                 REQUEST_TIMEOUT_COMMAND )
+    return response[ 'result' ]
 
 
 def _CompletionItemToCompletionData( insertion_text, item, fixits ):

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 ycmd contributors
+# Copyright (C) 2017-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -383,6 +383,13 @@ def Range( request_data ):
     'start': Position( start_line_num, start_line_value, start_codepoint ),
     'end': Position( end_line_num, end_line_value, end_codepoint )
   }
+
+
+def ExecuteCommand( request_id, command, arguments ):
+  return BuildRequest( request_id, 'workspace/executeCommand', {
+    'command': command,
+    'arguments': arguments
+  } )
 
 
 def FilePathToUri( file_name ):

--- a/ycmd/tests/java/get_completions_test.py
+++ b/ycmd/tests/java/get_completions_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 ycmd contributors
+# Copyright (C) 2017-2018 ycmd contributors
 # encoding: utf-8
 #
 # This file is part of ycmd.
@@ -223,7 +223,7 @@ def GetCompletions_Import_Class_test( app ):
     'request': {
       'filetype'  : 'java',
       'filepath'  : ProjectPath( 'TestLauncher.java' ),
-      'line_num'  : 4,
+      'line_num'  : 3,
       'column_num': 34,
     },
     'expect': {
@@ -250,7 +250,7 @@ def GetCompletions_Import_Classes_test( app ):
     'request': {
       'filetype'  : 'java',
       'filepath'  : filepath,
-      'line_num'  : 3,
+      'line_num'  : 4,
       'column_num': 52,
     },
     'expect': {

--- a/ycmd/tests/java/testdata/simple_eclipse_project/src/com/test/TestLauncher.java
+++ b/ycmd/tests/java/testdata/simple_eclipse_project/src/com/test/TestLauncher.java
@@ -1,7 +1,7 @@
 package com.test;
 
-import com.youcompleteme.*; import com.test.wobble.*;
 import com.youcompleteme.testing.Tset;
+import com.youcompleteme.*; import com.test.wobble.*;
 
 class TestLauncher {
   private TestFactory factory = new TestFactory();


### PR DESCRIPTION
This implements the jdt.ls `java.edit.organizeImports` command as a new Java completer subcommand  `OrganizeImports`. Demo:

![java-organize-imports](https://user-images.githubusercontent.com/10026824/37649285-94041ace-2c31-11e8-9d20-95dea30e2696.gif)

I switched the imports in `TestLauncher.java` to make the tests more interesting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/963)
<!-- Reviewable:end -->
