### PR TITLE
[READY] Support FixIts in TypeScript completions

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -378,20 +378,29 @@ class TypeScriptCompleter( Completer ):
 
 
   def ComputeCandidatesInner( self, request_data ):
+    def FormatEntry( entry ):
+      if 'source' in entry:
+        return {
+          'name': entry[ 'name' ],
+          'source': entry[ 'source' ]
+        }
+      return entry[ 'name' ]
+
     self._Reload( request_data )
     entries = self._SendRequest( 'completions', {
-      'file':   request_data[ 'filepath' ],
-      'line':   request_data[ 'line_num' ],
-      'offset': request_data[ 'start_codepoint' ]
+      'file':                         request_data[ 'filepath' ],
+      'line':                         request_data[ 'line_num' ],
+      'offset':                       request_data[ 'start_codepoint' ],
+      'includeExternalModuleExports': True
     } )
 
     detailed_entries = self._SendRequest( 'completionEntryDetails', {
       'file':       request_data[ 'filepath' ],
       'line':       request_data[ 'line_num' ],
       'offset':     request_data[ 'start_codepoint' ],
-      'entryNames': [ entry[ 'name' ] for entry in entries ]
+      'entryNames': [ FormatEntry( entry ) for entry in entries ]
     } )
-    return [ _ConvertDetailedCompletionData( entry )
+    return [ _ConvertDetailedCompletionData( request_data, entry )
              for entry in detailed_entries ]
 
 
@@ -845,7 +854,7 @@ def _LogLevel():
   return 'verbose' if _logger.isEnabledFor( logging.DEBUG ) else 'normal'
 
 
-def _ConvertDetailedCompletionData( completion_data ):
+def _ConvertDetailedCompletionData( request_data, completion_data ):
   name = completion_data[ 'name' ]
   display_parts = completion_data[ 'displayParts' ]
   signature = ''.join( [ part[ 'text' ] for part in display_parts ] )
@@ -862,11 +871,25 @@ def _ConvertDetailedCompletionData( completion_data ):
   detailed_info += [ doc[ 'text' ].strip() for doc in docs if doc ]
   detailed_info = '\n\n'.join( detailed_info )
 
+  fixits = None
+  if 'codeActions' in completion_data:
+    location = responses.Location( request_data[ 'line_num' ],
+                                   request_data[ 'column_num' ],
+                                   request_data[ 'filepath' ] )
+    fixits = responses.BuildFixItResponse( [
+      responses.FixIt( location,
+                       _BuildFixItForChanges( request_data,
+                                              action[ 'changes' ] ),
+                       action[ 'description' ] )
+      for action in completion_data[ 'codeActions' ]
+    ] )
+
   return responses.BuildCompletionData(
     insertion_text  = name,
     extra_menu_info = extra_menu_info,
     detailed_info   = detailed_info,
-    kind            = completion_data[ 'kind' ]
+    kind            = completion_data[ 'kind' ],
+    extra_data      = fixits
   )
 
 

--- a/ycmd/tests/typescript/diagnostics_test.py
+++ b/ycmd/tests/typescript/diagnostics_test.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2017 ycmd contributors
+# encoding: utf-8
+#
+# Copyright (C) 2017-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -73,6 +75,14 @@ def Diagnostics_FileReadyToParse_test( app ):
         'location_extent': RangeMatcher( filepath, ( 37, 1 ), ( 37, 12 ) ),
         'ranges': contains( RangeMatcher( filepath, ( 37, 1 ), ( 37, 12 ) ) ),
         'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': 'ERROR',
+        'text': "Cannot find name 'Bår'.",
+        'location': LocationMatcher( filepath, 39, 1 ),
+        'location_extent': RangeMatcher( filepath, ( 39, 1 ), ( 39, 5 ) ),
+        'ranges': contains( RangeMatcher( filepath, ( 39, 1 ), ( 39, 5 ) ) ),
+        'fixit_available': True
       } ),
     )
   )

--- a/ycmd/tests/typescript/testdata/test.ts
+++ b/ycmd/tests/typescript/testdata/test.ts
@@ -35,3 +35,5 @@ bar.testMethod();
 bar.nonExistingMethod();
 
 Bar.apply()
+
+Bår

--- a/ycmd/tests/typescript/testdata/unicode.ts
+++ b/ycmd/tests/typescript/testdata/unicode.ts
@@ -1,5 +1,5 @@
 
-class Bår {
+export class Bår {
   methodA(
     a: {
       foo: string;


### PR DESCRIPTION
If available, add FixIts to the `extra_data` field of TypeScript completions. This allows automatic insertion of an import when selecting a completion:

![typescript-auto-imports](https://user-images.githubusercontent.com/10026824/38372309-cc50d0a6-38ee-11e8-9f45-841190e07e9f.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/987)
<!-- Reviewable:end -->
