### PR TITLE
Allow ycmd to pass jdt.ls options on initialization

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1195,7 +1195,7 @@ class LanguageServerCompleter( Completer ):
     return os.path.dirname( request_data[ 'filepath' ] )
 
 
-  def SendInitialize( self, request_data ):
+  def SendInitialize( self, request_data, initializationOptions = {} ):
     """Sends the initialize request asynchronously.
     This must be called immediately after establishing the connection with the
     language server. Implementations must not issue further requests to the
@@ -1207,7 +1207,8 @@ class LanguageServerCompleter( Completer ):
 
       request_id = self.GetConnection().NextRequestId()
       msg = lsp.Initialize( request_id,
-                            self._GetProjectDirectory( request_data  ) )
+                            self._GetProjectDirectory( request_data  ),
+                            initializationOptions )
 
       def response_handler( response, message ):
         if message is None:
@@ -1260,7 +1261,9 @@ class LanguageServerCompleter( Completer ):
       # initialized notification, so we do the same. In future, we might
       # support getting this config from ycm_extra_conf or the client, but for
       # now, we send an empty object.
-      self.GetConnection().SendNotification( lsp.DidChangeConfiguration( {} ) )
+      # We should leave this behavior up to specific language server
+      # implementations.
+      # self.GetConnection().SendNotification(lsp.DidChangeConfiguration({}))
 
       # Notify the other threads that we have completed the initialize exchange.
       self._initialize_response = None

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -185,16 +185,14 @@ def BuildNotification( method, parameters ):
   } )
 
 
-def Initialize( request_id, project_directory ):
+def Initialize( request_id, project_directory, initializationOptions = {} ):
   """Build the Language Server initialize request"""
 
   return BuildRequest( request_id, 'initialize', {
     'processId': os.getpid(),
     'rootPath': project_directory,
     'rootUri': FilePathToUri( project_directory ),
-    'initializationOptions': {
-      # We don't currently support any server-specific options.
-    },
+    'initializationOptions': initializationOptions,
     'capabilities': {
       # We don't currently support any of the client capabilities, so we don't
       # include anything in here.

--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -45,5 +45,6 @@
   "rust_src_path": "",
   "racerd_binary_path": "",
   "python_binary_path": "",
-  "java_jdtls_use_clean_workspace": 1
+  "java_jdtls_use_clean_workspace": 1,
+  "java_jdlts_enable_gradle_import": 1
 }


### PR DESCRIPTION
There are many options supported by jdt.ls that need to be sent by a
client over Initialize and DidConfigurationChange notifications.
This change allows a specific setting to be passed based on an
user_option. Other settings can be integrated due to other use cases.

This proposal can be used to further extend eclipse.jdt.ls options. But for my current use case, I need a way to disable the Gradle import done by jdt.ls (buildship) because I manage the eclipse files manually (.classpath, etc)... This is due to limitations in buildship to make proper import of Gradle-based Android projects. Which is a use case that I see appear on other open issues for jdt.ls language clients.

Most significant perhaps, is the move of DidChangeConfiguration notification from inside the Initialize response handler.. And leaving it up to language clients to implement as needed. This was necessary because jdt.ls resets its settings if DidChangeConfiguration is received with an empty object.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/986)
<!-- Reviewable:end -->
