### PR TITLE
Fix building with system boost on Fedora

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -65,6 +65,8 @@ if ( EXISTS /etc/redhat-release )
     set( DISTRIBUTION "Red Hat" )
   elseif ( CONTENTS MATCHES "CentOS" )
     set( DISTRIBUTION "CentOS" )
+  elseif ( CONTENTS MATCHES "Fedora" )
+    set( DISTRIBUTION "Fedora" )
   endif()
 # Gentoo detection. Needed because Gentoo is a special snowflake that puts
 # llvm in weird places.

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -197,7 +197,7 @@ if ( USE_SYSTEM_BOOST )
   # Gentoo allows a very convenient system-wide python version switching
   # that handles symlinks of everything needed, including Boost.Python.
   # Thus, on Gentoo, we want to always link against boost_python.
-  if( USE_PYTHON2 OR DISTRIBUTION STREQUAL "Gentoo" )
+  if( USE_PYTHON2 OR DISTRIBUTION STREQUAL "Gentoo" OR DISTRIBUTION STREQUAL "Fedora" )
     list( APPEND Boost_COMPONENTS python )
   else()
     list( APPEND Boost_COMPONENTS python3 )


### PR DESCRIPTION
Without this ycm_core.so builds but doesn't have an init function exported. Which is really confusing -- if you try to run in py3 you get an error message about ycm_core.so being built for py2, and vice versa if you try to run in py2.

I would much rather the code to an autotools-style linking test to find the right boost lib, but I don't know enough about CMake to contribute that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/979)
<!-- Reviewable:end -->
