### PR TITLE
[READY] Improve TeX identifier regex

### DIFF
--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Copyright (C) 2014 Google Inc.
+# Copyright (C) 2014-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -144,17 +144,19 @@ FILETYPE_TO_IDENTIFIER_REGEX = {
     'haskell': re.compile( r"[_a-zA-Z][\w']+", re.UNICODE ),
 
     # Spec: ?
-    # Labels like \label{fig:foobar} are very common
-    'tex': re.compile( r"[_a-zA-Z:-]+", re.UNICODE ),
+    # Colons are often used in labels (e.g. \label{fig:foobar}) so we accept
+    # them in the middle of an identifier but not at its extremities. We also
+    # accept dashes for compound words.
+    'tex': re.compile( r"[^\W\d](?:[\w:-]*\w)?", re.UNICODE ),
 
     # Spec: http://doc.perl6.org/language/syntax
     'perl6': re.compile( r"[_a-zA-Z](?:\w|[-'](?=[_a-zA-Z]))*", re.UNICODE ),
 
     # https://www.scheme.com/tspl4/grammar.html#grammar:symbols
-    'scheme': re.compile(r"\+|\-|\.\.\.|"
-                         r"(?:->|(:?\\x[0-9A-Fa-f]+;|[!$%&*/:<=>?~^]|[^\W\d]))"
-                         r"(?:\\x[0-9A-Fa-f]+;|[-+.@!$%&*/:<=>?~^\w])*",
-                         re.UNICODE),
+    'scheme': re.compile( r"\+|\-|\.\.\.|"
+                          r"(?:->|(:?\\x[0-9A-Fa-f]+;|[!$%&*/:<=>?~^]|[^\W\d]))"
+                          r"(?:\\x[0-9A-Fa-f]+;|[-+.@!$%&*/:<=>?~^\w])*",
+                          re.UNICODE ),
 }
 
 FILETYPE_TO_IDENTIFIER_REGEX[ 'typescript' ] = (

--- a/ycmd/tests/identifier_utils_test.py
+++ b/ycmd/tests/identifier_utils_test.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (C) 2013 Google Inc.
+# Copyright (C) 2013-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -192,10 +192,10 @@ def IsIdentifier_Css_test():
 
   ok_( not iu.IsIdentifier( '-3b', 'css' ) )
   ok_( not iu.IsIdentifier( '-3' , 'css' ) )
-  ok_( not iu.IsIdentifier( '--', 'css' ) )
+  ok_( not iu.IsIdentifier( '--' , 'css' ) )
   ok_( not iu.IsIdentifier( '3'  , 'css' ) )
-  ok_( not iu.IsIdentifier( '' , 'css' ) )
-  ok_( not iu.IsIdentifier( '€', 'css' ) )
+  ok_( not iu.IsIdentifier( ''   , 'css' ) )
+  ok_( not iu.IsIdentifier( '€'  , 'css' ) )
 
 
 def IsIdentifier_R_test():
@@ -217,7 +217,7 @@ def IsIdentifier_R_test():
   ok_( not iu.IsIdentifier( '123', 'r' ) )
   ok_( not iu.IsIdentifier( '_1a', 'r' ) )
   ok_( not iu.IsIdentifier( '_a' , 'r' ) )
-  ok_( not iu.IsIdentifier( '' , 'r' ) )
+  ok_( not iu.IsIdentifier( ''   , 'r' ) )
 
 
 def IsIdentifier_Clojure_test():
@@ -243,7 +243,7 @@ def IsIdentifier_Clojure_test():
   ok_( not iu.IsIdentifier( '9'    , 'clojure' ) )
   ok_( not iu.IsIdentifier( 'a/b/c', 'clojure' ) )
   ok_( not iu.IsIdentifier( '(a)'  , 'clojure' ) )
-  ok_( not iu.IsIdentifier( '' , 'clojure' ) )
+  ok_( not iu.IsIdentifier( ''     , 'clojure' ) )
 
 
 def IsIdentifier_Elisp_test():
@@ -257,7 +257,7 @@ def IsIdentifier_Elisp_test():
   ok_( not iu.IsIdentifier( '9'    , 'elisp' ) )
   ok_( not iu.IsIdentifier( 'a/b/c', 'elisp' ) )
   ok_( not iu.IsIdentifier( '(a)'  , 'elisp' ) )
-  ok_( not iu.IsIdentifier( '' , 'elisp' ) )
+  ok_( not iu.IsIdentifier( ''     , 'elisp' ) )
 
 
 def IsIdentifier_Haskell_test():
@@ -271,19 +271,22 @@ def IsIdentifier_Haskell_test():
   ok_( not iu.IsIdentifier( "'x", 'haskell' ) )
   ok_( not iu.IsIdentifier( "9x", 'haskell' ) )
   ok_( not iu.IsIdentifier( "9" , 'haskell' ) )
-  ok_( not iu.IsIdentifier( '' , 'haskell' ) )
+  ok_( not iu.IsIdentifier( ''  , 'haskell' ) )
 
 
 def IsIdentifier_Tex_test():
-  ok_( iu.IsIdentifier( 'foo', 'tex' ) )
-  ok_( iu.IsIdentifier( 'fig:foo', 'tex' ) )
+  ok_( iu.IsIdentifier( 'foo'        , 'tex' ) )
+  ok_( iu.IsIdentifier( 'fig:foo'    , 'tex' ) )
   ok_( iu.IsIdentifier( 'fig:foo-bar', 'tex' ) )
   ok_( iu.IsIdentifier( 'sec:summary', 'tex' ) )
-  ok_( iu.IsIdentifier( 'eq:bar_foo', 'tex' ) )
+  ok_( iu.IsIdentifier( 'eq:bar_foo' , 'tex' ) )
+  ok_( iu.IsIdentifier( 'fōo'        , 'tex' ) )
+  ok_( iu.IsIdentifier( 'some8'      , 'tex' ) )
 
   ok_( not iu.IsIdentifier( '\section', 'tex' ) )
-  ok_( not iu.IsIdentifier( 'some8', 'tex' ) )
-  ok_( not iu.IsIdentifier( '' , 'tex' ) )
+  ok_( not iu.IsIdentifier( 'foo:'    , 'tex' ) )
+  ok_( not iu.IsIdentifier( '-bar'    , 'tex' ) )
+  ok_( not iu.IsIdentifier( ''        , 'tex' ) )
 
 
 def IsIdentifier_Perl6_test():
@@ -310,38 +313,38 @@ def IsIdentifier_Perl6_test():
   ok_( not iu.IsIdentifier( "x+"  , 'perl6' ) )
   ok_( not iu.IsIdentifier( "9x"  , 'perl6' ) )
   ok_( not iu.IsIdentifier( "9"   , 'perl6' ) )
-  ok_( not iu.IsIdentifier( '' , 'perl6' ) )
+  ok_( not iu.IsIdentifier( ''    , 'perl6' ) )
 
 
 def IsIdentifier_Scheme_test():
-  ok_( iu.IsIdentifier( 'λ'  , 'scheme') )
-  ok_( iu.IsIdentifier( '_'  , 'scheme' ) )
-  ok_( iu.IsIdentifier( '+'  , 'scheme' ) )
-  ok_( iu.IsIdentifier( '-'  , 'scheme' ) )
-  ok_( iu.IsIdentifier( '...', 'scheme' ) )
-  ok_( iu.IsIdentifier( r'\x01;'      , 'scheme' ) )
-  ok_( iu.IsIdentifier( r'h\x65;lle'  , 'scheme' ) )
-  ok_( iu.IsIdentifier( 'foo'         , 'scheme' ) )
-  ok_( iu.IsIdentifier( 'foo+-*/1-1'  , 'scheme' ) )
-  ok_( iu.IsIdentifier( 'call/cc'     , 'scheme' ) )
+  ok_( iu.IsIdentifier( 'λ'         , 'scheme') )
+  ok_( iu.IsIdentifier( '_'         , 'scheme' ) )
+  ok_( iu.IsIdentifier( '+'         , 'scheme' ) )
+  ok_( iu.IsIdentifier( '-'         , 'scheme' ) )
+  ok_( iu.IsIdentifier( '...'       , 'scheme' ) )
+  ok_( iu.IsIdentifier( r'\x01;'    , 'scheme' ) )
+  ok_( iu.IsIdentifier( r'h\x65;lle', 'scheme' ) )
+  ok_( iu.IsIdentifier( 'foo'       , 'scheme' ) )
+  ok_( iu.IsIdentifier( 'foo+-*/1-1', 'scheme' ) )
+  ok_( iu.IsIdentifier( 'call/cc'   , 'scheme' ) )
 
-  ok_( not iu.IsIdentifier( '.'  , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '..' , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '--' , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '++' , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '+1' , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '-1' , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '-abc'   , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '-<abc'  , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '@'      , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '@a'     , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '-@a'    , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '-12a'   , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '12a'    , 'scheme' ) )
-  ok_( not iu.IsIdentifier( '\\'     , 'scheme' ) )
-  ok_( not iu.IsIdentifier( r'\x'    , 'scheme' ) )
-  ok_( not iu.IsIdentifier( r'\x123' , 'scheme' ) )
-  ok_( not iu.IsIdentifier( r'aa\x123;cc\x'  , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '.'            , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '..'           , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '--'           , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '++'           , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '+1'           , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '-1'           , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '-abc'         , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '-<abc'        , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '@'            , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '@a'           , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '-@a'          , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '-12a'         , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '12a'          , 'scheme' ) )
+  ok_( not iu.IsIdentifier( '\\'           , 'scheme' ) )
+  ok_( not iu.IsIdentifier( r'\x'          , 'scheme' ) )
+  ok_( not iu.IsIdentifier( r'\x123'       , 'scheme' ) )
+  ok_( not iu.IsIdentifier( r'aa\x123;cc\x', 'scheme' ) )
 
 
 def StartOfLongestIdentifierEndingAtIndex_Simple_test():


### PR DESCRIPTION
Accepts Unicode characters in identifiers for TeX as well as numbers (except the first character). See issue https://github.com/Valloric/YouCompleteMe/issues/2670 and [this post on ycm-users]( https://groups.google.com/forum/#!searchin/ycm-users/tex%7Csort:date/ycm-users/lv5PK7nP0bI/SvGWT7TVAwAJ).

Fixes https://github.com/Valloric/YouCompleteMe/issues/2670.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/983)
<!-- Reviewable:end -->
