### PR TITLE
[READY] Clang-tidy - HICPP style fixes

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -150,8 +150,7 @@ std::vector< Range > GetRanges( const DiagnosticWrap &diagnostic_wrap ) {
   ranges.reserve( num_ranges );
 
   for ( size_t i = 0; i < num_ranges; ++i ) {
-    ranges.push_back(
-      Range( clang_getDiagnosticRange( diagnostic_wrap.get(), i ) ) );
+    ranges.emplace_back( clang_getDiagnosticRange( diagnostic_wrap.get(), i ) );
   }
 
   return ranges;

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -481,7 +481,7 @@ namespace {
 ///
 /// PreCondition: All FixIts in the container are on the same line.
 struct sort_by_location {
-  sort_by_location( int column ) : column_( column ) { }
+  explicit sort_by_location( int column ) : column_( column ) { }
 
   bool operator()( const FixIt &a, const FixIt &b ) {
     int a_distance = a.location.column_number_ - column_;

--- a/cpp/ycm/CodePoint.cpp
+++ b/cpp/ycm/CodePoint.cpp
@@ -59,13 +59,15 @@ const RawCodePoint FindCodePoint( const char *text ) {
     size_t step = count / 2;
     it = first + step;
     int cmp = std::strcmp( it->original, text );
-    if ( cmp == 0 )
+    if ( cmp == 0 ) {
       return *it;
+    }
     if ( cmp < 0 ) {
       first = ++it;
       count -= step + 1;
-    } else
+    } else {
       count = step;
+    }
   }
 
   return { text, text, text, text, false, false, false, 0, 0 };
@@ -100,7 +102,7 @@ CodePointSequence BreakIntoCodePoints( const std::string &text ) {
     if ( text.end() - iter < length ) {
       throw UnicodeDecodeError( "Invalid code point length." );
     }
-    code_points.push_back( std::string( iter, iter + length ) );
+    code_points.emplace_back( iter, iter + length );
     iter += length;
   }
 

--- a/cpp/ycm/IdentifierCompleter.cpp
+++ b/cpp/ycm/IdentifierCompleter.cpp
@@ -26,9 +26,6 @@
 namespace YouCompleteMe {
 
 
-IdentifierCompleter::IdentifierCompleter() {}
-
-
 IdentifierCompleter::IdentifierCompleter(
   const std::vector< std::string > &candidates ) {
   identifier_database_.AddIdentifiers( candidates, "", "" );

--- a/cpp/ycm/IdentifierCompleter.h
+++ b/cpp/ycm/IdentifierCompleter.h
@@ -35,7 +35,7 @@ public:
   IdentifierCompleter( const IdentifierCompleter& ) = delete;
   IdentifierCompleter& operator=( const IdentifierCompleter ) = delete;
 
-  YCM_EXPORT IdentifierCompleter();
+  YCM_EXPORT IdentifierCompleter() = default;
   YCM_EXPORT IdentifierCompleter(
     const std::vector< std::string > &candidates );
   YCM_EXPORT IdentifierCompleter(

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -52,7 +52,7 @@ using FiletypeIdentifierMap = std::map< std::string, FilepathToIdentifiers >;
 // This class is thread-safe.
 class IdentifierDatabase {
 public:
-  IdentifierDatabase();
+  YCM_EXPORT IdentifierDatabase();
   IdentifierDatabase( const IdentifierDatabase& ) = delete;
   IdentifierDatabase& operator=( const IdentifierDatabase& ) = delete;
 

--- a/cpp/ycm/PythonSupport.cpp
+++ b/cpp/ycm/PythonSupport.cpp
@@ -85,8 +85,7 @@ boost::python::list FilterAndSortCandidates(
       Result result = candidate->QueryMatchResult( query_object );
 
       if ( result.IsSubsequence() ) {
-        ResultAnd< size_t > result_and_object( result, i );
-        result_and_objects.push_back( std::move( result_and_object ) );
+        result_and_objects.emplace_back( result, i );
       }
     }
 

--- a/cpp/ycm/Result.cpp
+++ b/cpp/ycm/Result.cpp
@@ -58,6 +58,7 @@ Result::Result()
     first_char_same_in_query_and_text_( false ),
     query_is_candidate_prefix_( false ),
     char_match_index_sum_( 0 ),
+    num_wb_matches_( 0 ),
     candidate_( nullptr ),
     query_( nullptr ) {
 }
@@ -71,6 +72,7 @@ Result::Result( const Candidate *candidate,
     first_char_same_in_query_and_text_( false ),
     query_is_candidate_prefix_( query_is_candidate_prefix ),
     char_match_index_sum_( char_match_index_sum ),
+    num_wb_matches_( 0 ),
     candidate_( candidate ),
     query_( query ) {
   SetResultFeaturesFromQuery();
@@ -102,8 +104,9 @@ bool Result::operator< ( const Result &other ) const {
     //  - it appears before the other result in lexicographic order.
 
     if ( first_char_same_in_query_and_text_ !=
-         other.first_char_same_in_query_and_text_ )
+         other.first_char_same_in_query_and_text_ ) {
       return first_char_same_in_query_and_text_;
+    }
 
     if ( num_wb_matches_ == query_->Length() ||
          other.num_wb_matches_ == query_->Length() ) {

--- a/cpp/ycm/Word.cpp
+++ b/cpp/ycm/Word.cpp
@@ -37,8 +37,9 @@ std::vector< std::string > BreakCodePointsIntoCharacters(
   // automatically satisfied.
 
   auto code_point_pos = code_points.begin();
-  if ( code_point_pos == code_points.end() )
+  if ( code_point_pos == code_points.end() ) {
     return characters;
+  }
 
   std::string character;
   character.append( ( *code_point_pos )->Normal() );


### PR DESCRIPTION
- Implemented
  - Use emplace_back instead of push_back
  - Use = default; instead of {}; in constructors
  - Remove useless std::move
  - Some member initialisations
- Implemented by other checks
  - Braces around blocks
- False positive
  - Candidate.cpp:70:1: warning: constructor does not initialize these fields: text_is_lowercase_

- Weird mess in `ycm_core.cpp` caused by boost::python, clean with pybind11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/995)
<!-- Reviewable:end -->
