### PR TITLE
[READY] Improve TypeScript completion data

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -409,21 +409,14 @@ class TypeScriptCompleter( Completer ):
     if len( entries ) > MAX_DETAILED_COMPLETIONS:
       return [ _ConvertCompletionData(e) for e in entries ]
 
-    names = []
-    namelength = 0
-    for e in entries:
-      name = e[ 'name' ]
-      namelength = max( namelength, len( name ) )
-      names.append( name )
-
     detailed_entries = self._SendRequest( 'completionEntryDetails', {
       'file':       request_data[ 'filepath' ],
       'line':       request_data[ 'line_num' ],
       'offset':     request_data[ 'start_codepoint' ],
-      'entryNames': names
+      'entryNames': [ entry[ 'name' ] for entry in entries ]
     } )
-    return [ _ConvertDetailedCompletionData( e, namelength )
-             for e in detailed_entries ]
+    return [ _ConvertDetailedCompletionData( entry )
+             for entry in detailed_entries ]
 
 
   def GetSubcommandsMap( self ):
@@ -748,24 +741,32 @@ def _LogLevel():
 def _ConvertCompletionData( completion_data ):
   return responses.BuildCompletionData(
     insertion_text = completion_data[ 'name' ],
-    menu_text      = completion_data[ 'name' ],
     kind           = completion_data[ 'kind' ],
-    extra_data     = completion_data[ 'kind' ]
   )
 
 
-def _ConvertDetailedCompletionData( completion_data, padding = 0 ):
+def _ConvertDetailedCompletionData( completion_data ):
   name = completion_data[ 'name' ]
   display_parts = completion_data[ 'displayParts' ]
-  signature = ''.join( [ p[ 'text' ] for p in display_parts ] )
+  signature = ''.join( [ part[ 'text' ] for part in display_parts ] )
+  if name == signature:
+    extra_menu_info = None
+    detailed_info = []
+  else:
+    # Strip new lines and indentation from the signature to display it on one
+    # line.
+    extra_menu_info = re.sub( '\s+', ' ', signature )
+    detailed_info = [ signature ]
 
-  # needed to strip new lines and indentation from the signature
-  signature = re.sub( '\s+', ' ', signature )
-  menu_text = '{0} {1}'.format( name.ljust( padding ), signature )
+  docs = completion_data.get( 'documentation', [] )
+  detailed_info += [ doc[ 'text' ].strip() for doc in docs if doc ]
+  detailed_info = '\n\n'.join( detailed_info )
+
   return responses.BuildCompletionData(
-    insertion_text = name,
-    menu_text      = menu_text,
-    kind           = completion_data[ 'kind' ]
+    insertion_text  = name,
+    extra_menu_info = extra_menu_info,
+    detailed_info   = detailed_info,
+    kind            = completion_data[ 'kind' ]
   )
 
 

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+#
 # Copyright (C) 2015 ycmd contributors
 #
 # This file is part of ycmd.
@@ -26,7 +28,10 @@ from hamcrest import ( all_of, any_of, assert_that, calling,
                        contains_inanyorder, has_entries, has_item, is_not,
                        raises )
 from mock import patch
+from nose.tools import eq_
 from webtest import AppError
