### PR TITLE
[READY] Clang-tidy - performance checks

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -251,7 +251,7 @@ std::vector< CompletionData > ToCompletionDataVector(
 }
 
 
-Diagnostic BuildDiagnostic( DiagnosticWrap diagnostic_wrap,
+Diagnostic BuildDiagnostic( const DiagnosticWrap &diagnostic_wrap,
                             CXTranslationUnit translation_unit ) {
   Diagnostic diagnostic;
 

--- a/cpp/ycm/ClangCompleter/ClangHelpers.h
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.h
@@ -39,7 +39,7 @@ std::vector< CompletionData > ToCompletionDataVector(
 std::vector< CXUnsavedFile > ToCXUnsavedFiles(
   const std::vector< UnsavedFile > &unsaved_files );
 
-Diagnostic BuildDiagnostic( DiagnosticWrap diagnostic_wrap,
+Diagnostic BuildDiagnostic( const DiagnosticWrap &diagnostic_wrap,
                             CXTranslationUnit translation_unit );
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
@@ -31,22 +31,7 @@ namespace YouCompleteMe {
 namespace {
 
 std::size_t HashForFlags( const std::vector< std::string > &flags ) {
-  /*
-   * The way boost::hash implements hash< std::vector<T> > goes after the
-   * described way in "Library Extension Technical Report - Issue List"
-   * section 6.18. This function's body is taken straight (copy-pasted)
-   * from the TR to replicate boost's behaviour.
-   *
-   * When (if) it ends up in the STL this whole function could be
-   * replaced with:
-   *
-   * return std::hash< std::vector< std::string > >()( flags );
-   */
-  size_t seed = 0;
-  for ( auto flag : flags ) {
-    seed ^= std::hash< std::string >()( flag ) + ( seed<<6 ) + ( seed>>2 );
-  }
-  return seed;
+  return std::hash< std::vector< std::string > >()( flags );
 }
 
 }  // unnamed namespace

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.h
@@ -29,6 +29,22 @@
 
 using CXIndex = void*;
 
+namespace std {
+
+template <> struct hash< vector< string > > {
+  // The algorithm has been taken straight from a TR1.
+  // This is also the way Boost implements it.
+  size_t operator()( const vector< string > &string_vector ) const {
+    size_t seed = 0;
+    for ( const auto &element : string_vector )  {
+       seed ^= hash< string >()( element ) + ( seed << 6 ) + ( seed >> 2 );
+    }
+    return seed;
+  }
+};
+
+} // std namespace
+
 namespace YouCompleteMe {
 
 class TranslationUnitStore {

--- a/cpp/ycm/PythonSupport.cpp
+++ b/cpp/ycm/PythonSupport.cpp
@@ -47,10 +47,10 @@ std::vector< const Candidate * > CandidatesFromObjectList(
 
   for ( size_t i = 0; i < num_candidates; ++i ) {
     if ( candidate_property.empty() ) {
-      candidate_strings.push_back( GetUtf8String( candidates[ i ] ) );
+      candidate_strings.emplace_back( GetUtf8String( candidates[ i ] ) );
     } else {
-      candidate_strings.push_back( GetUtf8String(
-                                     candidates[ i ][ py_prop ] ) );
+      candidate_strings.emplace_back( GetUtf8String(
+                                        candidates[ i ][ py_prop ] ) );
     }
   }
 
@@ -87,8 +87,7 @@ pylist FilterAndSortCandidates(
       Result result = candidate->QueryMatchResult( query_object );
 
       if ( result.IsSubsequence() ) {
-        ResultAnd< size_t > result_and_object( result, i );
-        result_and_objects.push_back( std::move( result_and_object ) );
+        result_and_objects.emplace_back( result, i );
       }
     }
 


### PR DESCRIPTION
- Implemented:
  - Const referrences instead of copying
- Also implemented by others:
  - Useless std::move

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/993)
<!-- Reviewable:end -->
