### PR TITLE
[READY] Fix length of Word tests array

### DIFF
--- a/cpp/ycm/tests/Normalization_test.cpp
+++ b/cpp/ycm/tests/Normalization_test.cpp
@@ -74,7 +74,9 @@ TEST_P( NormalizationTest, NormalizationFormDecompositionIsConform ) {
 }
 
 
-const std::array< NormalizationTuple, 18746 > tests = { {
+// Tests generated from
+// https://unicode.org/Public/UCD/latest/ucd/NormalizationTest.txt
+const NormalizationTuple tests[] = {
   { "Ḋ", "Ḋ", "Ḋ", "Ḋ", "Ḋ" },
   { "Ḍ", "Ḍ", "Ḍ", "Ḍ", "Ḍ" },
   { "Ḍ̇", "Ḍ̇", "Ḍ̇", "Ḍ̇", "Ḍ̇" },
@@ -18821,7 +18823,7 @@ const std::array< NormalizationTuple, 18746 > tests = { {
   { "𑒹̴𑒽", "𑒹̴𑒽", "𑒹̴𑒽", "𑒹̴𑒽", "𑒹̴𑒽" },
   { "𑖸̴𑖯", "𑖸̴𑖯", "𑖸̴𑖯", "𑖸̴𑖯", "𑖸̴𑖯" },
   { "𑖹̴𑖯", "𑖹̴𑖯", "𑖹̴𑖯", "𑖹̴𑖯", "𑖹̴𑖯" },
-} };
+};
 
 
 INSTANTIATE_TEST_CASE_P( UnicodeTest, NormalizationTest, ValuesIn( tests ) );

--- a/cpp/ycm/tests/Word_test.cpp
+++ b/cpp/ycm/tests/Word_test.cpp
@@ -60,8 +60,8 @@ TEST_P( WordTest, BreakIntoCharacters ) {
 
 
 // Tests generated from
-// ftp://ftp.unicode.org/Public/UCD/latest/ucd/auxiliary/GraphemeBreakTest.txt
-const std::array< WordTuple, 878 > tests = { {
+// https://www.unicode.org/Public/UCD/latest/ucd/auxiliary/GraphemeBreakTest.txt
+const WordTuple tests[] = {
   { "  ", { " ", " " } },
   { " ̈ ", { " ̈", " " } },
   { " \r", { " ", "\r" } },
@@ -884,7 +884,7 @@ const std::array< WordTuple, 878 > tests = { {
   { "‍♀", { "‍♀" } },
   { "‍👦", { "‍👦" } },
   { "👦👦", { "👦", "👦" } },
-} };
+};
 
 
 INSTANTIATE_TEST_CASE_P( UnicodeTest, WordTest, ValuesIn( tests ) );


### PR DESCRIPTION
There are only 822 elements in that array, not 878.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/989)
<!-- Reviewable:end -->
