### PR TITLE
[READY] Cache flags by file and client data

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -285,99 +285,7 @@
                                             <div class="col-md-6 sw-request-model">
                             <div  class="panel panel-definition">
                                 <div class="panel-body">
-                                        
-                                                <section class="json-schema-properties">
-                                                    <dl>
-                                                            <dt data-property-name="line_num">
-                                                                <span class="json-property-name">line_num:</span>
-                                                                
-                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/LineNumber">LineNumber</a>
-                                                                </span>
-                                                                <span class="json-property-range" title="Value limits"></span>
-                                                                
-                                                                    <span class="json-property-required"></span>
-                                                            </dt>
-                                                            <dd>
-                                                                
-                                                                <div class="json-inner-schema">
-                                                                    
-                                                                </div>
-                                                            </dd>
-                                                            <dt data-property-name="column_num">
-                                                                <span class="json-property-name">column_num:</span>
-                                                                
-                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/ColumnNumber">ColumnNumber</a>
-                                                                </span>
-                                                                <span class="json-property-range" title="Value limits"></span>
-                                                                
-                                                                    <span class="json-property-required"></span>
-                                                            </dt>
-                                                            <dd>
-                                                                
-                                                                <div class="json-inner-schema">
-                                                                    
-                                                                </div>
-                                                            </dd>
-                                                            <dt data-property-name="filepath">
-                                                                <span class="json-property-name">filepath:</span>
-                                                                
-                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/FilePath">FilePath</a>
-                                                                </span>
-                                                                <span class="json-property-range" title="Value limits"></span>
-                                                                
-                                                                    <span class="json-property-required"></span>
-                                                            </dt>
-                                                            <dd>
-                                                                
-                                                                <div class="json-inner-schema">
-                                                                    
-                                                                </div>
-                                                            </dd>
-                                                            <dt data-property-name="file_data">
-                                                                <span class="json-property-name">file_data:</span>
-                                                                
-                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/FileDataMap">FileDataMap</a>
-                                                                </span>
-                                                                <span class="json-property-range" title="Value limits"></span>
-                                                                
-                                                                    <span class="json-property-required"></span>
-                                                            </dt>
-                                                            <dd>
-                                                                
-                                                                <div class="json-inner-schema">
-                                                                    
-                                                                </div>
-                                                            </dd>
-                                                            <dt data-property-name="completer_target">
-                                                                <span class="json-property-name">completer_target:</span>
-                                                                
-                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/CompleterTarget">CompleterTarget</a>
-                                                                </span>
-                                                                <span class="json-property-range" title="Value limits"></span>
-                                                                
-                                                            </dt>
-                                                            <dd>
-                                                                
-                                                                <div class="json-inner-schema">
-                                                                    
-                                                                </div>
-                                                            </dd>
-                                                            <dt data-property-name="working_dir">
-                                                                <span class="json-property-name">working_dir:</span>
-                                                                
-                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/WorkingDirectory">WorkingDirectory</a>
-                                                                </span>
-                                                                <span class="json-property-range" title="Value limits"></span>
-                                                                
-                                                            </dt>
-                                                            <dd>
-                                                                
-                                                                <div class="json-inner-schema">
-                                                                    
-                                                                </div>
-                                                            </dd>
-                                                    </dl>
-                                                </section>
+                                            <a class="json-schema-ref" href="#/definitions/SimpleRequest">SimpleRequest</a>
                                 </div>
                             </div></div>
                                         </div>
@@ -1016,6 +924,20 @@
                                                                 <span class="json-property-name">working_dir:</span>
                                                                 
                                                                 <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/WorkingDirectory">WorkingDirectory</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="extra_conf_data">
+                                                                <span class="json-property-name">extra_conf_data:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/ExtraConfData">ExtraConfData</a>
                                                                 </span>
                                                                 <span class="json-property-range" title="Value limits"></span>
                                                                 
@@ -1832,6 +1754,20 @@
                                                                 <span class="json-property-name">working_dir:</span>
                                                                 
                                                                 <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/WorkingDirectory">WorkingDirectory</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="extra_conf_data">
+                                                                <span class="json-property-name">extra_conf_data:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/ExtraConfData">ExtraConfData</a>
                                                                 </span>
                                                                 <span class="json-property-range" title="Value limits"></span>
                                                                 
@@ -2883,6 +2819,27 @@
                                     </section>
                     </div>
                 </div>        
