### PR TITLE
[RFC] Allow the user to manually specify a project path

### DIFF
--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -67,6 +67,7 @@ def Subcommands_DefinedSubcommands_test( app ):
                  'GetDoc',
                  'GetType',
                  'GoToReferences',
+                 'OpenProject',
                  'OrganizeImports',
                  'RefactorRename',
                  'RestartServer' ] ),


### PR DESCRIPTION
It may not always be possible to correctly identify the project
directory heuristically. We therefore allow the user to manually open a
"project directory" with a new 'OpenProject' command. This overrides our
heuristics until the server is restarted.

This is in conjunction with #981 to help with using more complex projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/982)
<!-- Reviewable:end -->
