### PR TITLE
Support java source from jar package

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -252,6 +252,10 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
       # We don't want expose this subcommand because it is not really needed
       # for the user but it is useful in tests for tearing down the server
       subcommands.remove( 'StopServer' )
+      # Don't expose ClassFileContents, user need not run the command manually
+      # client of ycmd will call this command whenever a uri like
+      # jdt://contents/*/.class is opened
+      subcommands.remove( 'ClassFileContents' )
     except ValueError:
       pass
     return subcommands

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -254,6 +254,9 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       'OrganizeImports': (
         lambda self, request_data, args: self.OrganizeImports( request_data )
       ),
+      'ClassFileContents': (
+        lambda self, request_data, args: self.ClassFileContents( request_data )
+      ),
     }
 
 

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1030,11 +1030,7 @@ class LanguageServerCompleter( Completer ):
       params = notification[ 'params' ]
       uri = params[ 'uri' ]
 
-      try:
-        filepath = lsp.UriToFilePath( uri )
-      except lsp.InvalidUriException:
-        _logger.exception( 'Ignoring diagnostics for unrecognized URI' )
-        return None
+      filepath = lsp.UriToFilePath( uri )
 
       with self._server_info_mutex:
         if filepath in self._server_file_state:
@@ -1327,6 +1323,19 @@ class LanguageServerCompleter( Completer ):
         raise RuntimeError( 'Cannot jump to location' )
     else:
       raise RuntimeError( 'Cannot jump to location' )
+
+
+  def ClassFileContents( self, request_data ):
+    """Issues the classFileContents request and returns the result as
+    response."""
+    if not self.ServerIsReady():
+      raise RuntimeError( 'Server is initializing. Please wait.' )
+
+    request_id = self.GetConnection().NextRequestId()
+    return self.GetConnection().GetResponse(
+      request_id,
+      lsp.ClassFileContents( request_id, request_data ),
+      REQUEST_TIMEOUT_COMMAND )
 
 
   def GoToReferences( self, request_data ):
@@ -1738,12 +1747,12 @@ def _LocationListToGoTo( request_data, response ):
 def _PositionToLocationAndDescription( request_data, position ):
   """Convert a LSP position to a ycmd location."""
   try:
-    filename = lsp.UriToFilePath( position[ 'uri' ] )
-    file_contents = GetFileLines( request_data, filename )
-  except lsp.InvalidUriException:
-    _logger.debug( "Invalid URI, file contents not available in GoTo" )
-    filename = ''
-    file_contents = []
+    if responses.IsJdtContentUri( position[ 'uri' ] ):
+      filename = position[ 'uri' ]
+      file_contents = []
+    else:
+      filename = lsp.UriToFilePath( position[ 'uri' ] )
+      file_contents = GetFileLines( request_data, filename )
   except IOError:
     # It's possible to receive positions for files which no longer exist (due to
     # race condition). UriToFilePath doesn't throw IOError, so we can assume
@@ -1793,12 +1802,7 @@ def _BuildRange( contents, filename, r ):
 
 def _BuildDiagnostic( contents, uri, diag ):
   """Return a ycmd diagnostic from a LSP diagnostic."""
