### PR TITLE
[READY] Improve java project detection heuristics

### DIFF
--- a/ycmd/tests/java/server_management_test.py
+++ b/ycmd/tests/java/server_management_test.py
@@ -162,6 +162,28 @@ def ServerManagement_ProjectDetection_MavenParent_test( app ):
                _ProjectDirectoryMatcher( project ) )
 
 
+@TidyJDTProjectFiles( PathToTestFile( 'simple_maven_project',
+                                      'simple_submodule' ) )
+@TidyJDTProjectFiles( PathToTestFile( 'simple_maven_project' ) )
+@IsolatedYcmd
+def ServerManagement_ProjectDetection_MavenParent_Submodule_test( app ):
+  StartJavaCompleterServerInDirectory( app,
+                                       PathToTestFile( 'simple_maven_project',
+                                                       'simple_submodule',
+                                                       'src',
+                                                       'main',
+                                                       'java',
+                                                       'com',
+                                                       'test' ) )
+
+  project = PathToTestFile( 'simple_maven_project' )
+
+  # Run the debug info to check that we have the correct project dir
+  request_data = BuildRequest( filetype = 'java' )
+  assert_that( app.post_json( '/debug_info', request_data ).json,
+               _ProjectDirectoryMatcher( project ) )
+
+
 @TidyJDTProjectFiles( PathToTestFile( 'simple_gradle_project' ) )
 @IsolatedYcmd
 def ServerManagement_ProjectDetection_GradleParent_test( app ):

--- a/ycmd/tests/java/testdata/simple_maven_project/pom.xml
+++ b/ycmd/tests/java/testdata/simple_maven_project/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.test</groupId>
   <artifactId>simple_maven_project</artifactId>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
   <version>1.0-SNAPSHOT</version>
   <name>simple_maven_project</name>
   <url>http://maven.apache.org</url>
@@ -15,4 +15,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <modules>
+    <module>simple_submodule</module>
+  </modules>
 </project>


### PR DESCRIPTION
It's not uncommon for multi-layer projects to be defined with having
build.gradle, pom.xml and even .project in a hierarchy. This is
particularly common on larger (non-toy) projects.

To cater for this, we improve the java project detection heuristics to
first search for the "nearest" project file, then continue searching to
find the last in any chain of consecutive project files of the same
type. This allows for opening files within sub-projects to load the
top-most project as the project directory.

Example structure:

```
Project/
   - build.gradle
   - SubprojectA/
     - build.gradle
     - src/java/main/com/blah/blah/blah/suba/SubA.java
   - SubprojectB/
     - build.gradle
     - src/java/main/com/blah/blah/blah/subb/SubB.java
```

If opening SubB.java, the project path should be `Project/` not `SubprojectB`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/981)
<!-- Reviewable:end -->
