### PR TITLE
[READY] Force MSVC to treat source files as UTF-8 encoded

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -178,10 +178,10 @@ endif()
 
 # For MSVC enable UNICODE and compilation on multiple processors. Increase the
 # number of sections that an object file can hold. This is needed for storing
-# the Unicode table.
+# the Unicode table. Also, force MSVC to treat source files as UTF-8 encoded.
 if ( MSVC )
   add_definitions( /DUNICODE /D_UNICODE /Zc:wchar_t- )
-  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /bigobj" )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /bigobj /utf-8" )
 endif()
 
 if( MSVC OR CYGWIN OR MSYS)


### PR DESCRIPTION
Compilation fails with a lot of these errors:
```
error C3688: invalid literal suffix '唷'; literal operator or literal operator template 'operator ""唷' not found
```
when the system local is Chinese on Windows. This is fixed by forcing MSVC to use UTF-8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1015)
<!-- Reviewable:end -->