-  try:
-    filename = lsp.UriToFilePath( uri )
-  except lsp.InvalidUriException:
-    _logger.debug( 'Invalid URI received for diagnostic' )
-    filename = ''
-
+  filename = lsp.UriToFilePath( uri )
   r = _BuildRange( contents, filename, diag[ 'range' ] )
 
   return responses.BuildDiagnosticData( responses.Diagnostic(
@@ -1811,12 +1815,7 @@ def _BuildDiagnostic( contents, uri, diag ):
 
 def TextEditToChunks( request_data, uri, text_edit ):
   """Returns a list of FixItChunks from a LSP textEdit."""
-  try:
-    filepath = lsp.UriToFilePath( uri )
-  except lsp.InvalidUriException:
-    _logger.debug( 'Invalid filepath received in TextEdit' )
-    filepath = ''
-
+  filepath = lsp.UriToFilePath( uri )
   contents = GetFileLines( request_data, filepath )
   return [
     responses.FixItChunk( change[ 'newText' ],

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -133,13 +133,21 @@ def BuildCompletionResponse( completion_datas,
   }
 
 
+def IsJdtContentUri( uri ):
+  return uri[ : 6 ] == "jdt://"
+
+
 # location.column_number_ is a byte offset
 def BuildLocationData( location ):
+  filename = ''
+  if location.filename_:
+    filename = location.filename_
+    if not IsJdtContentUri( filename ):
+      filename = os.path.normpath( filename )
   return {
     'line_num': location.line_number_,
     'column_num': location.column_number_,
-    'filepath': ( os.path.normpath( location.filename_ )
-                  if location.filename_ else '' ),
+    'filepath': filename,
   }
 
 
@@ -209,7 +217,10 @@ class Location( object ):
     self.line_number_ = line
     self.column_number_ = column
     if filename:
-      self.filename_ = os.path.realpath( filename )
+      if IsJdtContentUri( filename ):
+        self.filename_ = filename
+      else:
+        self.filename_ = os.path.realpath( filename )
     else:
       # When the filename passed (e.g. by a server) can't be recognized or
       # parsed, we send an empty filename. This at least allows the client to

--- a/ycmd/tests/java/diagnostics_test.py
+++ b/ycmd/tests/java/diagnostics_test.py
@@ -50,7 +50,6 @@ from ycmd.completers import completer
 
 from pprint import pformat
 from mock import patch
-from ycmd.completers.language_server import language_server_protocol as lsp
 from ycmd import handlers
 
 
@@ -456,46 +455,6 @@ public class Test {
 
 
 @IsolatedYcmd
-@patch(
-  'ycmd.completers.language_server.language_server_protocol.UriToFilePath',
-  side_effect = lsp.InvalidUriException )
-def FileReadyToParse_Diagnostics_InvalidURI_test( app, uri_to_filepath, *args ):
-  StartJavaCompleterServerInDirectory( app,
-                                       PathToTestFile( DEFAULT_PROJECT_DIR ) )
-
-  filepath = TestFactory
-  contents = ReadFile( filepath )
-
-  # It can take a while for the diagnostics to be ready
-  expiration = time.time() + 10
-  while True:
-    try:
-      results = _WaitForDiagnosticsToBeReady( app, filepath, contents )
-      print( 'Completer response: {0}'.format(
-        json.dumps( results, indent=2 ) ) )
-
-      uri_to_filepath.assert_called()
-
-      assert_that( results, has_item(
-        has_entries( {
-          'kind': 'WARNING',
-          'text': 'The value of the field TestFactory.Bar.testString is not '
-                  'used',
-          'location': LocationMatcher( '', 15, 19 ),
-          'location_extent': RangeMatcher( '', ( 15, 19 ), ( 15, 29 ) ),
-          'ranges': contains( RangeMatcher( '', ( 15, 19 ), ( 15, 29 ) ) ),
-          'fixit_available': False
-        } ),
-      ) )
-
-      return
-    except AssertionError:
-      if time.time() > expiration:
-        raise
-      time.sleep( 0.25 )
-
-
-@IsolatedYcmd
 def FileReadyToParse_ServerNotReady_test( app ):
   filepath = TestFactory
   contents = ReadFile( filepath )
@@ -680,38 +639,6 @@ def OnBufferUnload_ServerNotRunning_test( app ):
                                filetype = 'java' )
     result = app.post_json( '/event_notification', event_data ).json
     assert_that( result, equal_to( {} ) )
-
-
-@IsolatedYcmd
-def PollForMessages_InvalidUri_test( app, *args ):
-  StartJavaCompleterServerInDirectory(
-    app,
-    PathToTestFile( 'simple_eclipse_project' ) )
-
-  filepath = TestFactory
-  contents = ReadFile( filepath )
-
-  with patch(
-    'ycmd.completers.language_server.language_server_protocol.UriToFilePath',
-    side_effect = lsp.InvalidUriException ):
-
-    for tries in range( 0, 5 ):
-      response = app.post_json( '/receive_messages',
-                                BuildRequest(
-                                  filetype = 'java',
-                                  filepath = filepath,
-                                  contents = contents ) ).json
-      if response is True:
-        break
-      elif response is False:
-        raise AssertionError( 'Message poll was aborted unexpectedly' )
-      elif 'diagnostics' in response:
-        raise AssertionError( 'Did not expect diagnostics when file paths '
-                              'are invalid' )
-
-      time.sleep( 0.5 )
-
-  assert_that( response, equal_to( True ) )
 
 
 @IsolatedYcmd

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -175,23 +175,6 @@ def LanguageServerCompleter_GoToDeclaration_test():
     yield Test, response, checker, throws
 
 
-  with patch(
-    'ycmd.completers.language_server.language_server_protocol.UriToFilePath',
-    side_effect = lsp.InvalidUriException ):
-    yield Test, {
-      'result': {
-        'uri': uri,
-        'range': {
-          'start': { 'line': 0, 'character': 0 },
-          'end': { 'line': 0, 'character': 0 },
-        }
-      }
-    }, has_entries( {
-      'filepath': '',
-      'column_num': 1,
-      'line_num': 1,
-    } ), False
-
   with patch( 'ycmd.completers.completer_utils.GetFileContents',
               side_effect = lsp.IOError ):
     yield Test, {

--- a/ycmd/tests/language_server/language_server_protocol_test.py
+++ b/ycmd/tests/language_server/language_server_protocol_test.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 from ycmd.completers.language_server import language_server_protocol as lsp
-from hamcrest import assert_that, equal_to, calling, is_not, raises
+from hamcrest import assert_that, equal_to, is_not
 from ycmd.tests.test_utils import UnixOnly, WindowsOnly
 
 
@@ -152,9 +152,8 @@ def ServerFileStateStore_RetrieveDelete_test():
 
 @UnixOnly
 def UriToFilePath_Unix_test():
-  assert_that( calling( lsp.UriToFilePath ).with_args( 'test' ),
-               raises( lsp.InvalidUriException ) )
-
+  assert_that( lsp.UriToFilePath( 'jdt://usr/local/test/test.test' ),
+               equal_to( 'jdt://usr/local/test/test.test' ) )
   assert_that( lsp.UriToFilePath( 'file:/usr/local/test/test.test' ),
                equal_to( '/usr/local/test/test.test' ) )
   assert_that( lsp.UriToFilePath( 'file:///usr/local/test/test.test' ),
@@ -163,9 +162,6 @@ def UriToFilePath_Unix_test():
 
 @WindowsOnly
 def UriToFilePath_Windows_test():
-  assert_that( calling( lsp.UriToFilePath ).with_args( 'test' ),
-               raises( lsp.InvalidUriException ) )
-
   assert_that( lsp.UriToFilePath( 'file:c:/usr/local/test/test.test' ),
                equal_to( 'C:\\usr\\local\\test\\test.test' ) )
   assert_that( lsp.UriToFilePath( 'file://c:/usr/local/test/test.test' ),


### PR DESCRIPTION
eclipse.jdt.ls returns uri for class from jar package in scheme like 'jdt://contents/.*\.class.*', please see https://github.com/eclipse/eclipse.jdt.ls/blob/ae0081c28744dcdda117e97bf14b1bec9ca7f911/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ContentProviderManager.java#L40

For example,

    jdt://contents/spring-boot-autoconfigure-1.5.8.RELEASE.jar/org.springframework.boot.autoconfigure/SpringBootApplication.class?\u003dsurfingkeys/%5C/Users%5C/brook%5C/.m2%5C/repository%5C/org%5C/springframework%5C/boot%5C/spring-boot-autoconfigure%5C/1.5.8.RELEASE%5C/spring-boot-autoconfigure-1.5.8.RELEASE.jar%3Corg.springframework.boot.autoconfigure(SpringBootApplication.class

was returned for class SpringBootApplication.

This change is to parse java source path from source jar package, so that source code from jar package could be viewed.

Test case:

    ./run_tests.py ycmd/tests/utils_test.py:ParseSourcefileFromJdtUri_test --skip-build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1024)
<!-- Reviewable:end -->
