### PR TITLE
[READY] Add FixIt command to TypeScript completer

### DIFF
--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2013 Google Inc.
-#               2017 ycmd contributors
+# Copyright (C) 2013-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -152,12 +151,19 @@ def BuildRangeData( source_range ):
 
 
 class Diagnostic( object ):
-  def __init__ ( self, ranges, location, location_extent, text, kind ):
+  def __init__( self,
+                ranges,
+                location,
+                location_extent,
+                text,
+                kind,
+                fixits = [] ):
     self.ranges_ = ranges
     self.location_ = location
     self.location_extent_ = location_extent
     self.text_ = text
     self.kind_ = kind
+    self.fixits_ = fixits
 
 
 class FixIt( object ):
@@ -169,7 +175,7 @@ class FixIt( object ):
   must be byte offsets into the UTF-8 encoded version of the appropriate
   buffer.
   """
-  def __init__ ( self, location, chunks, text = '' ):
+  def __init__( self, location, chunks, text = '' ):
     """location of type Location, chunks of type list<FixItChunk>"""
     self.location = location
     self.chunks = chunks
@@ -179,7 +185,7 @@ class FixIt( object ):
 class FixItChunk( object ):
   """An individual replacement within a FixIt (aka Refactor)"""
 
-  def __init__ ( self, replacement_text, range ):
+  def __init__( self, replacement_text, range ):
     """replacement_text of type string, range of type Range"""
     self.replacement_text = replacement_text
     self.range = range
@@ -188,7 +194,7 @@ class FixItChunk( object ):
 class Range( object ):
   """Source code range relating to a diagnostic or FixIt (aka Refactor)."""
 
-  def __init__ ( self, start, end ):
+  def __init__( self, start, end ):
     "start of type Location, end of type Location"""
     self.start_ = start
     self.end_ = end
@@ -197,7 +203,7 @@ class Range( object ):
 class Location( object ):
   """Source code location for a diagnostic or FixIt (aka Refactor)."""
 
-  def __init__ ( self, line, column, filename ):
+  def __init__( self, line, column, filename ):
     """Line is 1-based line, column is 1-based column byte offset, filename is
     absolute path of the file"""
     self.line_number_ = line
@@ -221,15 +227,13 @@ def BuildDiagnosticData( diagnostic ):
   kind = ( diagnostic.kind_.name if hasattr( diagnostic.kind_, 'name' )
            else diagnostic.kind_ )
 
-  fixits = ( diagnostic.fixits_ if hasattr( diagnostic, 'fixits_' ) else [] )
-
   return {
     'ranges': [ BuildRangeData( x ) for x in diagnostic.ranges_ ],
     'location': BuildLocationData( diagnostic.location_ ),
     'location_extent': BuildRangeData( diagnostic.location_extent_ ),
     'text': diagnostic.text_,
     'kind': kind,
-    'fixit_available': len( fixits ) > 0,
+    'fixit_available': len( diagnostic.fixits_ ) > 0,
   }
 
 

--- a/ycmd/tests/typescript/diagnostics_test.py
+++ b/ycmd/tests/typescript/diagnostics_test.py
@@ -56,7 +56,7 @@ def Diagnostics_FileReadyToParse_test( app ):
         'location': LocationMatcher( filepath, 17, 5 ),
         'location_extent': RangeMatcher( filepath, ( 17, 5 ), ( 17, 6 ) ),
         'ranges': contains( RangeMatcher( filepath, ( 17, 5 ), ( 17, 6 ) ) ),
-        'fixit_available': False
+        'fixit_available': True
       } ),
       has_entries( {
         'kind': 'ERROR',
@@ -64,7 +64,7 @@ def Diagnostics_FileReadyToParse_test( app ):
         'location': LocationMatcher( filepath, 35, 5 ),
         'location_extent': RangeMatcher( filepath, ( 35, 5 ), ( 35, 22 ) ),
         'ranges': contains( RangeMatcher( filepath, ( 35, 5 ), ( 35, 22 ) ) ),
-        'fixit_available': False
+        'fixit_available': True
       } ),
       has_entries( {
         'kind': 'ERROR',


### PR DESCRIPTION
This is implemented similarly to the Clang completer i.e. the FixIts are stored in the diagnostics. Demo:

![typescript-fixit](https://user-images.githubusercontent.com/10026824/38051060-6ec280f0-32cd-11e8-9d45-2a790baf7582.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/976)
<!-- Reviewable:end -->
