### PR TITLE
[READY] Use const char* instead of std::string in Word tests

### DIFF
--- a/cpp/ycm/tests/TestUtils.cpp
+++ b/cpp/ycm/tests/TestUtils.cpp
@@ -70,14 +70,17 @@ std::ostream& operator<<( std::ostream& os, const Character *character ) {
 
 
 std::ostream& operator<<( std::ostream& os, const WordTuple &word ) {
-  os << "{ " << PrintToString( word.text_ ) << ", "
-             << PrintToString( word.characters_ ) << " }";
-  return os;
-}
-
-
-std::ostream& operator<<( std::ostream& os, const Word &word ) {
-  os << WordTuple( word );
+  os << "{ " << PrintToString( word.text_ ) << ", { ";
+  const std::vector< const char* > &characters( word.characters_ );
+  auto character_pos = characters.begin();
+  if ( character_pos != characters.end() ) {
+    os << PrintToString( *character_pos );
+    ++character_pos;
+    for ( ; character_pos != characters.end() ; ++character_pos ) {
+      os << ", " << PrintToString( *character_pos );
+    }
+    os << " }";
+  }
   return os;
 }
 

--- a/cpp/ycm/tests/TestUtils.h
+++ b/cpp/ycm/tests/TestUtils.h
@@ -147,28 +147,19 @@ struct WordTuple {
     : WordTuple( "", {} ) {
   }
 
-  WordTuple( const Word &word ) {
-    std::vector< std::string > strings;
-    for ( auto character : word.Characters() ) {
-      strings.push_back( character->Normal().c_str() );
-    }
-    WordTuple( word.Text(), strings );
-  }
-
-  WordTuple( const std::string &text,
-             const std::vector< std::string > &characters )
+  WordTuple( const char* text,
+             const std::vector< const char* > &characters )
     : text_( text ),
       characters_( characters ) {
   }
-
 
   bool operator== ( const WordTuple &other ) const {
     return text_ == other.text_ &&
            characters_ == other.characters_;
   };
 
-  std::string text_;
-  std::vector< std::string > characters_;
+  const char* text_;
+  std::vector< const char* > characters_;
 };
 
 
@@ -180,7 +171,6 @@ std::ostream& operator<<( std::ostream& os, const CharacterTuple &character );
 std::ostream& operator<<( std::ostream& os, const Character &character );
 std::ostream& operator<<( std::ostream& os, const Character *character );
 std::ostream& operator<<( std::ostream& os, const WordTuple &word );
-std::ostream& operator<<( std::ostream& os, const Word &word );
 
 
 // These matchers are used to remove the "is equal to" output from gtest.

--- a/cpp/ycm/tests/Word_test.cpp
+++ b/cpp/ycm/tests/Word_test.cpp
@@ -54,8 +54,12 @@ std::ostream& operator<<( std::ostream& os,
 
 
 TEST_P( WordTest, BreakIntoCharacters ) {
+  std::vector< std::string > characters;
+  for ( const auto &character : word_.characters_ ) {
+    characters.push_back( character );
+  }
   EXPECT_THAT( Word( word_.text_ ).Characters(),
-               ContainsPointees( repo_.GetCharacters( word_.characters_ ) ) );
+               ContainsPointees( repo_.GetCharacters( characters ) ) );
 }
 
 


### PR DESCRIPTION
This fixes the issue where recent versions of Clang would take forever to compile the `BreakIntoCharacters` tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/990)
<!-- Reviewable:end -->
