### PR TITLE
[READY] Always return detailed completions in TypeScript completer

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -382,11 +382,6 @@ class TypeScriptCompleter( Completer ):
       'offset': request_data[ 'start_codepoint' ]
     } )
 
-    # A less detailed version of the completion data is returned
-    # if there are too many entries. This improves responsiveness.
-    if len( entries ) > MAX_DETAILED_COMPLETIONS:
-      return [ _ConvertCompletionData(e) for e in entries ]
-
     detailed_entries = self._SendRequest( 'completionEntryDetails', {
       'file':       request_data[ 'filepath' ],
       'line':       request_data[ 'line_num' ],

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Copyright (C) 2015 ycmd contributors
+# Copyright (C) 2015-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -24,10 +24,8 @@ from __future__ import division
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from hamcrest import ( all_of, any_of, assert_that, calling,
-                       contains_inanyorder, has_entries, has_item, is_not,
-                       raises )
-from mock import patch
+from hamcrest import ( assert_that, calling, contains_inanyorder, has_entries,
+                       has_item, raises )
 from nose.tools import eq_
 from webtest import AppError
 import pprint
@@ -120,9 +118,6 @@ def GetCompletions_Basic_test( app ):
 
 
 @SharedYcmd
-@patch( 'ycmd.completers.typescript.'
-          'typescript_completer.MAX_DETAILED_COMPLETIONS',
-        1000 )
 def GetCompletions_Keyword_test( app ):
   RunTest( app, {
     'description': 'No extra and detailed info when completion is a keyword',
@@ -138,52 +133,6 @@ def GetCompletions_Keyword_test( app ):
           'insertion_text': 'class',
           'kind':           'keyword',
         } )
-      } )
-    }
-  } )
-
-
-@SharedYcmd
-@patch( 'ycmd.completers.typescript.'
-          'typescript_completer.MAX_DETAILED_COMPLETIONS',
-        2 )
-def GetCompletions_MaxDetailedCompletion_test( app ):
-  RunTest( app, {
-    'request': {
-      'line_num': 17,
-      'column_num': 6,
-      'filepath': PathToTestFile( 'test.ts' ),
-    },
-    'expect': {
-      'response': requests.codes.ok,
-      'data': has_entries( {
-        'completions': all_of(
-          contains_inanyorder(
-            CompletionEntryMatcher( 'methodA' ),
-            CompletionEntryMatcher( 'methodB' ),
-            CompletionEntryMatcher( 'methodC' ),
-          ),
-          is_not( any_of(
-            has_item(
-              CompletionEntryMatcher(
-                'methodA',
-                '(method) Foo.methodA(): void'
-              )
-            ),
-            has_item(
-              CompletionEntryMatcher(
-                'methodB',
-                '(method) Foo.methodB(): void'
-              )
-            ),
-            has_item(
-              CompletionEntryMatcher(
-                'methodC',
-                '(method) Foo.methodC(a: { foo: string; bar: number; }): void'
-              )
-            )
-          ) )
-        )
       } )
     }
   } )


### PR DESCRIPTION
This limit of 100 detailed completions is often a source of confusion to users. See issues https://github.com/Valloric/YouCompleteMe/issues/1878, https://github.com/Valloric/YouCompleteMe/issues/2040, and https://github.com/Valloric/YouCompleteMe/issues/2955. With completions being async in YCM, this is less a problem to always return detailed completions even if there are a lot of suggestions. Removing this limit is also important to support automatic imports (we need detailed completions for that).

Closes https://github.com/Valloric/YouCompleteMe/issues/2955.
 