+                <div id="definition-ExtraConfData" class="panel panel-definition">
+                        <div class="panel-heading">
+                                <h3 class="panel-title"><a name="/definitions/ExtraConfData"></a>ExtraConfData:
+                                    <span class="json-property-type">
+                <span class="json-property-type">object</span>
+                <span class="json-property-range" title="Value limits"></span>
+                
+                </span>
+                                </h3>
+                        </div>
+                    <div class="panel-body">
+                                <section class="json-schema-description">
+                                    <p>A dictionary passed to the <code>FlagsForFile</code> function of the
+                            <code>.ycm_extra_conf.py</code> file as the <code>client_data</code> parameter. This optional
+                            field should be used to give users a way to customize the
+                            <code>.ycm_extra_conf.py</code> file with their own set of options.</p>
+                            
+                                </section>
+                            
+                    </div>
+                </div>        
                 <div id="definition-FileData" class="panel panel-definition">
                         <div class="panel-heading">
                                 <h3 class="panel-title"><a name="/definitions/FileData"></a>FileData:
@@ -3675,6 +3632,20 @@
                                                     <span class="json-property-name">working_dir:</span>
                                                     
                                                     <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/WorkingDirectory">WorkingDirectory</a>
+                                                    </span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                </dt>
+                                                <dd>
+                                                    
+                                                    <div class="json-inner-schema">
+                                                        
+                                                    </div>
+                                                </dd>
+                                                <dt data-property-name="extra_conf_data">
+                                                    <span class="json-property-name">extra_conf_data:</span>
+                                                    
+                                                    <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/ExtraConfData">ExtraConfData</a>
                                                     </span>
                                                     <span class="json-property-range" title="Value limits"></span>
                                                     

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -148,6 +148,13 @@ definitions:
       Absolute path to the filesystem working directory of the client. This is
       used by completer engines to determine things like the project root
       for the file being modified, amongst other things.
+  ExtraConfData:
+    type: object
+    description: |-
+      A dictionary passed to the `FlagsForFile` function of the
+      `.ycm_extra_conf.py` file as the `client_data` parameter. This optional
+      field should be used to give users a way to customize the
+      `.ycm_extra_conf.py` file with their own set of options.
   FileData:
     type: object
     description: |-
@@ -184,8 +191,8 @@ definitions:
       $ref: "#/definitions/FileData"
 
   # Due to the way the API combines keys at the top level, we are not able to
-  # compose this item per-request. So this definition is actually not used, but
-  # is kept here as a source of copypasta.
+  # compose this item per-request. So this definition must be copy-pasted for
+  # some requests.
   SimpleRequest:
     type: object
     required:
@@ -206,6 +213,8 @@ definitions:
         $ref: "#/definitions/CompleterTarget"
       working_dir:
         $ref: "#/definitions/WorkingDirectory"
+      extra_conf_data:
+        $ref: "#/definitions/ExtraConfData"
 
   Exception:
     type: object
@@ -637,6 +646,8 @@ paths:
                 $ref: "#/definitions/CompleterTarget"
               working_dir:
                 $ref: "#/definitions/WorkingDirectory"
+              extra_conf_data:
+                $ref: "#/definitions/ExtraConfData"
               event_name:
                 type: string
                 enum:
@@ -756,6 +767,8 @@ paths:
                 $ref: "#/definitions/CompleterTarget"
               working_dir:
                 $ref: "#/definitions/WorkingDirectory"
+              extra_conf_data:
+                $ref: "#/definitions/ExtraConfData"
               command_arguments:
                 type: array
                 description: |-
@@ -881,25 +894,7 @@ paths:
             of dirty buffers.
           required: true
           schema:
-            type: object
-            required:
-              - line_num
-              - column_num
-              - filepath
-              - file_data
-            properties:
-              line_num:
-                $ref: "#/definitions/LineNumber"
-              column_num:
-                $ref: "#/definitions/ColumnNumber"
-              filepath:
-                $ref: "#/definitions/FilePath"
-              file_data:
-                $ref: "#/definitions/FileDataMap"
-              completer_target:
-                $ref: "#/definitions/CompleterTarget"
-              working_dir:
-                $ref: "#/definitions/WorkingDirectory"
+            $ref: "#/definitions/SimpleRequest"
       responses:
         200:
           description: The list of completion suggestions.

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -447,7 +447,7 @@ class ClangCompleter( Completer ):
                                      filename ),
                filename )
 
