### PR TITLE
[READY] Add GoTo and GoToDeclaration commands to TypeScript completer

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -436,7 +436,11 @@ class TypeScriptCompleter( Completer ):
                            self._RestartServer( request_data ) ),
       'StopServer'     : ( lambda self, request_data, args:
                            self._StopServer() ),
+      'GoTo'           : ( lambda self, request_data, args:
+                           self._GoToDefinition( request_data ) ),
       'GoToDefinition' : ( lambda self, request_data, args:
+                           self._GoToDefinition( request_data ) ),
+      'GoToDeclaration': ( lambda self, request_data, args:
                            self._GoToDefinition( request_data ) ),
       'GoToReferences' : ( lambda self, request_data, args:
                            self._GoToReferences( request_data ) ),


### PR DESCRIPTION
This PR adds the `GoTo` and `GoToDeclaration` commands to the TypeScript completer in order to be consistent with other completers. These commands are identical to `GoToDefinition`.

Added a test to check the list of commands defined in the TypeScript completer and refactored all the subcommands tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/972)
<!-- Reviewable:end -->
