### PR TITLE
[READY] Optimize lines splitting for current file

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -29,7 +29,7 @@ import os
 import re
 from collections import defaultdict
 from future.utils import iteritems
-from ycmd.utils import ToCppStringCompatible, ToUnicode, ReadFile
+from ycmd.utils import ToCppStringCompatible, ToUnicode, ReadFile, SplitLines
 
 _logger = logging.getLogger( __name__ )
 
@@ -230,3 +230,11 @@ def GetFileContents( request_data, filename ):
   except IOError:
     _logger.exception( 'Error reading file {}'.format( filename ) )
     return ''
+
+
+def GetFileLines( request_data, filename ):
+  """Like GetFileContents but return the contents as a list of lines. Avoid
+  splitting the lines if they have already been split for the current file."""
+  if filename == request_data[ 'filepath' ]:
+    return request_data[ 'lines' ]
+  return SplitLines( GetFileContents( request_data, filename ) )

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -31,7 +31,7 @@ import requests
 import threading
 
 from ycmd.completers.completer import Completer
-from ycmd.completers.completer_utils import GetFileContents
+from ycmd.completers.completer_utils import GetFileLines
 from ycmd.completers.cs import solutiondetection
 from ycmd.utils import CodepointOffsetToByteOffset, urljoin
 from ycmd import responses
@@ -671,7 +671,7 @@ def _BuildLocation( request_data, filename, line_num, column_num ):
   # column is 1 in that case.
   if column_num <= 0:
     column_num = 1
-  contents = utils.SplitLines( GetFileContents( request_data, filename ) )
+  contents = GetFileLines( request_data, filename )
   line_value = contents[ line_num - 1 ]
   return responses.Location(
       line_num,

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -31,7 +31,7 @@ import threading
 from subprocess import PIPE
 from ycmd import utils, responses
 from ycmd.completers.completer import Completer
-from ycmd.completers.completer_utils import GetFileContents
+from ycmd.completers.completer_utils import GetFileLines
 
 _logger = logging.getLogger( __name__ )
 
@@ -548,7 +548,7 @@ class TernCompleter( Completer ):
     filepath = self._ServerPathToAbsolute( response[ 'file' ] )
     return responses.BuildGoToResponseFromLocation(
       _BuildLocation(
-        utils.SplitLines( GetFileContents( request_data, filepath ) ),
+        GetFileLines( request_data, filepath ),
         filepath,
         response[ 'start' ][ 'line' ],
         response[ 'start' ][ 'ch' ] ) )
@@ -566,8 +566,7 @@ class TernCompleter( Completer ):
     def BuildRefResponse( ref ):
       filepath = self._ServerPathToAbsolute( ref[ 'file' ] )
       return responses.BuildGoToResponseFromLocation(
-        _BuildLocation(
-          utils.SplitLines( GetFileContents( request_data, filepath ) ),
+        _BuildLocation( GetFileLines( request_data, filepath ),
           filepath,
           ref[ 'start' ][ 'line' ],
           ref[ 'start' ][ 'ch' ] ) )
@@ -650,8 +649,7 @@ class TernCompleter( Completer ):
 
     def BuildFixItChunk( change ):
       filepath = self._ServerPathToAbsolute( change[ 'file' ] )
-      file_contents = utils.SplitLines(
-        GetFileContents( request_data, filepath ) )
+      file_contents = GetFileLines( request_data, filepath )
       return responses.FixItChunk(
         change[ 'text' ],
         BuildRange( file_contents,

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -28,7 +28,6 @@ import hashlib
 
 from ycmd.utils import ( ByteOffsetToCodepointOffset,
                          pathname2url,
-                         SplitLines,
                          ToBytes,
                          ToUnicode,
                          url2pathname,
@@ -357,8 +356,7 @@ def FormattingOptions( request_data ):
 
 
 def Range( request_data ):
-  filepath = request_data[ 'filepath' ]
-  lines = SplitLines( request_data[ 'file_data' ][ filepath ][ 'contents' ] )
+  lines = request_data[ 'lines' ]
 
   start = request_data[ 'range' ][ 'start' ]
   start_line_num = start[ 'line_num' ]

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -37,7 +37,7 @@ from tempfile import NamedTemporaryFile
 from ycmd import responses
 from ycmd import utils
 from ycmd.completers.completer import Completer
-from ycmd.completers.completer_utils import GetFileContents
+from ycmd.completers.completer_utils import GetFileLines
 
 SERVER_NOT_RUNNING_MESSAGE = 'TSServer is not running.'
 NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
@@ -113,8 +113,7 @@ def ShouldEnableTypeScriptCompleter():
 
 def TsDiagnosticToYcmdDiagnostic( request_data, ts_diagnostic ):
   filepath = request_data[ 'filepath' ]
-  contents = utils.SplitLines(
-    request_data[ 'file_data' ][ filepath ][ 'contents' ] )
+  contents = request_data[ 'lines' ]
 
   ts_start_location = ts_diagnostic[ 'startLocation' ]
   ts_start_line = ts_start_location[ 'line' ]
@@ -552,8 +551,7 @@ class TypeScriptCompleter( Completer ):
 
     span = filespans[ 0 ]
     return responses.BuildGoToResponseFromLocation(
-      _BuildLocation( utils.SplitLines( GetFileContents( request_data,
-                                                         span[ 'file' ] ) ),
+      _BuildLocation( GetFileLines( request_data, span[ 'file' ] ),
                       span[ 'file' ],
                       span[ 'start' ][ 'line' ],
                       span[ 'start' ][ 'offset' ] ) )
@@ -568,8 +566,7 @@ class TypeScriptCompleter( Completer ):
     } )
     return [
       responses.BuildGoToResponseFromLocation(
-        _BuildLocation( utils.SplitLines( GetFileContents( request_data,
-                                                           ref[ 'file' ] ) ),
+        _BuildLocation( GetFileLines( request_data, ref[ 'file' ] ),
                         ref[ 'file' ],
                         ref[ 'start' ][ 'line' ],
                         ref[ 'start' ][ 'offset' ] ),
@@ -790,7 +787,7 @@ def _BuildFixItChunksForFile( request_data, new_name, file_replacement ):
   # whereas all other paths in Python are of the C:\\blah\\blah form. We use
   # normpath to have python do the conversion for us.
   file_path = os.path.normpath( file_replacement[ 'file' ] )
-  file_contents = utils.SplitLines( GetFileContents( request_data, file_path ) )
+  file_contents = GetFileLines( request_data, file_path )
   return [ _BuildFixItChunkForRange( new_name, file_contents, file_path, r )
            for r in file_replacement[ 'locs' ] ]
 


### PR DESCRIPTION
With PR #958, we now store the lines of the current file in `request_data[ 'lines' ]`. This should be used where possible to avoid splitting the current file more than once. Since we often do `SplitLines( GetFileContents() )` in the code, I added a new function `GetFileLines` for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/970)
<!-- Reviewable:end -->
