### PR TITLE
[READY] Replace re module with regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ docs/package-lock.json
 
 # jdt.ls
 third_party/eclipse.jdt.ls
+
+# regex module
+third_party/regex/py*

--- a/run_tests.py
+++ b/run_tests.py
@@ -31,6 +31,8 @@ for folder in os.listdir( DIR_OF_THIRD_PARTY ):
   # sys.path the path is.
   if folder == 'python-future':
     continue
+  if folder == 'regex':
+    folder = p.join( folder, 'py{}'.format( sys.version_info[ 0 ] ) )
   python_path.append( p.abspath( p.join( DIR_OF_THIRD_PARTY, folder ) ) )
 if os.environ.get( 'PYTHONPATH' ) is not None:
   python_path.append( os.environ['PYTHONPATH'] )

--- a/third_party/regex/README.md
+++ b/third_party/regex/README.md
@@ -1,0 +1,8 @@
+ycmd regex module
+=================
+
+This is the directory where the `build.py` script installs the [regex][] module.
+The Python 2 and Python 3 versions of that module are installed in the `py2` and
+`py3` folders respectively.
+
+[regex]: https://pypi.python.org/pypi/regex/

--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -26,10 +26,10 @@ from builtins import *  # noqa
 # We don't want ycm_core inside Vim.
 import logging
 import os
-import re
 from collections import defaultdict
 from future.utils import iteritems
-from ycmd.utils import ToCppStringCompatible, ToUnicode, ReadFile, SplitLines
+from ycmd.utils import ( ToCppStringCompatible, ToUnicode, re, ReadFile,
+                         SplitLines )
 
 _logger = logging.getLogger( __name__ )
 

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -27,14 +27,13 @@ from collections import defaultdict
 from future.utils import iteritems
 import logging
 import os.path
-import re
 import textwrap
 import xml.etree.ElementTree
 from xml.etree.ElementTree import ParseError as XmlParseError
 
 import ycm_core
 from ycmd import responses
-from ycmd.utils import ToCppStringCompatible, ToUnicode, ToBytes
+from ycmd.utils import re, ToBytes, ToCppStringCompatible, ToUnicode
 from ycmd.completers.completer import Completer
 from ycmd.completers.cpp.flags import ( Flags, PrepareFlagsForClang,
                                         NoCompilationDatabase,

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -25,10 +25,9 @@ from builtins import *  # noqa
 import ycm_core
 import os
 import inspect
-import re
 from future.utils import PY2, native
 from ycmd import extra_conf_store
-from ycmd.utils import ( ToCppStringCompatible, OnMac, OnWindows, ToUnicode,
+from ycmd.utils import ( re, ToCppStringCompatible, OnMac, OnWindows, ToUnicode,
                          ToBytes, PathsToAllParentFolders )
 from ycmd.responses import NoExtraConfDetected
 

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -26,14 +26,13 @@ from collections import defaultdict
 from future.utils import itervalues
 import logging
 import os
-import re
 import requests
 import threading
 
 from ycmd.completers.completer import Completer
 from ycmd.completers.completer_utils import GetFileLines
 from ycmd.completers.cs import solutiondetection
-from ycmd.utils import CodepointOffsetToByteOffset, urljoin
+from ycmd.utils import CodepointOffsetToByteOffset, re, urljoin
 from ycmd import responses
 from ycmd import utils
 

--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -25,12 +25,11 @@ from builtins import *  # noqa
 
 import logging
 import os
-import re
 from collections import defaultdict
 
 from ycmd.completers.completer import Completer
 from ycmd.utils import ( ExpandVariablesInPath, GetCurrentDirectory, OnWindows,
-                         ToUnicode )
+                         re, ToUnicode )
 from ycmd import responses
 
 EXTRA_INFO_MAP = { 1 : '[File]', 2 : '[Dir]', 3 : '[File&Dir]' }

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -25,7 +25,6 @@ from builtins import *  # noqa
 import json
 import logging
 import os
-import re
 import subprocess
 import itertools
 import threading
@@ -38,6 +37,7 @@ from ycmd import responses
 from ycmd import utils
 from ycmd.completers.completer import Completer
 from ycmd.completers.completer_utils import GetFileLines
+from ycmd.utils import re
 
 SERVER_NOT_RUNNING_MESSAGE = 'TSServer is not running.'
 NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'

--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -24,8 +24,7 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-import re
-from ycmd.utils import SplitLines
+from ycmd.utils import re, SplitLines
 
 C_STYLE_COMMENT = "/\*(?:\n|.)*?\*/"
 CPP_STYLE_COMMENT = "//.*?$"

--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -188,5 +188,9 @@ def AddNearestThirdPartyFoldersToSysPath( filepath ):
                        os.path.realpath( os.path.join( path_to_third_party,
                                                        folder ) ) )
       continue
+
+    if folder == 'regex':
+      folder = os.path.join( folder, 'py{}'.format( sys.version_info[ 0 ] ) )
+
     sys.path.insert( 0, os.path.realpath( os.path.join( path_to_third_party,
                                                         folder ) ) )

