### PR TITLE
[READY] Clang-tidy - LLVM style fix

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -16,13 +16,13 @@
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "ClangCompleter.h"
-#include "Result.h"
 #include "Candidate.h"
-#include "TranslationUnit.h"
 #include "CandidateRepository.h"
-#include "CompletionData.h"
-#include "Utils.h"
 #include "ClangUtils.h"
+#include "CompletionData.h"
+#include "Result.h"
+#include "TranslationUnit.h"
+#include "Utils.h"
 
 #include <clang-c/Index.h>
 #include <memory>

--- a/cpp/ycm/ClangCompleter/Documentation.cpp
+++ b/cpp/ycm/ClangCompleter/Documentation.cpp
@@ -28,7 +28,7 @@ bool CXCommentValid( const CXComment &comment ) {
   return clang_Comment_getKind( comment ) != CXComment_Null;
 }
 
-}
+} // unnamed namespace
 
 DocumentationData::DocumentationData( const CXCursor &cursor )
   : raw_comment( CXStringToString(

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -15,15 +15,14 @@
 // You should have received a copy of the GNU General Public License
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "TranslationUnit.h"
-#include "CompletionData.h"
 #include "ClangUtils.h"
 #include "ClangHelpers.h"
+#include "CompletionData.h"
+#include "TranslationUnit.h"
 
-#include <boost/filesystem.hpp>
-
-#include <cstdlib>
 #include <algorithm>
+#include <boost/filesystem.hpp>
+#include <cstdlib>
 #include <memory>
 
 using std::unique_lock;
@@ -476,6 +475,7 @@ void TranslationUnit::UpdateLatestDiagnostics() {
 }
 
 namespace {
+
 /// Sort a FixIt container by its location's distance from a given column
 /// (such as the cursor location).
 ///
@@ -493,7 +493,8 @@ struct sort_by_location {
 private:
   int column_;
 };
-}
+
+} // unnamed namespace
 
 std::vector< FixIt > TranslationUnit::GetFixItsForLocationInFile(
   const std::string &filename,

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -18,9 +18,9 @@
 #include "IdentifierUtils.h"
 #include "Utils.h"
 
-#include <unordered_map>
-#include <boost/regex.hpp>
 #include <boost/algorithm/string/regex.hpp>
+#include <boost/regex.hpp>
+#include <unordered_map>
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/PythonSupport.cpp
+++ b/cpp/ycm/PythonSupport.cpp
@@ -16,13 +16,13 @@
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "PythonSupport.h"
-#include "Result.h"
 #include "Candidate.h"
 #include "CandidateRepository.h"
+#include "Result.h"
 #include "Utils.h"
 
-#include <vector>
 #include <utility>
+#include <vector>
 
 using pybind11::len;
 using pybind11::str;

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -16,10 +16,11 @@
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Utils.h"
-#include <cmath>
-#include <limits>
+
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <cmath>
+#include <limits>
 
 namespace fs = boost::filesystem;
 

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -23,13 +23,13 @@
 #ifdef USE_CLANG_COMPLETER
 #  include "ClangCompleter.h"
 #  include "ClangUtils.h"
+#  include "CompilationDatabase.h"
 #  include "CompletionData.h"
 #  include "Diagnostic.h"
+#  include "Documentation.h"
 #  include "Location.h"
 #  include "Range.h"
 #  include "UnsavedFile.h"
-#  include "CompilationDatabase.h"
-#  include "Documentation.h"
 #endif // USE_CLANG_COMPLETER
 
 #include <pybind11/stl_bind.h>


### PR DESCRIPTION
This is the first in the upcoming clang-tidy PR series.

Ycmd triggered two warning types - namespace comment and include order.
Besides those two, LLVM checks also include header include guards and "twine locals".

Twine locals is something like this:

```c++
static Twine Moo = Twine("bark") + "bah";

// becomes

static std::string Moo = (Twine("bark") + "bah").str();
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/991)
<!-- Reviewable:end -->
