### PR TITLE
[READY] Add TSServer version to debug info

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -176,9 +176,7 @@ class TypeScriptCompleter( Completer ):
     self._tsserver_is_running = threading.Event()
 
     # Start a thread to read response from TSServer.
-    self._thread = threading.Thread( target = self._ReaderLoop, args = () )
-    self._thread.daemon = True
-    self._thread.start()
+    utils.StartThread( self._ReaderLoop )
 
     # Used to map sequence id's to their corresponding DeferredResponse
     # objects. The reader loop uses this to hand out responses.
@@ -200,13 +198,8 @@ class TypeScriptCompleter( Completer ):
 
 
   def _SetServerVersion( self ):
-    def SetServerVersionInThread():
-      with self._tsserver_version_lock:
-        self._tsserver_version = self._SendRequest( 'status' )[ 'version' ]
-
-    self._thread = threading.Thread( target = SetServerVersionInThread )
-    self._thread.daemon = True
-    self._thread.start()
+    with self._tsserver_version_lock:
+      self._tsserver_version = self._SendRequest( 'status' )[ 'version' ]
 
 
   def _StartServer( self ):
@@ -236,7 +229,7 @@ class TypeScriptCompleter( Completer ):
 
       self._tsserver_is_running.set()
 
-      self._SetServerVersion()
+      utils.StartThread( self._SetServerVersion )
 
 
   def _ReaderLoop( self ):

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -153,11 +153,12 @@ class TypeScriptCompleter( Completer ):
 
     self._logfile = None
 
+    self._tsserver_lock = threading.RLock()
     self._tsserver_binary_path = FindTsserverBinary()
-
     self._tsserver_handle = None
-    self._tsserver_version_lock = threading.Lock()
     self._tsserver_version = None
+    # Used to read response only if TSServer is running.
+    self._tsserver_is_running = threading.Event()
 
     # Used to prevent threads from concurrently writing to
     # the tsserver process' stdin
@@ -169,11 +170,6 @@ class TypeScriptCompleter( Completer ):
 
     # Used to prevent threads from concurrently accessing the sequence counter
     self._sequenceid_lock = threading.Lock()
-
-    self._server_lock = threading.RLock()
-
-    # Used to read response only if TSServer is running.
-    self._tsserver_is_running = threading.Event()
 
     # Start a thread to read response from TSServer.
     utils.StartThread( self._ReaderLoop )
@@ -198,12 +194,13 @@ class TypeScriptCompleter( Completer ):
 
 
   def _SetServerVersion( self ):
-    with self._tsserver_version_lock:
-      self._tsserver_version = self._SendRequest( 'status' )[ 'version' ]
+    version = self._SendRequest( 'status' )[ 'version' ]
+    with self._tsserver_lock:
+      self._tsserver_version = version
 
 
   def _StartServer( self ):
-    with self._server_lock:
+    with self._tsserver_lock:
       if self._ServerIsRunning():
         return
 
@@ -369,7 +366,7 @@ class TypeScriptCompleter( Completer ):
 
 
   def _ServerIsRunning( self ):
-    with self._server_lock:
+    with self._tsserver_lock:
       return utils.ProcessIsRunning( self._tsserver_handle )
 
 
@@ -794,7 +791,7 @@ class TypeScriptCompleter( Completer ):
 
 
   def _RestartServer( self, request_data ):
-    with self._server_lock:
+    with self._tsserver_lock:
       self._StopServer()
       self._StartServer()
       # This is needed because after we restart the TSServer it would lose all
@@ -807,7 +804,7 @@ class TypeScriptCompleter( Completer ):
 
 
   def _StopServer( self ):
-    with self._server_lock:
+    with self._tsserver_lock:
       if self._ServerIsRunning():
         _logger.info( 'Stopping TSServer with PID {0}'.format(
                           self._tsserver_handle.pid ) )
@@ -836,10 +833,9 @@ class TypeScriptCompleter( Completer ):
 
 
   def DebugInfo( self, request_data ):
