### PR TITLE
[RFC] Add clang-tidy support

### DIFF
--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -18,6 +18,7 @@ REQUIREMENTS="cmake
               node.js
               go
               mono
+              llvm
               readline
               autoconf
               pkg-config

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -471,3 +471,24 @@ endif()
 if ( DEFINED ENV{YCM_BENCHMARK} )
   add_subdirectory( benchmarks )
 endif()
+
+if( NOT APPLE )
+  find_program( CLANG_TIDY NAMES clang-tidy )
+else()
+  execute_process( COMMAND brew --prefix llvm OUTPUT_VARIABLE LLVM_ROOT )
+  string( STRIP ${LLVM_ROOT} LLVM_ROOT )
+  message( STATUS "${LLVM_ROOT}/bin" )
+  find_program( CLANG_TIDY NAMES clang-tidy PATHS "${LLVM_ROOT}/bin" )
+endif()
+
+if ( CLANG_TIDY )
+  message( STATUS "clang-tidy executable found: ${CLANG_TIDY}" )
+  set( CLANG_TIDY_ARGS
+       "${CLANG_TIDY}"
+       "-checks=-*,cppcoreguidelines-*,google-*,hicpp-*,misc-*,modernize-*,performance-*,readability-*"
+       "-warnings-as-errors=*,-google-explicit-constructor,-hicpp-explicit-conversions" )
+  set_target_properties( ycm_core PROPERTIES
+                         CXX_CLANG_TIDY "${CLANG_TIDY_ARGS}" )
+else()
+  message( STATUS "clang-tidy not found" )
+endif()


### PR DESCRIPTION
This PR makes use of clang-tidy for static analysis and fails the build if clang-tidy raises (almost) any warning. I have enabled every set of warnings that produced any warnings, so that everyone can see all of the warnings. Before I make the fixes proposed by clang-tidy I wanted us to first agree on which tests are worth keeping. Note that this means that this PR won't even compile.

Two warnings couldn't have been turned into errors because they are also detected inside boost's code. The warnings in question:
- `google-explicit-constructor`
- `hicpp-explicit-conversions`

These are left in as warnings. Unfortunately, the `--quiet` build hides warnings from us, but the benchmark build is not running the `--quiet` build, so we can still see the warnings.

Once again, as it is now, this PR will fail to compile because all warnings are promoted to errors. To see the warnings, as warnings, you can take a look at [this travis build](https://travis-ci.org/bstaletic/ycmd/builds/357064094).

### The list of clang-tidy diagnostics

#### Readability (in order of appearance)

- `readability-implicit-bool-cast` - Forces the use `==` instead of `!` inside `if()` statements.
  - Depending on situation, this can make code look weird - consider `== 1u` instead of `== true`.
- `readability-inconsistent-declaration-parameter-name` - Declaration and definition must have the same parameter names.
- `readability-container-size-empty` - Use `empty()` instead of `size()` for checking emptiness of containers.
- `readability-else-after-return` - If you have a conditional early return, don't have an `else` after it.

#### Modernise

- `modernize-return-braced-init-list` - "Don't repeat the return type, use braced initialisation lists instead".
- `modernize-use-emplace` - Use `emplace_back()` instead of `push_back()`.
- `modernize-make-unique` - Use `make_unique` instead of naked `new`.

#### Cpp core guidelines

- `cppcoreguidelines-pro-type-member-init` - Uninitialised record type.
- `cppcoreguidelines-pro-bounds-pointer-arithmetic` - Prohibits pointer arithmetic.
- `cppcoreguidelines-pro-type-const-cast` - Prohibits `const_cast`.
- `cppcoreguidelines-pro-bounds-array-to-pointer-decay` - "do not implicitly decay an array into a pointer; consider using gsl::array_view or an explicit cast instead".
#### Google

- `google-runtime-references` - No non-const references. Either a naked pointer or a const reference.
- `google-explicit-constructor` - Single parameter constructors must be declared `explicit`.
  - This is the one we can't turn into an error.
- `google-readability-namespace-comments` - Anonymous namespace doesn't have a closing comment.
- `google-runtime-int` - Use `int16` instead of `short`.
- `google-build-using-namespace` - "do not use namespace using-directives; use using-declarations instead".
#### Performance

- `performance-unnecessary-value-param` - Passed by value, but could be a const reference.
- `performance-for-range-copy` - Range based `for` is not a const reference.

#### Hicpp

- `hicpp-use-equals-default` - Constructors should use `= default;` instead of `{};`.
- `hicpp-explicit-conversions`, equivalent to, and silenced by, `google-explicit-contructor`.
  - That one also can't be an error.

#### Misc

- `misc-move-const-arg` - Useless `std::move`.

#### Others

- I know there are others, but they are silenced because another warning is issued in the same place.
  - One such example is [missing rule of five](https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)#Rule_of_Five).
    - I'm assuming that obeying rule of five will allow "performance" and/or "modernize" sets of diagnostics to show more things that could be improved, because then it can suggest heavier use of move semantics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/967)
<!-- Reviewable:end -->