-    client_data = request_data.get( 'extra_conf_data', None )
+    client_data = request_data[ 'extra_conf_data' ]
     return self._flags.FlagsForFile( filename, client_data = client_data )
 
 

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -91,7 +91,7 @@ class Flags( object ):
   'modules') that contain a method FlagsForFile( filename )."""
 
   def __init__( self ):
-    # It's caches all the way down...
+    # We cache the flags by a tuple of filename and client data.
     self.flags_for_file = {}
     self.extra_clang_flags = _ExtraClangFlags()
     self.no_extra_conf_file_warning_posted = False
@@ -128,7 +128,7 @@ class Flags( object ):
     # may be called from multiple threads, and python gives us
     # 1-python-statement synchronisation for "free" (via the GIL)
     try:
-      return self.flags_for_file[ filename ]
+      return self.flags_for_file[ filename, client_data ]
     except KeyError:
       pass
 
@@ -148,13 +148,15 @@ class Flags( object ):
 
     return self._ParseFlagsFromExtraConfOrDatabase( filename,
                                                     results,
-                                                    add_extra_clang_flags )
+                                                    add_extra_clang_flags,
+                                                    client_data )
 
 
   def _ParseFlagsFromExtraConfOrDatabase( self,
                                           filename,
                                           results,
-                                          add_extra_clang_flags ):
+                                          add_extra_clang_flags,
+                                          client_data ):
     if 'override_filename' in results:
       filename = results[ 'override_filename' ] or filename
 
@@ -172,7 +174,7 @@ class Flags( object ):
                                             _ShouldAllowWinStyleFlags( flags ) )
 
     if results.get( 'do_cache', True ):
-      self.flags_for_file[ filename ] = sanitized_flags, filename
+      self.flags_for_file[ filename, client_data ] = sanitized_flags, filename
 
     return sanitized_flags, filename
 

--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -28,6 +28,7 @@ from future.utils import iteritems
 
 from ycmd.utils import ( ByteOffsetToCodepointOffset,
                          CodepointOffsetToByteOffset,
+                         HashableDict,
                          ToUnicode,
                          ToBytes,
                          SplitLines )
@@ -91,7 +92,9 @@ class RequestWrap( object ):
 
       'force_semantic': ( self._GetForceSemantic, None ),
 
-      'lines': ( self._CurrentLines, None )
+      'lines': ( self._CurrentLines, None ),
+
+      'extra_conf_data': ( self._GetExtraConfData, None )
     }
     self._cached_computed = dict()
 
@@ -128,6 +131,7 @@ class RequestWrap( object ):
          self[ 'start_column' ]     != other[ 'start_column' ] or
          self[ 'prefix' ]           != other[ 'prefix' ] or
          self[ 'force_semantic' ]   != other[ 'force_semantic' ] or
+         self[ 'extra_conf_data' ]  != other[ 'extra_conf_data' ] or
          len( self[ 'file_data' ] ) != len( other[ 'file_data' ] ) ):
       return False
 
@@ -247,6 +251,10 @@ class RequestWrap( object ):
 
   def _GetForceSemantic( self ):
     return bool( self._request.get( 'force_semantic', False ) )
+
+
+  def _GetExtraConfData( self ):
+    return HashableDict( self._request.get( 'extra_conf_data', {} ) )
 
 
 def CompletionStartColumn( line_value, column_num, filetype ):

--- a/ycmd/tests/clang/testdata/client_data/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/client_data/.ycm_extra_conf.py
@@ -1,2 +1,2 @@
 def FlagsForFile( filename, **kwargs ):
-  return { 'flags': kwargs[ 'client_data' ][ 'flags' ] }
+  return { 'flags': kwargs[ 'client_data' ].get( 'flags', [] ) }

--- a/ycmd/tests/clang/testdata/client_data/macro.cpp
+++ b/ycmd/tests/clang/testdata/client_data/macro.cpp
@@ -1,0 +1,12 @@
+struct Test {
+#ifdef SOME_MACRO
+  int macro_defined;
+#else
+  int macro_not_defined;
+#endif
+};
+
+int main() {
+  Test test;
+  test.
+}

--- a/ycmd/tests/request_wrap_test.py
+++ b/ycmd/tests/request_wrap_test.py
@@ -24,7 +24,8 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from hamcrest import assert_that, calling, equal_to, raises
+from hamcrest import ( assert_that, calling, empty, equal_to, has_entry,
+                       has_string, matches_regexp, raises )
 from nose.tools import eq_
 
 from ycmd.utils import ToBytes
@@ -35,7 +36,8 @@ def PrepareJson( contents = '',
                  line_num = 1,
                  column_num = 1,
                  filetype = '',
-                 force_semantic = None ):
+                 force_semantic = None,
+                 extra_conf_data = None ):
   message = {
     'line_num': line_num,
     'column_num': column_num,
@@ -49,6 +51,8 @@ def PrepareJson( contents = '',
   }
   if force_semantic is not None:
     message[ 'force_semantic' ] = force_semantic
+  if extra_conf_data is not None:
+    message[ 'extra_conf_data' ] = extra_conf_data
 
   return message
 
@@ -372,3 +376,19 @@ def ForceSemanticCompletion_test():
 
   wrap = RequestWrap( PrepareJson( force_semantic = 'No' ) )
   assert_that( wrap[ 'force_semantic' ], equal_to( True ) )
+
+
+def ExtraConfData_test():
+  wrap = RequestWrap( PrepareJson() )
+  assert_that( wrap[ 'extra_conf_data' ], empty() )
+
+  wrap = RequestWrap( PrepareJson( extra_conf_data = { 'key': 'value' } ) )
+  extra_conf_data = wrap[ 'extra_conf_data' ]
+  assert_that( extra_conf_data, has_entry( 'key', 'value' ) )
+  assert_that(
+    extra_conf_data,
+    has_string( matches_regexp( "^<HashableDict {u?'key': u?'value'}>$" ) )
+  )
+  # Check that extra_conf_data can be used as a dictionary's key.
+  assert_that( { extra_conf_data: 'extra conf data' },
+               has_entry( extra_conf_data, 'extra conf data' ) )

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -25,6 +25,8 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 from future.utils import PY2, native
+import collections
+import json
 import os
 import socket
 import subprocess
@@ -496,3 +498,35 @@ def StartThread( func, *args ):
   thread.daemon = True
   thread.start()
   return thread
+
+
+class HashableDict( collections.Mapping ):
+  """A dictionary that can be used in dictionary's keys. The dictionary must be
+  JSON-encodable; in particular, all keys must be strings."""
+
+  def __init__( self, *args, **kwargs ):
+    self._dict = dict( *args, **kwargs )
+
+
+  def __getitem__( self, key ):
+    return self._dict[ key ]
+
+
+  def __iter__( self ):
+    return iter( self._dict )
+
+
+  def __len__( self ):
+    return len( self._dict )
+
+
+  def __repr__( self ):
+    return '<HashableDict %s>' % repr( self._dict )
+
+
+  def __hash__( self ):
+    try:
+      return self._hash
+    except AttributeError:
+      self._hash = json.dumps( self._dict, sort_keys = True ).__hash__()
+      return self._hash


### PR DESCRIPTION
We currently cache the compilation flags by file path but we should also cache them according to the `client_data` parameter given to the `FlagsForFile` function since this parameter may be used to change the list of flags. In other words, the `flags_for_file` variable should be indexed by the `( filename, client_data )` tuple. However, `client_data` is a dictionary and dictionaries are not hashable so they can't be used as part of dictionaries' keys. We need to introduce a new class `HashableDict` which is a dictionary wrapper implementing the `__hash__` method, and convert `client_data` to that class.

In addition, this PR simplifies the use of the `client_data` parameter in the `FlagsForFile` function by always passing the parameter as a dictionary. For instance, instead of having to write:
```python
def FlagsForFile( filename, **kwargs ):
  client_data = kwargs.get( 'client_data' )
  if client_data:
    return { 'flags': client_data.get( 'flags', [] ) }
  return { 'flags': [] }
```
one can now write:
```python
def FlagsForFile( filename, **kwargs ):
  return { 'flags': kwargs[ 'client_data' ].get( 'flags', [] ) }
```

The API docs are updated to mention the optional `extra_conf_data` field in a request.

Here's a demo with the Vim client (but this could work for any client supporting the `extra_conf_data` feature) that shows the benefit of these changes :

![ycmd-cache-client-data](https://user-images.githubusercontent.com/10026824/39136458-97431a78-471b-11e8-8749-f461a0049d51.gif)

In that demo, the compilation flags are given by setting the `g:ycm_compiler_flags` option. Without these changes, the user would have to run the `ClearCompilationFlagCache` command or restart the server after modifying the `g:ycm_compiler_flags` option for the flags to be updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1010)
<!-- Reviewable:end -->
