### PR TITLE
[READY] Fix get completions tests

### DIFF
--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -293,7 +293,7 @@ def GetCompletions_IdentifierCompleter_JustFinishedIdentifier_test( app ):
                has_items( CompletionEntryMatcher( 'foo' ) ) )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def GetCompletions_IdentifierCompleter_IgnoreFinishedIdentifierInString_test(
   app ):
 
@@ -323,7 +323,7 @@ def GetCompletions_IdentifierCompleter_IdentifierUnderCursor_test( app ):
                has_items( CompletionEntryMatcher( 'foo' ) ) )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def GetCompletions_IdentifierCompleter_IgnoreCursorIdentifierInString_test(
   app ):
 


### PR DESCRIPTION
Two tests in `get_completions_test.py` are not executed because their `IsolatedYcmd` decorator is not properly defined (parentheses are missing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1009)
<!-- Reviewable:end -->