--- a/ycmd/tests/completer_utils_test.py
+++ b/ycmd/tests/completer_utils_test.py
@@ -24,12 +24,12 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-import re
 from collections import defaultdict
 from future.utils import iteritems
 from nose.tools import eq_, ok_
 
 from ycmd.completers import completer_utils as cu
+from ycmd.utils import re
 
 
 def _ExtractPatternsFromFiletypeTriggerDict( triggerDict ):
@@ -78,7 +78,7 @@ def FiletypeDictUnion_Works_test():
 
 def PrepareTrigger_UnicodeTrigger_Test():
   regex = cu._PrepareTrigger( 'æ' )
-  eq_( regex.pattern, u'\\æ' )
+  eq_( regex.pattern, re.escape( u'æ' ) )
 
 
 def MatchesSemanticTrigger_Basic_test():

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -176,6 +176,29 @@ def GetCompletions_IdentifierCompleter_UnicodeQuery_InLine_test( app ):
   )
 
 
+@IsolatedYcmd()
+def GetCompletions_IdentifierCompleter_Unicode_MultipleCodePoints_test( app ):
+  # The first ō is on one code point while the second is on two ("o" + combining
+  # macron character).
+  event_data = BuildRequest( contents = 'fōo\nfōo',
+                             event_name = 'FileReadyToParse' )
+
+  app.post_json( '/event_notification', event_data )
+
+  # query is 'fo'
+  completion_data = BuildRequest( contents = 'fōo\nfōo\nfo',
+                                  line_num = 3,
+                                  column_num = 3 )
+  response_data = app.post_json( '/completions', completion_data ).json
+
+  eq_( 1, response_data[ 'completion_start_column' ] )
+  assert_that(
+    response_data[ 'completions' ],
+    has_items( CompletionEntryMatcher( 'fōo', '[ID]' ),
+               CompletionEntryMatcher( 'fōo', '[ID]' ) )
+  )
+
+
 @SharedYcmd
 @patch( 'ycmd.tests.test_utils.DummyCompleter.CandidatesList',
         return_value = [ 'foo', 'bar', 'qux' ] )

--- a/ycmd/tests/server_utils_test.py
+++ b/ycmd/tests/server_utils_test.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
+from future.utils import PY2
 from hamcrest import ( assert_that, calling, contains, contains_inanyorder,
                        empty, equal_to, has_length, raises )
 from mock import patch
@@ -37,7 +38,7 @@ from ycmd.tests import PathToTestFile
 
 DIR_OF_THIRD_PARTY = os.path.abspath(
   os.path.join( os.path.dirname( __file__ ), '..', '..', 'third_party' ) )
-THIRD_PARTY_FOLDERS = (
+THIRD_PARTY_FOLDERS = [
   os.path.join( DIR_OF_THIRD_PARTY, 'bottle' ),
   os.path.join( DIR_OF_THIRD_PARTY, 'frozendict' ),
   os.path.join( DIR_OF_THIRD_PARTY, 'godef' ),
@@ -49,7 +50,14 @@ THIRD_PARTY_FOLDERS = (
   os.path.join( DIR_OF_THIRD_PARTY, 'tern_runtime' ),
   os.path.join( DIR_OF_THIRD_PARTY, 'waitress' ),
   os.path.join( DIR_OF_THIRD_PARTY, 'eclipse.jdt.ls' ),
-)
+]
+if PY2:
+  THIRD_PARTY_FOLDERS.append(
+    os.path.join( DIR_OF_THIRD_PARTY, 'regex', 'py2' ) )
+else:
+  THIRD_PARTY_FOLDERS.append(
+    os.path.join( DIR_OF_THIRD_PARTY, 'regex', 'py3' ) )
+
 
 
 @patch( 'ycmd.server_utils._logger', autospec = True )

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -48,6 +48,17 @@ else:
   from urllib.request import pathname2url, url2pathname  # noqa
 
 
+# We replace the re module with regex as it has better support for characters on
+# multiple code points. However, this module has a compiled component so we
+# can't import it in YCM if it is built for a different version of Python (e.g.
+# if YCM is running on Python 2 while ycmd on Python 3). We fall back to the re
+# module in that case.
+try:
+  import regex as re
+except ImportError: # pragma: no cover
+  import re # noqa
+
+
 # Creation flag to disable creating a console window on Windows. See
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863.aspx
 CREATE_NO_WINDOW = 0x08000000


### PR DESCRIPTION
The `\w` pattern from the `re` module does not match Unicode characters with combining marks (e.g. `e` + acute accent). This causes identifiers that contains such characters to not be properly extracted from the buffer. The solution is to replace the `re` module with [regex](https://pypi.python.org/pypi/regex/). This module has a compiled component so we can't simply vendor it. Instead, we download it in the `build.py` script as a pip package and install it to `third_party/regex` in the `py2` folder for Python 2 and `py3` for Python 3. We use two folders because YCM is going to import this module and if it's running on a different version of Python than ycmd, this will fail. We need to fall back to the `re` module in that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/974)
<!-- Reviewable:end -->