-    with self._server_lock:
-      with self._tsserver_version_lock:
-        item_version = responses.DebugInfoItem( 'version',
-                                                self._tsserver_version )
+    with self._tsserver_lock:
+      item_version = responses.DebugInfoItem( 'version',
+                                              self._tsserver_version )
       tsserver = responses.DebugInfoServer(
           name = 'TSServer',
           handle = self._tsserver_handle,

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -31,7 +31,6 @@ import sys
 import time
 import traceback
 from bottle import request
-from threading import Thread
 
 import ycm_core
 from ycmd import extra_conf_store, hmac_plugin, server_state, user_options_store
@@ -40,6 +39,7 @@ from ycmd.responses import ( BuildExceptionResponse, BuildCompletionResponse,
 from ycmd.request_wrap import RequestWrap
 from ycmd.bottle_utils import SetResponseHeader
 from ycmd.completers.completer_utils import FilterAndSortCandidatesWrap
+from ycmd.utils import StartThread
 
 
 # num bytes for the request body buffer; request.json only works if the request
@@ -311,9 +311,7 @@ def ServerShutdown():
 
   # Use a separate thread to let the server send the response before shutting
   # down.
-  terminator = Thread( target = Terminator )
-  terminator.daemon = True
-  terminator.start()
+  StartThread( Terminator )
 
 
 def ServerCleanup():
@@ -349,7 +347,4 @@ def KeepSubserversAlive( check_interval_seconds ):
       for completer in loaded_completers:
         completer.ServerIsHealthy()
 
-  keepalive = Thread( target = Keepalive,
-                      args = ( check_interval_seconds, ) )
-  keepalive.daemon = True
-  keepalive.start()
+  StartThread( Keepalive, check_interval_seconds )

--- a/ycmd/tests/java/diagnostics_test.py
+++ b/ycmd/tests/java/diagnostics_test.py
@@ -25,7 +25,6 @@ from builtins import *  # noqa
 
 import time
 import json
-import threading
 from future.utils import iterkeys
 from hamcrest import ( assert_that,
                        contains,
@@ -46,7 +45,7 @@ from ycmd.tests.java import ( DEFAULT_PROJECT_DIR,
 
 from ycmd.tests.test_utils import ( BuildRequest, LocationMatcher, RangeMatcher,
                                     WithRetry )
-from ycmd.utils import ReadFile
+from ycmd.utils import ReadFile, StartThread
 from ycmd.completers import completer
 
 from pprint import pformat
@@ -398,10 +397,7 @@ public class Test {
       if 'filepath' in message and message[ 'filepath' ] == filepath:
         messages_for_filepath.append( message )
 
-  poll_task = threading.Thread( target = PollForMessagesInAnotherThread,
-                                args = ( filepath, old_contents ) )
-  poll_task.daemon = True
-  poll_task.start()
+  StartThread( PollForMessagesInAnotherThread, filepath, old_contents )
 
   new_contents = """package com.youcompleteme;
 
@@ -765,8 +761,7 @@ def PollForMessages_AbortedWhenServerDies_test( app ):
 
     raise AssertionError( 'The poll request was not aborted in 5 tries' )
 
-  message_poll_task = threading.Thread( target=AwaitMessages )
-  message_poll_task.start()
+  message_poll_task = StartThread( AwaitMessages )
 
   app.post_json(
     '/run_completer_command',

--- a/ycmd/tests/java/server_management_test.py
+++ b/ycmd/tests/java/server_management_test.py
@@ -27,7 +27,6 @@ import functools
 import os
 import psutil
 import time
-import threading
 
 from mock import patch
 from hamcrest import ( assert_that,
@@ -324,8 +323,7 @@ def ServerManagement_ServerDiesWhileShuttingDown_test( app ):
   # shutdown code as a successful shutdown. We need to do the shutdown and
   # terminate in parallel as the post_json is a blocking call.
   with patch.object( completer.GetConnection(), 'WriteData' ):
-    stop_server_task = threading.Thread( target=StopServerInAnotherThread )
-    stop_server_task.start()
+    stop_server_task = utils.StartThread( StopServerInAnotherThread )
     process.terminate()
     stop_server_task.join()
 

--- a/ycmd/tests/typescript/debug_info_test.py
+++ b/ycmd/tests/typescript/debug_info_test.py
@@ -22,8 +22,8 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from hamcrest import ( assert_that, contains, empty, has_entries, has_entry,
-                       instance_of )
+from hamcrest import ( any_of, assert_that, contains, empty, has_entries,
+                       has_entry, instance_of )
 
 from ycmd.tests.typescript import SharedYcmd
 from ycmd.tests.test_utils import BuildRequest
@@ -38,12 +38,16 @@ def DebugInfo_test( app ):
       'name': 'TypeScript',
       'servers': contains( has_entries( {
         'name': 'TSServer',
-        'is_running': instance_of( bool ),
+        'is_running': True,
         'executable': instance_of( str ),
         'pid': instance_of( int ),
         'address': None,
         'port': None,
-        'logfiles': contains( instance_of( str ) )
+        'logfiles': contains( instance_of( str ) ),
+        'extras': contains( has_entries( {
+          'key': 'version',
+          'value': any_of( None, instance_of( str ) )
+        } ) )
       } ) ),
       'items': empty()
     } ) )

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -31,6 +31,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import threading
 
 
 # Idiom to import pathname2url, url2pathname, urljoin, and urlparse on Python 2
@@ -477,3 +478,10 @@ def GetCurrentDirectory():
   # OSError.
   except OSError:
     return tempfile.gettempdir()
+
+
+def StartThread( func, *args ):
+  thread = threading.Thread( target = func, args = args )
+  thread.daemon = True
+  thread.start()
+  return thread

--- a/ycmd/watchdog_plugin.py
+++ b/ycmd/watchdog_plugin.py
@@ -25,8 +25,9 @@ from builtins import *  # noqa
 import time
 import copy
 import logging
-from threading import Thread, Lock
+from threading import Lock
 from ycmd.handlers import ServerShutdown
+from ycmd.utils import StartThread
 
 _logger = logging.getLogger( __name__ )
 
@@ -59,9 +60,7 @@ class WatchdogPlugin( object ):
     self._last_request_time_lock = Lock()
     if idle_suicide_seconds <= 0:
       return
-    self._watchdog_thread = Thread( target = self._WatchdogMain )
-    self._watchdog_thread.daemon = True
-    self._watchdog_thread.start()
+    StartThread( self._WatchdogMain )
 
 
   def _GetLastRequestTime( self ):


### PR DESCRIPTION
This is more complicated than expected for a number of reasons:
 - we need to send the `status` request to get the version;
 - we can't just send the request when getting the debug info because we want to know the version even if TSServer crashed so we send the request immediately after the server started and store the result in a variable;
 - we don't want the request to block;
 - we need a lock for the variable because it can be accessed by multiple threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/973)
<!-- Reviewable:end -->
