### PR TITLE
[READY] Fix unexpected coverage changes

### DIFF
--- a/ycmd/tests/language_server/language_server_connection_test.py
+++ b/ycmd/tests/language_server/language_server_connection_test.py
@@ -126,20 +126,20 @@ def LanguageServerConnection_CloseTwice_test():
 
 
 @patch.object( lsc, 'MAX_QUEUED_MESSAGES', 2 )
-def LanguageServerConnection_AddNotificationToQueue_RingBuffer():
+def LanguageServerConnection_AddNotificationToQueue_RingBuffer_test():
   connection = MockConnection()
   notifications = connection._notifications
 
   # Queue empty
 
-  assert_that( calling( notifications.get_nowait(), raises( queue.Empty ) ) )
+  assert_that( calling( notifications.get_nowait ), raises( queue.Empty ) )
 
   # Queue partially full, then drained
 
   connection._AddNotificationToQueue( 'one' )
 
   assert_that( notifications.get_nowait(), equal_to( 'one' ) )
-  assert_that( calling( notifications.get_nowait(), raises( queue.Empty ) ) )
+  assert_that( calling( notifications.get_nowait ), raises( queue.Empty ) )
 
   # Queue full, then drained
 
@@ -148,7 +148,7 @@ def LanguageServerConnection_AddNotificationToQueue_RingBuffer():
 
   assert_that( notifications.get_nowait(), equal_to( 'one' ) )
   assert_that( notifications.get_nowait(), equal_to( 'two' ) )
-  assert_that( calling( notifications.get_nowait(), raises( queue.Empty ) ) )
+  assert_that( calling( notifications.get_nowait ), raises( queue.Empty ) )
 
   # Queue full, then new notification, then drained
 
@@ -158,4 +158,4 @@ def LanguageServerConnection_AddNotificationToQueue_RingBuffer():
 
   assert_that( notifications.get_nowait(), equal_to( 'two' ) )
   assert_that( notifications.get_nowait(), equal_to( 'three' ) )
-  assert_that( calling( notifications.get_nowait(), raises( queue.Empty ) ) )
+  assert_that( calling( notifications.get_nowait ), raises( queue.Empty ) )


### PR DESCRIPTION
codecov sometimes reports unexpected coverage changes for two code paths:
 - the notifications queue being full in the language server completer;
 - process not terminated after waiting for `x` seconds.

This happens because these two code paths may or may not be interpreted when running the tests. We fix that by using `pragma: no cover` in the first case and by adding a test that always covers the second case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/999)
<!-- Reviewable:end -->