+import pprint
+import requests
 
 from ycmd.tests.typescript import IsolatedYcmd, PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import ( BuildRequest, CompletionEntryMatcher,
@@ -35,24 +40,34 @@ from ycmd.utils import ReadFile
 
 
 def RunTest( app, test ):
-  filepath = PathToTestFile( 'test.ts' )
-  contents = ReadFile( filepath )
+  contents = ReadFile( test[ 'request' ][ 'filepath' ] )
 
-  event_data = BuildRequest( filepath = filepath,
-                             filetype = 'typescript',
-                             contents = contents,
-                             event_name = 'BufferVisit' )
+  def CombineRequest( request, data ):
+    kw = request
+    request.update( data )
+    return BuildRequest( **kw )
 
-  app.post_json( '/event_notification', event_data )
+  app.post_json(
+    '/event_notification',
+    CombineRequest( test[ 'request' ], {
+      'contents': contents,
+      'filetype': 'typescript',
+      'event_name': 'BufferVisit'
+    } )
+  )
 
-  completion_data = BuildRequest( filepath = filepath,
-                                  filetype = 'typescript',
-                                  contents = contents,
-                                  force_semantic = True,
-                                  line_num = 17,
-                                  column_num = 6 )
+  response = app.post_json(
+    '/completions',
+    CombineRequest( test[ 'request' ], {
+      'contents': contents,
+      'filetype': 'typescript',
+      'force_semantic': True
+    } )
+  )
 
-  response = app.post_json( '/completions', completion_data )
+  print( 'completer response: {0}'.format( pprint.pformat( response.json ) ) )
+
+  eq_( response.status_code, test[ 'expect' ][ 'response' ] )
 
   assert_that( response.json, test[ 'expect' ][ 'data' ] )
 
@@ -60,17 +75,69 @@ def RunTest( app, test ):
 @SharedYcmd
 def GetCompletions_Basic_test( app ):
   RunTest( app, {
+    'description': 'Extra and detailed info when completions are methods',
+    'request': {
+      'line_num': 17,
+      'column_num': 6,
+      'filepath': PathToTestFile( 'test.ts' )
+    },
     'expect': {
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': contains_inanyorder(
-          CompletionEntryMatcher( 'methodA', extra_params = {
-            'menu_text': 'methodA (method) Foo.methodA(): void' } ),
-          CompletionEntryMatcher( 'methodB', extra_params = {
-            'menu_text': 'methodB (method) Foo.methodB(): void' } ),
-          CompletionEntryMatcher( 'methodC', extra_params = {
-            'menu_text': ( 'methodC (method) Foo.methodC(a: '
-                           '{ foo: string; bar: number; }): void' ) } ),
+          CompletionEntryMatcher(
+            'methodA',
+            '(method) Foo.methodA(): void',
+            extra_params = {
+              'kind': 'method',
+              'detailed_info': '(method) Foo.methodA(): void\n\n'
+                               'Unicode string: 说话'
+            }
+          ),
+          CompletionEntryMatcher(
+            'methodB',
+            '(method) Foo.methodB(): void',
+            extra_params = {
+              'kind': 'method',
+              'detailed_info': '(method) Foo.methodB(): void'
+            }
+          ),
+          CompletionEntryMatcher(
+            'methodC',
+            '(method) Foo.methodC(a: { foo: string; bar: number; }): void',
+            extra_params = {
+              'kind': 'method',
+              'detailed_info': '(method) Foo.methodC(a: {\n'
+                               '    foo: string;\n'
+                               '    bar: number;\n'
+                               '}): void'
+            }
+          )
         )
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+@patch( 'ycmd.completers.typescript.'
+          'typescript_completer.MAX_DETAILED_COMPLETIONS',
+        1000 )
+def GetCompletions_Keyword_test( app ):
+  RunTest( app, {
+    'description': 'No extra and detailed info when completion is a keyword',
+    'request': {
+      'line_num': 2,
+      'column_num': 5,
+      'filepath': PathToTestFile( 'test.ts' ),
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completions': has_item( {
+          'insertion_text': 'class',
+          'kind':           'keyword',
+        } )
       } )
     }
   } )
