### PR TITLE
[READY] Fix regex used to complete include statement

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2011-2012 Google Inc.
-#               2018      ycmd contributors
+# Copyright (C) 2011-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -50,7 +49,7 @@ NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 PRAGMA_DIAG_TEXT_TO_IGNORE = '#pragma once in main file'
 TOO_MANY_ERRORS_DIAG_TEXT_TO_IGNORE = 'too many errors emitted, stopping now'
 NO_DOCUMENTATION_MESSAGE = 'No documentation available for current context'
-INCLUDE_REGEX = re.compile( '(\s*#\s*(?:include|import)\s*)(:?"[^"]*|<[^>]*)' )
+INCLUDE_REGEX = re.compile( '(\s*#\s*(?:include|import)\s*)(?:"[^"]*|<[^>]*)' )
 
 
 class ClangCompleter( Completer ):

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -913,6 +913,28 @@ def GetCompletions_QuotedInclude_AfterSpace_test( app ):
 
 
 @SharedYcmd
+def GetCompletions_QuotedInclude_Invalid_test( app ):
+  RunTest( app, {
+    'description': 'completion of an invalid include statement',
+    'request': {
+      'filetype'  : 'cpp',
+      'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
+      'line_num'  : 11,
+      'column_num': 12,
+      'compilation_flags': [ '-x', 'cpp' ]
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 12,
+        'completions': empty(),
+        'errors': empty(),
+      } )
+    },
+  } )
+
+
+@SharedYcmd
 def GetCompletions_BracketInclude_AtStart_test( app ):
   RunTest( app, {
     'description': 'completion of #include <',

--- a/ycmd/tests/clang/testdata/test-include/main.cpp
+++ b/ycmd/tests/clang/testdata/test-include/main.cpp
@@ -8,3 +8,4 @@
 
 #include "dir with spaces/d.hpp"
 #include <system/
+#include :"


### PR DESCRIPTION
A typo in the regex for include statements: mostly harmless because instead of not capturing the `("[^"]*|<[^>]*)` pattern, it's matching an optional colon before the quotes, e.g. `#include :"` is matched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1023)
<!-- Reviewable:end -->
