### PR TITLE
Show the right message in the clang completer when _LocationForGoTo is called and the file is being parsed

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -211,6 +211,10 @@ class ClangCompleter( Completer ):
     if not flags:
       raise ValueError( NO_COMPILE_FLAGS_MESSAGE )
 
+    if self._completer.UpdatingTranslationUnit(
+        ToCppStringCompatible( filename ) ):
+      raise ValueError( PARSING_FILE_MESSAGE )
+
     files = self.GetUnsavedFilesVector( request_data )
     line = request_data[ 'line_num' ]
     column = request_data[ 'column_num' ]


### PR DESCRIPTION
In a C++ file, if a user tries to use one of the GoTo commands while the file is being parsed, no location is returned and the user receives a `Can't jump to declaration` `RuntimeError` message or similar. If the user waits a couple of seconds for the parsing to end, the command will work. 

The error message is misleading, I think that the user should be shown a `PARSING_FILE_MESSAGE` as in [line 151](https://github.com/Emigre/ycmd/blob/4de05405155803e8d0bf80262ff630815f3ca9c6/ycmd/completers/cpp/clang_completer.py#L151) of the modified file. With this change, the user sees a `ValueError: Still parsing file, no completions yet.` message and knows that he has to wait.

**How to reproduce**
- Create a C++ project.
- Enter a file and quickly try to use`YcmCompleter GoToDeclaration`

**Expected result**
- If the file is being parsed at that moment the user is shown a `Still parsing file, no completions yet` information message. 
- Then if he waits and tries again when it has been parsed, the command works as expected.

**Actual result**
- If the file is being parsed at that moment the user is shown a `Can't jump to declaration` error message. 
- Then if he waits and tries again when it has been parsed, the command works as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/966)
<!-- Reviewable:end -->
