### PR TITLE
Clang-tidy - google style fixes

### DIFF
--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -481,7 +481,7 @@ namespace {
 ///
 /// PreCondition: All FixIts in the container are on the same line.
 struct sort_by_location {
-  sort_by_location( int column ) : column_( column ) { }
+  explicit sort_by_location( int column ) : column_( column ) { }
 
   bool operator()( const FixIt &a, const FixIt &b ) {
     int a_distance = a.location.column_number_ - column_;
@@ -493,7 +493,7 @@ struct sort_by_location {
 private:
   int column_;
 };
-}
+}  // namespace
 
 std::vector< FixIt > TranslationUnit::GetFixItsForLocationInFile(
   const std::string &filename,

--- a/cpp/ycm/CodePoint.cpp
+++ b/cpp/ycm/CodePoint.cpp
@@ -59,13 +59,15 @@ const RawCodePoint FindCodePoint( const char *text ) {
     size_t step = count / 2;
     it = first + step;
     int cmp = std::strcmp( it->original, text );
-    if ( cmp == 0 )
+    if ( cmp == 0 ) {
       return *it;
+    }
     if ( cmp < 0 ) {
       first = ++it;
       count -= step + 1;
-    } else
+    } else {
       count = step;
+    }
   }
 
   return { text, text, text, text, false, false, false, 0, 0 };

--- a/cpp/ycm/Result.cpp
+++ b/cpp/ycm/Result.cpp
@@ -102,8 +102,9 @@ bool Result::operator< ( const Result &other ) const {
     //  - it appears before the other result in lexicographic order.
 
     if ( first_char_same_in_query_and_text_ !=
-         other.first_char_same_in_query_and_text_ )
+         other.first_char_same_in_query_and_text_ ) {
       return first_char_same_in_query_and_text_;
+    }
 
     if ( num_wb_matches_ == query_->Length() ||
          other.num_wb_matches_ == query_->Length() ) {

--- a/cpp/ycm/Word.cpp
+++ b/cpp/ycm/Word.cpp
@@ -37,8 +37,9 @@ std::vector< std::string > BreakCodePointsIntoCharacters(
   // automatically satisfied.
 
   auto code_point_pos = code_points.begin();
-  if ( code_point_pos == code_points.end() )
+  if ( code_point_pos == code_points.end() ) {
     return characters;
+  }
 
   std::string character;
   character.append( ( *code_point_pos )->Normal() );

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -56,11 +56,11 @@ bool HasClangSupport() {
 }
 
 
-BOOST_PYTHON_FUNCTION_OVERLOADS( FilterAndSortCandidatesOverloads,
+BOOST_PYTHON_FUNCTION_OVERLOADS( explicit explicit FilterAndSortCandidatesOverloads,
                                  FilterAndSortCandidates,
                                  3, 4 )
 
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS( CandidatesForQueryAndTypeOverloads,
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS( explicit explicit CandidatesForQueryAndTypeOverloads,
                                         CandidatesForQueryAndType,
                                         2, 3 )
 


### PR DESCRIPTION
- Implemented
  - Braces around every block
  - Single argument constructors require "explicit"
- Not implemented
  - prohibiting non-const references
- Covered by llvm
  - namespace comments

Weird mess in `ycm_core.cpp` caused by boost::python, not present with pybind11.