### PR TITLE
[READY] Add OrganizeImports command to TypeScript completer

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -419,6 +419,8 @@ class TypeScriptCompleter( Completer ):
                            self._GetDoc( request_data ) ),
       'FixIt'          : ( lambda self, request_data, args:
                            self._FixIt( request_data, args ) ),
+      'OrganizeImports': ( lambda self, request_data, args:
+                           self._OrganizeImports( request_data ) ),
       'RefactorRename' : ( lambda self, request_data, args:
                            self._RefactorRename( request_data, args ) ),
     }
@@ -661,6 +663,28 @@ class TypeScriptCompleter( Completer ):
         fixits.extend( diagnostic.fixits_ )
 
     return responses.BuildFixItResponse( fixits )
+
+
+  def _OrganizeImports( self, request_data ):
+    self._Reload( request_data )
+
+    filepath = request_data[ 'filepath' ]
+    changes = self._SendRequest( 'organizeImports', {
+      'scope': {
+        'type': 'file',
+        'args': {
+          'file': filepath
+        }
+      }
+    } )
+
+    location = responses.Location( request_data[ 'line_num' ],
+                                   request_data[ 'column_num' ],
+                                   filepath )
+    return responses.BuildFixItResponse( [
+      responses.FixIt( location,
+                       _BuildFixItForChanges( request_data, changes ) )
+    ] )
 
 
   def _RefactorRename( self, request_data, args ):

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Copyright (C) 2015 ycmd contributors
+# Copyright (C) 2015-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -100,6 +100,7 @@ def Subcommands_DefinedSubcommands_test( app ):
       'GetType',
       'GoToReferences',
       'FixIt',
+      'OrganizeImports',
       'RefactorRename',
       'RestartServer'
     )
@@ -422,6 +423,42 @@ def Subcommands_FixIt_test( app ):
             'location': LocationMatcher( PathToTestFile( 'test.ts' ), 35, 12 )
           } )
         )
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_OrganizeImports_test( app ):
+  filepath = PathToTestFile( 'imports.ts' )
+  RunTest( app, {
+    'description': 'OrganizeImports removes unused imports, '
+                   'coalesces imports from the same module, and sorts them',
+    'request': {
+      'command': 'OrganizeImports',
+      'filepath': filepath,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+            ChunkMatcher(
+              matches_regexp(
+                'import \* as lib from "library";\r?\n'
+                'import func, { func1, func2 } from "library";\r?\n' ),
+              LocationMatcher( filepath,  1, 1 ),
+              LocationMatcher( filepath,  2, 1 ) ),
+            ChunkMatcher(
+              '',
+              LocationMatcher( filepath,  5, 1 ),
+              LocationMatcher( filepath,  6, 1 ) ),
+            ChunkMatcher(
+              '',
+              LocationMatcher( filepath,  9, 1 ),
+              LocationMatcher( filepath, 10, 1 ) ),
+          )
+        } ) )
       } )
     }
   } )

--- a/ycmd/tests/typescript/testdata/imports.ts
+++ b/ycmd/tests/typescript/testdata/imports.ts
@@ -1,0 +1,12 @@
+import func from "library";
+
+func();
+
+import * as lib from "library";
+
+lib.func();
+
+import { func1, func2 } from "library";
+
+func1();
+func2();


### PR DESCRIPTION
A recent addition to TSServer:

![typescript-organize-imports](https://user-images.githubusercontent.com/10026824/38051504-cea1d5d8-32ce-11e8-8539-f1fa3e15122d.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/978)
<!-- Reviewable:end -->
