### PR TITLE
[READY] Add Format command to TypeScript completer

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2015-2016 Google Inc.
-#               2016-2017 ycmd contributors
+# Copyright (C) 2015-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -444,6 +443,8 @@ class TypeScriptCompleter( Completer ):
                            self._GetDoc( request_data ) ),
       'RefactorRename' : ( lambda self, request_data, args:
                            self._RefactorRename( request_data, args ) ),
+      'Format'         : ( lambda self, request_data, args:
+                           self._Format( request_data ) ),
     }
 
 
@@ -677,6 +678,43 @@ class TypeScriptCompleter( Completer ):
     ] )
 
 
+  def _Format( self, request_data ):
+    filepath = request_data[ 'filepath' ]
+
+    self._Reload( request_data )
+
+    # TODO: support all formatting options. See
+    # https://github.com/Microsoft/TypeScript/blob/72e92a055823f1ade97d03d7526dbab8be405dde/lib/protocol.d.ts#L2060-L2077
+    # for the list of options. While not standard, a way to support these
+    # options, which is already adopted by a number of clients, would be to read
+    # the "formatOptions" field in the tsconfig.json file.
+    options = request_data[ 'options' ]
+    self._SendRequest( 'configure', {
+      'file': filepath,
+      'formatOptions': {
+        'tabSize': options[ 'tab_size' ],
+        'indentSize': options[ 'tab_size' ],
+        'convertTabsToSpaces': options[ 'insert_spaces' ],
+      }
+    } )
+
+    response = self._SendRequest( 'format',
+                                  _BuildTsFormatRange( request_data ) )
+
+    contents = GetFileLines( request_data, filepath )
+    chunks = [ _BuildFixItChunkForRange( text_edit[ 'newText' ],
+                                         contents,
+                                         filepath,
+                                         text_edit ) for text_edit in response ]
+
+    location = responses.Location( request_data[ 'line_num' ],
+                                   request_data[ 'column_num' ],
+                                   filepath )
+    return responses.BuildFixItResponse( [
+      responses.FixIt( location, chunks )
+    ] )
+
+
   def _RestartServer( self, request_data ):
     with self._server_lock:
       self._StopServer()
@@ -770,7 +808,7 @@ def _BuildFixItChunkForRange( new_name,
                               file_contents,
                               file_name,
                               source_range ):
