### PR TITLE
[READY] Clang-tidy - modernize checks

### DIFF
--- a/cpp/ycm/Word.h
+++ b/cpp/ycm/Word.h
@@ -36,7 +36,7 @@ using Bitset = std::bitset< NUM_BYTES >;
 // https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundary_Rules
 class Word {
 public:
-  YCM_EXPORT explicit Word( const std::string &text );
+  YCM_EXPORT explicit Word( std::string text );
   // Make class noncopyable
   Word( const Word& ) = delete;
   Word& operator=( const Word& ) = delete;


### PR DESCRIPTION
- Implemented
  - std::string &&text argument instead of const std::string &text
- Also implemented by others:
  - = default
  - emplace_back instead of push_back
- C++14 features (acording to cppreferrence, but clang-tidy seems to respect `-std`, so I'd let the builds have their say):
  - make_unique

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/994)
<!-- Reviewable:end -->
