### PR TITLE
[READY] Check for broken Anaconda build flags

### DIFF
--- a/build.py
+++ b/build.py
@@ -387,6 +387,15 @@ def ParseArguments():
        not args.all_completers ):
     sys.exit( 'ERROR: you can\'t pass --system-libclang without also passing '
               '--clang-completer or --all as well.' )
+
+  if ( 'Anaconda' in sys.version and
+     args.clang_completer and
+     not args.system_libclang ):
+    sys.exit( 'ERROR: Anaconda\'s libraries are too'
+              ' old to support libclang.\n'
+              '       If you want to build ycm_core.so with Anaconda, '
+              'specify --system-libclang.\n'
+              '       Alternatively, build ycm_core.so without Anaconda.')
   return args
 
 


### PR DESCRIPTION
As discussed in gitter, we figured out what makes ycmd broken when using Anaconda python.

Here's the result of this PR:
```
bstaletic@gentoo ycmd  (git)-[anaconda_check]-% ./build.py --clang-completer
ERROR: Anaconda's libraries are too old to support libclang.
       If you want to build ycm_core.so with Anaconda, specify --system-libclang.
       Alternatively, build ycm_core.so without Anaconda.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1022)
<!-- Reviewable:end -->
