### PR TITLE
[READY] Clang tidy - clang analyzer

### DIFF
--- a/cpp/ycm/CodePoint.cpp
+++ b/cpp/ycm/CodePoint.cpp
@@ -55,9 +55,9 @@ const RawCodePoint FindCodePoint( const char *text ) {
   auto first = code_points.begin();
   size_t count = code_points.size();
 
-  for ( auto it = first; count > 0; ) {
+  while ( count > 0 ) {
     size_t step = count / 2;
-    it = first + step;
+    auto it = first + step;
     int cmp = std::strcmp( it->original, text );
     if ( cmp == 0 )
       return *it;


### PR DESCRIPTION
This one is enabled by default. If we want it disabled, we need to be explicit.
It actually caught a sneaky "`dead-code.DeadStore`".
There are tons of checks here and a lot of those are platform specific.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/997)
<!-- Reviewable:end -->
