### PR TITLE
[READY] Restore options after isolated tests

### DIFF
--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -203,11 +203,13 @@ def SetUpApp( custom_options = {} ):
 def IsolatedApp( custom_options = {} ):
   old_server_state = handlers._server_state
   old_extra_conf_store_state = extra_conf_store.Get()
+  old_options = user_options_store.GetAll()
   try:
     yield SetUpApp( custom_options )
   finally:
     handlers._server_state = old_server_state
     extra_conf_store.Set( old_extra_conf_store_state )
+    user_options_store.SetAll( old_options )
 
 
 def StartCompleterServer( app, filetype, filepath = '/foo' ):


### PR DESCRIPTION
The options passed to an isolated test are changing the state of the user options store (through [the `UpdateUserOptions` function](https://github.com/Valloric/ycmd/blob/2f87e12f7dae0c4ea6f7a83ed58daa62b83c3b63/ycmd/handlers.py#L336)). We need to restore the options at the end of each isolated test like we already do for the extra conf store.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1008)
<!-- Reviewable:end -->
