### PR TITLE
[READY] Minor fixes from LGTM

### DIFF
--- a/build.py
+++ b/build.py
@@ -673,7 +673,6 @@ def EnableJavaCompleter( switches ):
       jdtls_build_stamp = JDTLS_BUILD_STAMP )
   url = JDTLS_SERVER_URL_FORMAT.format(
       jdtls_milestone = JDTLS_MILESTONE,
-      jdtls_build_stamp = JDTLS_BUILD_STAMP,
       jdtls_package_name = package_name )
   file_name = p.join( CACHE, package_name )
 

--- a/cpp/ycm/Word.cpp
+++ b/cpp/ycm/Word.cpp
@@ -51,7 +51,7 @@ std::vector< std::string > BreakCodePointsIntoCharacters(
     return characters;
   }
 
-  int regional_indicator_nb = 0;
+  bool is_regional_indicator_nb_odd = false;
   bool within_emoji_modifier = false;
 
   for ( ; code_point_pos != code_points.end() ; ++previous_code_point_pos,
@@ -222,7 +222,6 @@ std::vector< std::string > BreakCodePointsIntoCharacters(
         }
         break;
       case BreakProperty::REGIONAL_INDICATOR:
-        regional_indicator_nb += 1;
         switch( property ) {
           // Rule GB9: do not break before extending characters or when using a
           // zero-width joiner (ZWJ).
@@ -231,13 +230,14 @@ std::vector< std::string > BreakCodePointsIntoCharacters(
           // Rule GB9a: do not break before spacing marks.
           case BreakProperty::SPACINGMARK:
             character.append( code_point );
-            regional_indicator_nb = 0;
+            is_regional_indicator_nb_odd = false;
             break;
           // Rules GB12 and GB13: do not break within emoji flag sequences. That
           // is, do not break between regional indicator (RI) symbols if there
           // is an odd number of RI characters before the break point.
           case BreakProperty::REGIONAL_INDICATOR:
-            if ( regional_indicator_nb % 2 == 1 ) {
+            is_regional_indicator_nb_odd = !is_regional_indicator_nb_odd;
+            if ( is_regional_indicator_nb_odd ) {
               character.append( code_point );
             } else {
               characters.push_back( character );
@@ -247,7 +247,7 @@ std::vector< std::string > BreakCodePointsIntoCharacters(
           default:
             characters.push_back( character );
             character = code_point;
-            regional_indicator_nb = 0;
+            is_regional_indicator_nb_odd = false;
         }
         break;
       default:

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,7 @@
     <p>The full list of command line options can be obtained by passing <code>--help</code>
     to ycmd (e.g. <code>python -m ycmd --help</code>). However, the following
     options warrant further discussion:</p>
-    <h3 id="-options_file-"><code>--options_file</code></h3>
+    <h3 id="-options_file"><code>--options_file</code></h3>
     <p>This mandatory option supplies the name of a file containing user options
     data. This option (and thus the file) are mandatory, as they are required
     to set the shared HMAC secret.</p>
@@ -2991,8 +2991,8 @@
                     <div class="panel-body">
                                 <section class="json-schema-description">
                                     <p>Absolute path to the file in the filesystem. If the file does
-                            not yet exist (for example, a new file), then the value may be the empty
-                            string.</p>
+                            not yet exist (for example, a new file), then the value should be an
+                            arbitrary unique string.</p>
                             
                                 </section>
                             

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -127,8 +127,8 @@ definitions:
     type: string
     description: |-
       Absolute path to the file in the filesystem. If the file does
-      not yet exist (for example, a new file), then the value may be the empty
-      string.
+      not yet exist (for example, a new file), then the value should be an
+      arbitrary unique string.
   CompleterTarget:
     type: string
     description: |-

--- a/update_unicode.py
+++ b/update_unicode.py
@@ -103,13 +103,13 @@ def UnicodeToBinaryUtf8( code_point ):
   binary_length = len( binary )
   if binary_length <= 7:
     return binary.zfill( 8 )
-  if binary_length > 7 and binary_length <= 11:
+  if binary_length <= 11:
     binary = binary.zfill( 11 )
     return '110' + binary[ :5 ] + '10' + binary[ 5: ]
-  if binary_length > 11 and binary_length <= 16:
+  if binary_length <= 16:
     binary = binary.zfill( 16 )
     return '1110' + binary[ :4 ] + '10' + binary[ 4:10 ] + '10' + binary[ 10: ]
-  if binary_length > 16 and binary_length <= 21:
+  if binary_length <= 21:
     binary = binary.zfill( 21 )
     return ( '11110' + binary[ :3 ] + '10' + binary[ 3:9 ] +
              '10' + binary[ 9:15 ] + '10' + binary[ 15: ] )

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -46,7 +46,6 @@ from ycmd.responses import NoExtraConfDetected, UnknownExtraConf
 CLANG_FILETYPES = set( [ 'c', 'cpp', 'objc', 'objcpp' ] )
 PARSING_FILE_MESSAGE = 'Still parsing file, no completions yet.'
 NO_COMPILE_FLAGS_MESSAGE = 'Still no compile flags, no completions yet.'
-INVALID_FILE_MESSAGE = 'File is invalid.'
 NO_COMPLETIONS_MESSAGE = 'No completions found; errors in the file?'
 NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 PRAGMA_DIAG_TEXT_TO_IGNORE = '#pragma once in main file'
@@ -445,8 +444,6 @@ class ClangCompleter( Completer ):
 
   def _FlagsForRequest( self, request_data ):
     filename = request_data[ 'filepath' ]
-    if not filename:
-      raise INVALID_FILE_MESSAGE
 
     if 'compilation_flags' in request_data:
       # Not supporting specifying the translation unit using this method as it

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -418,7 +418,6 @@ def _RemoveUnusedFlags( flags, filename, enable_windows_style_flags ):
     flags = flags[ 1: ]
 
   skip_next = False
-  previous_flag = flags[ 0 ]
   current_flag = flags[ 0 ]
 
   filename = os.path.realpath( filename )

--- a/ycmd/completers/python/jedi_completer.py
+++ b/ycmd/completers/python/jedi_completer.py
@@ -320,7 +320,6 @@ class JediCompleter( Completer ):
       return self._GoToDefinition( request_data )
     except Exception as e:
       self._logger.exception( e )
-      pass
 
     try:
       return self._GoToDeclaration( request_data )


### PR DESCRIPTION
Fix some errors reported by [the LGTM service](https://lgtm.com/projects/g/Valloric/ycmd/).

I removed the filename check in the Clang completer since a client should never send an empty string for the filename: an arbitrary unique string should be used for a non-existing file (in YCM, we use the current directory plus the buffer number). The reason is simple: if the client has several buffers with no filename then the server must be able to distinguish them. I updated the API docs to reflect this. If we really want to check that the filename is not the empty string, we should do that when validating the request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1012)
<!-- Reviewable:end -->
