### PR TITLE
[READY] Clang-tidy - readability checks

### DIFF
--- a/cpp/ycm/CandidateRepository.h
+++ b/cpp/ycm/CandidateRepository.h
@@ -59,7 +59,8 @@ private:
   CandidateRepository() = default;
   ~CandidateRepository() = default;
 
-  const std::string &ValidatedCandidateText( const std::string &text );
+  const std::string &ValidatedCandidateText(
+      const std::string &candidate_text );
 
   static CandidateRepository *instance_;
   static std::mutex instance_mutex_;

--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -95,7 +95,7 @@ void BuildFullDiagnosticDataFromChildren(
 
   // Populate any fixit attached to this diagnostic.
   FixIt fixit = BuildFixIt( diag_text, diagnostic );
-  if ( fixit.chunks.size() > 0 ) {
+  if ( !fixit.chunks.empty() ) {
     fixits.push_back( fixit );
   }
 

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -89,8 +89,8 @@ TranslationUnit::TranslationUnit(
 
   std::vector< CXUnsavedFile > cxunsaved_files =
     ToCXUnsavedFiles( unsaved_files );
-  const CXUnsavedFile *unsaved = cxunsaved_files.size() > 0
-                                 ? &cxunsaved_files[ 0 ] : nullptr;
+  const CXUnsavedFile *unsaved = cxunsaved_files.empty()
+                                 ? nullptr : &cxunsaved_files[ 0 ];
 
   // Actually parse the translation unit.
   CXErrorCode failure = clang_parseTranslationUnit2FullArgv(
@@ -159,8 +159,8 @@ std::vector< CompletionData > TranslationUnit::CandidatesForLocation(
 
   std::vector< CXUnsavedFile > cxunsaved_files =
     ToCXUnsavedFiles( unsaved_files );
-  const CXUnsavedFile *unsaved = cxunsaved_files.size() > 0
-                                 ? &cxunsaved_files[ 0 ] : nullptr;
+  const CXUnsavedFile *unsaved = cxunsaved_files.empty()
+                                 ? nullptr : &cxunsaved_files[ 0 ];
 
   // codeCompleteAt reparses the TU if the underlying source file has changed on
   // disk since the last time the TU was updated and there are no unsaved files.
@@ -433,8 +433,8 @@ void TranslationUnit::Reparse( std::vector< CXUnsavedFile > &unsaved_files,
       return;
     }
 
-    CXUnsavedFile *unsaved = unsaved_files.size() > 0
-                             ? &unsaved_files[ 0 ] : nullptr;
+    CXUnsavedFile *unsaved = unsaved_files.empty()
+                             ? nullptr : &unsaved_files[ 0 ];
 
     // This function should technically return a CXErrorCode enum but return an
     // int instead.

--- a/cpp/ycm/CodePoint.cpp
+++ b/cpp/ycm/CodePoint.cpp
@@ -59,13 +59,15 @@ const RawCodePoint FindCodePoint( const char *text ) {
     size_t step = count / 2;
     auto it = first + step;
     int cmp = std::strcmp( it->original, text );
-    if ( cmp == 0 )
+    if ( cmp == 0 ) {
       return *it;
+    }
     if ( cmp < 0 ) {
       first = ++it;
       count -= step + 1;
-    } else
+    } else {
       count = step;
+    }
   }
 
   return { text, text, text, text, false, false, false, 0, 0 };

--- a/cpp/ycm/CodePoint.h
+++ b/cpp/ycm/CodePoint.h
@@ -130,7 +130,7 @@ public:
   };
 
 private:
-  CodePoint( const RawCodePoint &character );
+  CodePoint( const RawCodePoint &code_point );
 
   std::string normal_;
   std::string folded_case_;

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -91,9 +91,8 @@ void IdentifierDatabase::ResultsForQueryAndType(
       for ( const Candidate * candidate : *path_and_candidates.second ) {
         if ( ContainsKey( seen_candidates, candidate ) ) {
           continue;
-        } else {
-          seen_candidates.insert( candidate );
         }
+        seen_candidates.insert( candidate );
 
         if ( candidate->IsEmpty() ||
              !candidate->ContainsBytes( query_object ) ) {

--- a/cpp/ycm/Result.cpp
+++ b/cpp/ycm/Result.cpp
@@ -102,8 +102,9 @@ bool Result::operator< ( const Result &other ) const {
     //  - it appears before the other result in lexicographic order.
 
     if ( first_char_same_in_query_and_text_ !=
-         other.first_char_same_in_query_and_text_ )
+         other.first_char_same_in_query_and_text_ ) {
       return first_char_same_in_query_and_text_;
+    }
 
     if ( num_wb_matches_ == query_->Length() ||
          other.num_wb_matches_ == query_->Length() ) {

--- a/cpp/ycm/Result.h
+++ b/cpp/ycm/Result.h
@@ -32,7 +32,7 @@ public:
   Result( const Candidate *candidate,
           const Word *query,
           size_t char_match_index_sum,
-          bool query_is_candidate_prefix_ );
+          bool query_is_candidate_prefix );
 
   bool operator< ( const Result &other ) const;
 

--- a/cpp/ycm/Word.cpp
+++ b/cpp/ycm/Word.cpp
@@ -37,8 +37,9 @@ std::vector< std::string > BreakCodePointsIntoCharacters(
   // automatically satisfied.
 
   auto code_point_pos = code_points.begin();
-  if ( code_point_pos == code_points.end() )
+  if ( code_point_pos == code_points.end() ) {
     return characters;
+  }
 
   std::string character;
   character.append( ( *code_point_pos )->Normal() );


### PR DESCRIPTION
- Prohibits implicit cast to bool
- vector::empty() instead of vector::size() for checking empty vectors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/992)
<!-- Reviewable:end -->
