### PR TITLE
[READY] Bundle and compile the regex module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,3 @@ docs/package-lock.json
 
 # jdt.ls
 third_party/eclipse.jdt.ls
-
-# regex module
-third_party/regex/py*

--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,6 @@
 [submodule "third_party/python-future"]
 	path = third_party/python-future
 	url = https://github.com/PythonCharmers/python-future
+[submodule "third_party/cregex"]
+	path = third_party/cregex
+	url = https://github.com/micbou/regex.git

--- a/benchmark.py
+++ b/benchmark.py
@@ -31,7 +31,8 @@ def BuildYcmdLibsAndRunBenchmark( args, extra_args ):
   build_cmd = [
     sys.executable,
     p.join( DIR_OF_THIS_SCRIPT, 'build.py' ),
-    '--clang-completer'
+    '--clang-completer',
+    '--no-regex'
   ] + extra_args
 
   os.environ[ 'YCM_BENCHMARK' ] = '1'

--- a/run_tests.py
+++ b/run_tests.py
@@ -31,8 +31,8 @@ for folder in os.listdir( DIR_OF_THIRD_PARTY ):
   # sys.path the path is.
   if folder == 'python-future':
     continue
-  if folder == 'regex':
-    folder = p.join( folder, 'py{}'.format( sys.version_info[ 0 ] ) )
+  if folder == 'cregex':
+    folder = p.join( folder, 'regex_{}'.format( sys.version_info[ 0 ] ) )
   python_path.append( p.abspath( p.join( DIR_OF_THIRD_PARTY, folder ) ) )
 if os.environ.get( 'PYTHONPATH' ) is not None:
   python_path.append( os.environ['PYTHONPATH'] )

--- a/third_party/regex/README.md
+++ b/third_party/regex/README.md
@@ -1,8 +1,0 @@
-ycmd regex module
-=================
-
-This is the directory where the `build.py` script installs the [regex][] module.
-The Python 2 and Python 3 versions of that module are installed in the `py2` and
-`py3` folders respectively.
-
-[regex]: https://pypi.python.org/pypi/regex/

--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -189,8 +189,9 @@ def AddNearestThirdPartyFoldersToSysPath( filepath ):
                                                        folder ) ) )
       continue
 
-    if folder == 'regex':
-      folder = os.path.join( folder, 'py{}'.format( sys.version_info[ 0 ] ) )
+    if folder == 'cregex':
+      folder = os.path.join( folder,
+                             'regex_{}'.format( sys.version_info[ 0 ] ) )
 
     sys.path.insert( 0, os.path.realpath( os.path.join( path_to_third_party,
                                                         folder ) ) )

--- a/ycmd/tests/server_utils_test.py
+++ b/ycmd/tests/server_utils_test.py
@@ -53,10 +53,10 @@ THIRD_PARTY_FOLDERS = [
 ]
 if PY2:
   THIRD_PARTY_FOLDERS.append(
-    os.path.join( DIR_OF_THIRD_PARTY, 'regex', 'py2' ) )
+    os.path.join( DIR_OF_THIRD_PARTY, 'cregex', 'regex_2' ) )
 else:
   THIRD_PARTY_FOLDERS.append(
-    os.path.join( DIR_OF_THIRD_PARTY, 'regex', 'py3' ) )
+    os.path.join( DIR_OF_THIRD_PARTY, 'cregex', 'regex_3' ) )
 
 
 


### PR DESCRIPTION
It turns out that using pip to download and install the regex module in a specific folder is too much to ask. See issues https://github.com/Valloric/YouCompleteMe/issues/3001 and https://github.com/Valloric/ycmd/issues/1014. There is also the issue that pip is not always available. The default Python doesn't have pip on macOS and the `python-pip` or `python3-pip` packages must be installed on Ubuntu. We need a better solution.

This PR proposes to vendor the regex sources as a Git submodule and compile the module when running the `build.py` script. The [submodule](https://github.com/micbou/regex) is a clone of [the official repository](https://bitbucket.org/mrabarnett/mrab-regex) (which is a mercurial repository hosted on BitBucket) containing a `CMakeLists.txt` file to easily compile the module with CMake. We put the submodule in a different folder than `third_party/regex` to avoid the error that a directory already exists when pulling the changes with Git.

Finally, we add the `--no-regex` option to the `build.py` script to disable compilation of the regex module. This allows running the ycm_core tests or benchmarks without building the module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1017)
<!-- Reviewable:end -->
