### PR TITLE
[READY] Prevent users from modifying extra conf data

### DIFF
--- a/ycmd/tests/request_wrap_test.py
+++ b/ycmd/tests/request_wrap_test.py
@@ -24,8 +24,8 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from hamcrest import ( assert_that, calling, empty, equal_to, has_entry,
-                       has_string, matches_regexp, raises )
+from hamcrest import ( assert_that, calling, contains, empty, equal_to,
+                       has_entry, has_string, matches_regexp, raises )
 from nose.tools import eq_
 
 from ycmd.utils import ToBytes
@@ -382,13 +382,18 @@ def ExtraConfData_test():
   wrap = RequestWrap( PrepareJson() )
   assert_that( wrap[ 'extra_conf_data' ], empty() )
 
-  wrap = RequestWrap( PrepareJson( extra_conf_data = { 'key': 'value' } ) )
+  wrap = RequestWrap( PrepareJson( extra_conf_data = { 'key': [ 'value' ] } ) )
   extra_conf_data = wrap[ 'extra_conf_data' ]
-  assert_that( extra_conf_data, has_entry( 'key', 'value' ) )
+  assert_that( extra_conf_data, has_entry( 'key', contains( 'value' ) ) )
   assert_that(
     extra_conf_data,
-    has_string( matches_regexp( "^<HashableDict {u?'key': u?'value'}>$" ) )
+    has_string( matches_regexp( "^<HashableDict {u?'key': \[u?'value'\]}>$" ) )
   )
+
   # Check that extra_conf_data can be used as a dictionary's key.
   assert_that( { extra_conf_data: 'extra conf data' },
                has_entry( extra_conf_data, 'extra conf data' ) )
+
+  # Check that extra_conf_data's values are immutable.
+  extra_conf_data[ 'key' ].append( 'another_value' )
+  assert_that( extra_conf_data, has_entry( 'key', contains( 'value' ) ) )

--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -582,3 +582,14 @@ def GetCurrentDirectory_Py2NoCurrentDirectory_test():
 def GetCurrentDirectory_Py3NoCurrentDirectory_test():
   with patch( 'os.getcwd', side_effect = FileNotFoundError ): # noqa
     eq_( utils.GetCurrentDirectory(), tempfile.gettempdir() )
+
+
+def HashableDict_Equality_test():
+  dict1 = { 'key': 'value' }
+  dict2 = { 'key': 'another_value' }
+  ok_(     utils.HashableDict( dict1 ) == utils.HashableDict( dict1 ) )
+  ok_( not utils.HashableDict( dict1 ) != utils.HashableDict( dict1 ) )
+  ok_( not utils.HashableDict( dict1 ) == dict1 )
+  ok_(     utils.HashableDict( dict1 ) != dict1 )
+  ok_( not utils.HashableDict( dict1 ) == utils.HashableDict( dict2 ) )
+  ok_(     utils.HashableDict( dict1 ) != utils.HashableDict( dict2 ) )

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -26,6 +26,7 @@ from builtins import *  # noqa
 
 from future.utils import PY2, native
 import collections
+import copy
 import json
 import os
 import socket
@@ -501,15 +502,15 @@ def StartThread( func, *args ):
 
 
 class HashableDict( collections.Mapping ):
-  """A dictionary that can be used in dictionary's keys. The dictionary must be
-  JSON-encodable; in particular, all keys must be strings."""
+  """An immutable dictionary that can be used in dictionary's keys. The
+  dictionary must be JSON-encodable; in particular, all keys must be strings."""
 
   def __init__( self, *args, **kwargs ):
     self._dict = dict( *args, **kwargs )
 
 
   def __getitem__( self, key ):
-    return self._dict[ key ]
+    return copy.deepcopy( self._dict[ key ] )
 
 
   def __iter__( self ):
@@ -530,3 +531,11 @@ class HashableDict( collections.Mapping ):
     except AttributeError:
       self._hash = json.dumps( self._dict, sort_keys = True ).__hash__()
       return self._hash
+
+
+  def __eq__( self, other ):
+    return isinstance( other, HashableDict ) and self._dict == other._dict
+
+
+  def __ne__( self, other ):
+    return not self == other


### PR DESCRIPTION
Users can change the values of the extra conf data by doing something like
```python
def FlagsForFile( filename, **kwargs ):
  flags = kwargs[ 'client_data' ][ 'flags' ]  
  flags.append( '-Wall' ) # Change the value of request_data[ 'extra_conf_data' ][ 'flags' ]
  return { 'flags': flags }
```
in the `.ycm_extra_conf.py` file. This was already possible prior to PR https://github.com/Valloric/ycmd/pull/1010 but it's now a problem because cache is invalidated if extra conf data has changed. We prevent that by doing a deep copy when getting a value of a `HashableDict`'s key.

Also, implement the `__eq__` and `__ne__` methods in `HashableDict` as recommended by the official documentation on [`__hash__`](https://docs.python.org/2/reference/datamodel.html#object.__hash__)
> If a class does not define a __cmp__() or __eq__() method it should not define a __hash__() operation either

and [`__eq__`](https://docs.python.org/2/reference/datamodel.html#object.__eq__)
> There are no implied relationships among the comparison operators. The truth of x==y does not imply that x!=y is false. Accordingly, when defining __eq__(), one should also define __ne__() so that the operators will behave as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1029)
<!-- Reviewable:end -->