@@ -82,7 +149,13 @@ def GetCompletions_Basic_test( app ):
         2 )
 def GetCompletions_MaxDetailedCompletion_test( app ):
   RunTest( app, {
+    'request': {
+      'line_num': 17,
+      'column_num': 6,
+      'filepath': PathToTestFile( 'test.ts' ),
+    },
     'expect': {
+      'response': requests.codes.ok,
       'data': has_entries( {
         'completions': all_of(
           contains_inanyorder(
@@ -92,15 +165,23 @@ def GetCompletions_MaxDetailedCompletion_test( app ):
           ),
           is_not( any_of(
             has_item(
-              CompletionEntryMatcher( 'methodA', extra_params = {
-                'menu_text': 'methodA (method) Foo.methodA(): void' } ) ),
+              CompletionEntryMatcher(
+                'methodA',
+                '(method) Foo.methodA(): void'
+              )
+            ),
             has_item(
-              CompletionEntryMatcher( 'methodB', extra_params = {
-                'menu_text': 'methodB (method) Foo.methodB(): void' } ) ),
+              CompletionEntryMatcher(
+                'methodB',
+                '(method) Foo.methodB(): void'
+              )
+            ),
             has_item(
-              CompletionEntryMatcher( 'methodC', extra_params = {
-                'menu_text': ( 'methodC (method) Foo.methodC(a: '
-                               '{ foo: string; bar: number; }): void' ) } ) )
+              CompletionEntryMatcher(
+                'methodC',
+                '(method) Foo.methodC(a: { foo: string; bar: number; }): void'
+              )
+            )
           ) )
         )
       } )
@@ -125,18 +206,37 @@ def GetCompletions_AfterRestart_test( app ):
                                   line_num = 17,
                                   column_num = 6 )
 
-  response = app.post_json( '/completions', completion_data )
-  assert_that( response.json, has_entries( {
-        'completions': contains_inanyorder(
-          CompletionEntryMatcher( 'methodA', extra_params = {
-            'menu_text': 'methodA (method) Foo.methodA(): void' } ),
-          CompletionEntryMatcher( 'methodB', extra_params = {
-            'menu_text': 'methodB (method) Foo.methodB(): void' } ),
-          CompletionEntryMatcher( 'methodC', extra_params = {
-            'menu_text': ( 'methodC (method) Foo.methodC(a: '
-                           '{ foo: string; bar: number; }): void' ) } ),
+  assert_that(
+    app.post_json( '/completions', completion_data ).json,
+    has_entries( {
+      'completions': contains_inanyorder(
+        CompletionEntryMatcher(
+          'methodA',
+          '(method) Foo.methodA(): void',
+          extra_params = { 'kind': 'method' }
+        ),
+        CompletionEntryMatcher(
+          'methodB',
+          '(method) Foo.methodB(): void',
+          extra_params = {
+            'kind': 'method',
+            'detailed_info': '(method) Foo.methodB(): void'
+          }
+        ),
+        CompletionEntryMatcher(
+          'methodC',
+          '(method) Foo.methodC(a: { foo: string; bar: number; }): void',
+          extra_params = {
+            'kind': 'method',
+            'detailed_info': '(method) Foo.methodC(a: {\n'
+                             '    foo: string;\n'
+                             '    bar: number;\n'
+                             '}): void'
+          }
         )
-      } ) )
+      )
+    } )
+  )
 
 
 @IsolatedYcmd

--- a/ycmd/tests/typescript/testdata/test.ts
+++ b/ycmd/tests/typescript/testdata/test.ts
@@ -1,6 +1,6 @@
 
 class Foo {
-  // Unicode string: 说话
+  /** Unicode string: 说话 */
   methodA() {}
   methodB() {}
   methodC(


### PR DESCRIPTION
Add the completion signature and docstring (if any) to the ` detailed_info` field in the TypeScript completer. Make the completion data more consistent with other completers. Here's the comparison before and after in Vim:

![typescript-completion-before](https://user-images.githubusercontent.com/10026824/37929719-06715c3e-3141-11e8-9a9f-ef1e5dc7e553.gif)

![typescript-completion-after](https://user-images.githubusercontent.com/10026824/37929722-09ad529a-3141-11e8-955b-9d1df218e13b.gif)

Fixes https://github.com/Valloric/YouCompleteMe/issues/1944.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/971)
<!-- Reviewable:end -->