-  """ returns list FixItChunk for a tsserver source range """
+  """Returns list FixItChunk for a tsserver source range."""
   return responses.FixItChunk(
       new_name,
       responses.Range(
@@ -785,10 +823,9 @@ def _BuildFixItChunkForRange( new_name,
 
 
 def _BuildFixItChunksForFile( request_data, new_name, file_replacement ):
-  """ returns a list of FixItChunk for each replacement range for the
-  supplied file"""
-
-  # On windows, tsserver annoyingly returns file path as C:/blah/blah,
+  """Returns a list of FixItChunk for each replacement range for the supplied
+  file."""
+  # On Windows, TSServer annoyingly returns file path as C:/blah/blah,
   # whereas all other paths in Python are of the C:\\blah\\blah form. We use
   # normpath to have python do the conversion for us.
   file_path = os.path.normpath( file_replacement[ 'file' ] )
@@ -800,8 +837,42 @@ def _BuildFixItChunksForFile( request_data, new_name, file_replacement ):
 def _BuildLocation( file_contents, filename, line, offset ):
   return responses.Location(
     line = line,
-    # tsserver returns codepoint offsets, but we need byte offsets, so we must
-    # convert
+    # TSServer returns codepoint offsets, but we need byte offsets, so we must
+    # convert.
     column = utils.CodepointOffsetToByteOffset( file_contents[ line - 1 ],
                                                 offset ),
     filename = filename )
+
+
+def _BuildTsFormatRange( request_data ):
+  filepath = request_data[ 'filepath' ]
+  lines = GetFileLines( request_data, filepath )
+
+  if 'range' not in request_data:
+    return {
+      'file': filepath,
+      'line': 1,
+      'offset': 1,
+      'endLine': len( lines ),
+      'endOffset': len( lines[ - 1 ] ) + 1
+    }
+
+  start = request_data[ 'range' ][ 'start' ]
+  start_line_num = start[ 'line_num' ]
+  start_line_value = lines[ start_line_num - 1 ]
+  start_codepoint = utils.ByteOffsetToCodepointOffset( start_line_value,
+                                                       start[ 'column_num' ] )
+
+  end = request_data[ 'range' ][ 'end' ]
+  end_line_num = end[ 'line_num' ]
+  end_line_value = lines[ end_line_num - 1 ]
+  end_codepoint = utils.ByteOffsetToCodepointOffset( end_line_value,
+                                                     end[ 'column_num' ] )
+
+  return {
+    'file': filepath,
+    'line': start_line_num,
+    'offset': start_codepoint,
+    'endLine': end_line_num,
+    'endOffset': end_codepoint
+  }

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -1117,7 +1117,7 @@ def Subcommands_Format_WholeFile_Spaces_test( app ):
                              'Test.java' )
   RunTest( app, {
     'description': 'Formatting is applied on the whole file '
-                   'with tabs composed of 4 spaces by default',
+                   'with tabs composed of 4 spaces',
     'request': {
       'command': 'Format',
       'filepath': filepath,
@@ -1299,7 +1299,7 @@ def Subcommands_Format_Range_Spaces_test( app ):
                              'Test.java' )
   RunTest( app, {
     'description': 'Formatting is applied on some part of the file '
-                   'with tabs composed of 4 spaces by default',
+                   'with tabs composed of 4 spaces',
     'request': {
       'command': 'Format',
       'filepath': filepath,

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -82,6 +82,7 @@ def Subcommands_DefinedSubcommands_test( app ):
   assert_that(
     app.post_json( '/defined_subcommands', subcommands_data ).json,
     contains_inanyorder(
+      'Format',
       'GoTo',
       'GoToDeclaration',
       'GoToDefinition',
@@ -93,6 +94,318 @@ def Subcommands_DefinedSubcommands_test( app ):
       'RestartServer'
     )
   )
+
+
+@SharedYcmd
+def Subcommands_Format_WholeFile_Spaces_test( app ):
+  filepath = PathToTestFile( 'test.ts' )
+  RunTest( app, {
+    'description': 'Formatting is applied on the whole file '
+                   'with tabs composed of 4 spaces',
+    'request': {
+      'command': 'Format',
+      'filepath': filepath,
+      'options': {
+        'tab_size': 4,
+        'insert_spaces': True
+      }
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+
+            ChunkMatcher( '    ',
+                          LocationMatcher( filepath,  3,  1 ),
+                          LocationMatcher( filepath,  3,  3 ) ),
+
+            ChunkMatcher( '    ',
+                          LocationMatcher( filepath,  4,  1 ),
+                          LocationMatcher( filepath,  4,  3 ) ),
+
+            ChunkMatcher( ' ',
+                          LocationMatcher( filepath,  4, 14 ),
+                          LocationMatcher( filepath,  4, 14 ) ),
+
+            ChunkMatcher( '    ',
+                          LocationMatcher( filepath,  5,  1 ),
+                          LocationMatcher( filepath,  5,  3 ) ),
+
+            ChunkMatcher( ' ',
+                          LocationMatcher( filepath,  5, 14 ),
+                          LocationMatcher( filepath,  5, 14 ) ),
+
+            ChunkMatcher( '    ',
+                          LocationMatcher( filepath,  6,  1 ),
+                          LocationMatcher( filepath,  6,  3 ) ),
+
+            ChunkMatcher( '        ',
+                          LocationMatcher( filepath,  7,  1 ),
+                          LocationMatcher( filepath,  7,  5 ) ),
+
+            ChunkMatcher( '            ',
+                          LocationMatcher( filepath,  8,  1 ),
+                          LocationMatcher( filepath,  8,  7 ) ),
+
+            ChunkMatcher( '            ',
+                          LocationMatcher( filepath,  9,  1 ),
+                          LocationMatcher( filepath,  9,  7 ) ),
+
+            ChunkMatcher( '        ',
+                          LocationMatcher( filepath, 10,  1 ),
+                          LocationMatcher( filepath, 10,  5 ) ),
+
+            ChunkMatcher( '    ',
+                          LocationMatcher( filepath, 11,  1 ),
+                          LocationMatcher( filepath, 11,  3 ) ),
+
+            ChunkMatcher( ' ',
+                          LocationMatcher( filepath, 11,  6 ),
+                          LocationMatcher( filepath, 11,  6 ) ),
+
+            ChunkMatcher( '    ',
+                          LocationMatcher( filepath, 27,  1 ),
+                          LocationMatcher( filepath, 27,  3 ) ),
+
+            ChunkMatcher( '     ',
+                          LocationMatcher( filepath, 28,  1 ),
+                          LocationMatcher( filepath, 28,  4 ) ),
+
+            ChunkMatcher( '     ',
+                          LocationMatcher( filepath, 29,  1 ),
+                          LocationMatcher( filepath, 29,  4 ) ),
+
+            ChunkMatcher( '    ',
+                          LocationMatcher( filepath, 30,  1 ),
+                          LocationMatcher( filepath, 30,  3 ) ),
+
+            ChunkMatcher( ' ',
+                          LocationMatcher( filepath, 30, 17 ),
+                          LocationMatcher( filepath, 30, 17 ) ),
+
+          )
+        } ) )
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_Format_WholeFile_Tabs_test( app ):
+  filepath = PathToTestFile( 'test.ts' )
+  RunTest( app, {
+    'description': 'Formatting is applied on the whole file '
+                   'with tabs composed of 2 spaces',
+    'request': {
+      'command': 'Format',
+      'filepath': filepath,
+      'options': {
+        'tab_size': 4,
+        'insert_spaces': False
+      }
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+
+            ChunkMatcher( '\t',
+                          LocationMatcher( filepath,  3,  1 ),
+                          LocationMatcher( filepath,  3,  3 ) ),
+
+            ChunkMatcher( '\t',
+                          LocationMatcher( filepath,  4,  1 ),
+                          LocationMatcher( filepath,  4,  3 ) ),
+
+            ChunkMatcher( ' ',
+                          LocationMatcher( filepath,  4, 14 ),
+                          LocationMatcher( filepath,  4, 14 ) ),
+
+            ChunkMatcher( '\t',
+                          LocationMatcher( filepath,  5,  1 ),
+                          LocationMatcher( filepath,  5,  3 ) ),
+
+            ChunkMatcher( ' ',
+                          LocationMatcher( filepath,  5, 14 ),
+                          LocationMatcher( filepath,  5, 14 ) ),
+
+            ChunkMatcher( '\t',
+                          LocationMatcher( filepath,  6,  1 ),
+                          LocationMatcher( filepath,  6,  3 ) ),
+
+            ChunkMatcher( '\t\t',
+                          LocationMatcher( filepath,  7,  1 ),
+                          LocationMatcher( filepath,  7,  5 ) ),
+
+            ChunkMatcher( '\t\t\t',
+                          LocationMatcher( filepath,  8,  1 ),
+                          LocationMatcher( filepath,  8,  7 ) ),
+
+            ChunkMatcher( '\t\t\t',
+                          LocationMatcher( filepath,  9,  1 ),
+                          LocationMatcher( filepath,  9,  7 ) ),
+
+            ChunkMatcher( '\t\t',
+                          LocationMatcher( filepath, 10,  1 ),
+                          LocationMatcher( filepath, 10,  5 ) ),
+
+            ChunkMatcher( '\t',
+                          LocationMatcher( filepath, 11,  1 ),
+                          LocationMatcher( filepath, 11,  3 ) ),
+
+            ChunkMatcher( ' ',
+                          LocationMatcher( filepath, 11,  6 ),
+                          LocationMatcher( filepath, 11,  6 ) ),
+
+            ChunkMatcher( '\t',
+                          LocationMatcher( filepath, 27,  1 ),
+                          LocationMatcher( filepath, 27,  3 ) ),
+
+            ChunkMatcher( '\t ',
+                          LocationMatcher( filepath, 28,  1 ),
+                          LocationMatcher( filepath, 28,  4 ) ),
+
+            ChunkMatcher( '\t ',
+                          LocationMatcher( filepath, 29,  1 ),
+                          LocationMatcher( filepath, 29,  4 ) ),
+
+            ChunkMatcher( '\t',
+                          LocationMatcher( filepath, 30,  1 ),
+                          LocationMatcher( filepath, 30,  3 ) ),
+
+            ChunkMatcher( ' ',
+                          LocationMatcher( filepath, 30, 17 ),
+                          LocationMatcher( filepath, 30, 17 ) ),
+
+          )
+        } ) )
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_Format_Range_Spaces_test( app ):
+  filepath = PathToTestFile( 'test.ts' )
+  RunTest( app, {
+    'description': 'Formatting is applied on some part of the file '
+                   'with tabs composed of 4 spaces by default',
+    'request': {
+      'command': 'Format',
+      'filepath': filepath,
+      'range': {
+        'start': {
+          'line_num': 6,
+          'column_num': 3,
+        },
+        'end': {
+          'line_num': 11,
+          'column_num': 6
+        }
+      },
+      'options': {
+        'tab_size': 4,
+        'insert_spaces': True
+      }
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+
+            ChunkMatcher( '    ',
+                          LocationMatcher( filepath,  6,  1 ),
+                          LocationMatcher( filepath,  6,  3 ) ),
+
+            ChunkMatcher( '        ',
+                          LocationMatcher( filepath,  7,  1 ),
+                          LocationMatcher( filepath,  7,  5 ) ),
+
+            ChunkMatcher( '            ',
+                          LocationMatcher( filepath,  8,  1 ),
+                          LocationMatcher( filepath,  8,  7 ) ),
+
+            ChunkMatcher( '            ',
+                          LocationMatcher( filepath,  9,  1 ),
+                          LocationMatcher( filepath,  9,  7 ) ),
+
+            ChunkMatcher( '        ',
+                          LocationMatcher( filepath, 10,  1 ),
+                          LocationMatcher( filepath, 10,  5 ) ),
+
+            ChunkMatcher( '    ',
+                          LocationMatcher( filepath, 11,  1 ),
+                          LocationMatcher( filepath, 11,  3 ) ),
+
+          )
+        } ) )
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_Format_Range_Tabs_test( app ):
+  filepath = PathToTestFile( 'test.ts' )
+  RunTest( app, {
+    'description': 'Formatting is applied on some part of the file '
+                   'with tabs instead of spaces',
+    'request': {
+      'command': 'Format',
+      'filepath': filepath,
+      'range': {
+        'start': {
+          'line_num': 6,
+          'column_num': 3,
+        },
+        'end': {
+          'line_num': 11,
+          'column_num': 6
+        }
+      },
+      'options': {
+        'tab_size': 4,
+        'insert_spaces': False
+      }
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+
+            ChunkMatcher( '\t',
+                          LocationMatcher( filepath,  6,  1 ),
+                          LocationMatcher( filepath,  6,  3 ) ),
+
+            ChunkMatcher( '\t\t',
+                          LocationMatcher( filepath,  7,  1 ),
+                          LocationMatcher( filepath,  7,  5 ) ),
+
+            ChunkMatcher( '\t\t\t',
+                          LocationMatcher( filepath,  8,  1 ),
+                          LocationMatcher( filepath,  8,  7 ) ),
+
+            ChunkMatcher( '\t\t\t',
+                          LocationMatcher( filepath,  9,  1 ),
+                          LocationMatcher( filepath,  9,  7 ) ),
+
+            ChunkMatcher( '\t\t',
+                          LocationMatcher( filepath, 10,  1 ),
+                          LocationMatcher( filepath, 10,  5 ) ),
+
+            ChunkMatcher( '\t',
+                          LocationMatcher( filepath, 11,  1 ),
+                          LocationMatcher( filepath, 11,  3 ) ),
+
+          )
+        } ) )
+      } )
+    }
+  } )
 
 
 @SharedYcmd


### PR DESCRIPTION
Like the Java `Format` command:

![typescript-format](https://user-images.githubusercontent.com/10026824/38051368-56f43256-32ce-11e8-8f48-9feb14e1493b.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/977)
<!-- Reviewable:end -->
