### PR TITLE
Add CUDA support

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -200,7 +200,7 @@ DEFAULT_FILETYPE_TRIGGERS = {
     r're!\[.*\]\s',             # method composition
   ],
   'ocaml' : [ '.', '#' ],
-  'cpp,objcpp' : [ '->', '.', '::' ],
+  'cpp,cuda,objcpp' : [ '->', '.', '::' ],
   'perl' : [ '->' ],
   'php' : [ '->', '::' ],
   'cs,java,javascript,typescript,d,python,perl6,scala,vb,elixir,go,groovy' : [

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -41,7 +41,7 @@ from ycmd.completers.cpp.ephemeral_values_set import EphemeralValuesSet
 from ycmd.completers.cpp.include_cache import IncludeCache, IncludeList
 from ycmd.responses import NoExtraConfDetected, UnknownExtraConf
 
-CLANG_FILETYPES = { 'c', 'cpp', 'objc', 'objcpp' }
+CLANG_FILETYPES = { 'c', 'cpp', 'cuda', 'objc', 'objcpp' }
 PARSING_FILE_MESSAGE = 'Still parsing file, no completions yet.'
 NO_COMPILE_FLAGS_MESSAGE = 'Still no compile flags, no completions yet.'
 NO_COMPLETIONS_MESSAGE = 'No completions found; errors in the file?'

--- a/ycmd/completers/cuda/hook.py
+++ b/ycmd/completers/cuda/hook.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2018 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
+from builtins import *  # noqa
+
+import ycm_core
+from ycmd.completers.cpp.clang_completer import ClangCompleter
+
+
+def GetCompleter( user_options ):
+  if ycm_core.HasClangSupport():
+    return ClangCompleter( user_options )
+  return None

--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -93,7 +93,7 @@ FILETYPE_TO_COMMENT_AND_STRING_REGEX = {
                                   DOUBLE_QUOTE_STRING ] ), re.MULTILINE )
 }
 
-for filetype in [ 'c', 'objc', 'objcpp', 'javascript', 'typescript' ]:
+for filetype in [ 'c', 'cuda', 'objc', 'objcpp', 'javascript', 'typescript' ]:
   FILETYPE_TO_COMMENT_AND_STRING_REGEX[ filetype ] = (
     FILETYPE_TO_COMMENT_AND_STRING_REGEX[ 'cpp' ] )
 

--- a/ycmd/tests/clang/diagnostics_test.py
+++ b/ycmd/tests/clang/diagnostics_test.py
@@ -436,3 +436,115 @@ def Diagnostics_Unity_test( app ):
         'fixit_available': True
       } ),
     ) )
+
+
+@SharedYcmd
+def Diagnostics_CUDA_Kernel_test( app ):
+  filepath = PathToTestFile( 'cuda', 'kernel_call.cu' )
+  contents = ReadFile( filepath )
+
+  event_data = BuildRequest( filepath = filepath,
+                             contents = contents,
+                             event_name = 'FileReadyToParse',
+                             filetype = 'cuda',
+                             compilation_flags = [ '-x', 'cuda', '-nocudainc',
+                                                   '-nocudalib' ] )
+
+  response = app.post_json( '/event_notification', event_data ).json
+
+  pprint( response )
+
+  assert_that( response, contains_inanyorder(
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': has_entries( { 'line_num': 59, 'column_num': 5 } ),
+      'location_extent': has_entries( {
+          'start': has_entries( { 'line_num': 59, 'column_num': 5 } ),
+          'end': has_entries( { 'line_num': 59, 'column_num': 6 } ),
+      } ),
+      'ranges': contains( has_entries( {
+          'start': has_entries( { 'line_num': 59, 'column_num': 3 } ),
+          'end': has_entries( { 'line_num': 59, 'column_num': 5 } ),
+      } ) ),
+      'text': equal_to( 'call to global function g1 not configured' ),
+      'fixit_available': False
+    } ),
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': has_entries( { 'line_num': 60, 'column_num': 9 } ),
+      'location_extent': has_entries( {
+          'start': has_entries( { 'line_num': 60, 'column_num': 9 } ),
+          'end': has_entries( { 'line_num': 60, 'column_num': 12 } ),
+      } ),
+      'ranges': contains( has_entries( {
+          'start': has_entries( { 'line_num': 60, 'column_num': 5 } ),
+          'end': has_entries( { 'line_num': 60, 'column_num': 8 } ),
+      } ) ),
+      'text': equal_to(
+          'too few execution configuration arguments to kernel function call,' +
+            ' expected at least 2, have 1'
+      ),
+      'fixit_available': False
+    } ),
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': has_entries( { 'line_num': 61, 'column_num': 20 } ),
+      'location_extent': has_entries( {
+          'start': has_entries( { 'line_num': 61, 'column_num': 20 } ),
+          'end': has_entries( { 'line_num': 61, 'column_num': 21 } ),
+      } ),
+      'ranges': contains(
+          has_entries( {
+            'start': has_entries( { 'line_num': 61, 'column_num': 5 } ),
+            'end': has_entries( { 'line_num': 61, 'column_num': 8 } ),
+          } ),
+          has_entries( {
+            'start': has_entries( { 'line_num': 61, 'column_num': 20 } ),
+            'end': has_entries( { 'line_num': 61, 'column_num': 21 } ),
+          } ),
+      ),
+      'text': equal_to( 'too many execution configuration arguments to kernel' +
+                          ' function call, expected at most 4, have 5' ),
+      'fixit_available': False
+    } ),
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': has_entries( { 'line_num': 65, 'column_num': 15 } ),
+      'location_extent': has_entries( {
+          'start': has_entries( { 'line_num': 65, 'column_num': 15 } ),
+          'end': has_entries( { 'line_num': 65, 'column_num': 16 } ),
+      } ),
+      'ranges': contains( has_entries( {
+          'start': has_entries( { 'line_num': 65, 'column_num': 3 } ),
+          'end': has_entries( { 'line_num': 65, 'column_num': 5 } ),
+      } ) ),
+      'text': equal_to( 'kernel call to non-global function h1' ),
+      'fixit_available': False
+    } ),
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': has_entries( { 'line_num': 68, 'column_num': 15 } ),
+      'location_extent': has_entries( {
+          'start': has_entries( { 'line_num': 68, 'column_num': 15 } ),
+          'end': has_entries( { 'line_num': 68, 'column_num': 16 } ),
+      } ),
+      'ranges': contains( has_entries( {
+          'start': has_entries( { 'line_num': 68, 'column_num': 3 } ),
+          'end': has_entries( { 'line_num': 68, 'column_num': 5 } ),
+      } ) ),
+      'text': equal_to( "kernel function type 'int (*)(int)' must have " +
+                          "void return type" ),
+      'fixit_available': False
+    } ),
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': has_entries( { 'line_num': 70, 'column_num': 8 } ),
+      'location_extent': has_entries( {
+          'start': has_entries( { 'line_num': 70, 'column_num': 8 } ),
+          'end': has_entries( { 'line_num': 70, 'column_num': 18 } ),
+      } ),
+      'ranges': empty(),
+      'text': equal_to( "use of undeclared identifier 'undeclared'" ),
+      'fixit_available': False
+    } ),
+  ) )

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -980,6 +980,28 @@ def CompilationDatabase_ExplicitHeaderFileEntry_test():
                   '-Wall' ) )
 
 
+def CompilationDatabase_CUDALanguageFlags_test():
+  with TemporaryTestDir() as tmp_dir:
+    compile_commands = [
+      {
+        'directory': tmp_dir,
+        'command': 'clang++ -Wall {}'.format( './test.cu' ),
+        'file': os.path.join( tmp_dir, 'test.cu' ),
+      },
+    ]
+
+    with TemporaryClangProject( tmp_dir, compile_commands ):
+      # If we ask for a header file, it returns the equivalent cu file
+      assert_that(
+        flags.Flags().FlagsForFile(
+          os.path.join( tmp_dir, 'test.h' ),
+          add_extra_clang_flags = False )[ 0 ],
+        contains( 'clang++',
+                  '-x',
+                  'cuda',
+                  '-Wall' ) )
+
+
 def _MakeRelativePathsInFlagsAbsoluteTest( test ):
   wd = test[ 'wd' ] if 'wd' in test else '/not_test'
   assert_that(

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -1235,3 +1235,27 @@ def GetCompletions_UnityInclude_test( app ):
       } )
     }
   } )
+
+
+@SharedYcmd
+def GetCompletions_cuda_test( app ):
+  RunTest( app, {
+    'description': 'Completion of CUDA files',
+    'request': {
+      'filetype'  : 'cuda',
+      'filepath'  : PathToTestFile( 'cuda', 'completion_test.cu' ),
+      'line_num'  : 16,
+      'column_num': 29,
+      'force_semantic': True,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 29,
+        'completions': contains(
+          CompletionEntryMatcher( 'do_something', 'void' ),
+        ),
+        'errors': empty(),
+      } )
+    }
+  } )

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -82,6 +82,27 @@ def Subcommands_GoTo_ZeroBasedLineAndColumn_test( app ):
 
 
 @SharedYcmd
+def Subcommands_GoTo_CUDA_test( app ):
+  filepath = PathToTestFile( 'cuda', 'basic.cu' )
+  contents = ReadFile( filepath )
+
+  goto_data = BuildRequest( completer_target = 'filetype_default',
+                            command_arguments = [ 'GoToDefinition' ],
+                            compilation_flags = [ '-x', 'cuda' ],
+                            line_num = 8,
+                            column_num = 3,
+                            filepath = filepath,
+                            contents = contents,
+                            filetype = 'cuda' )
+
+  eq_( {
+    'filepath': filepath,
+    'line_num': 4,
+    'column_num': 17
+  }, app.post_json( '/run_completer_command', goto_data ).json )
+
+
+@SharedYcmd
 def RunGoToTest_all( app, filename, command, test ):
   contents = ReadFile( PathToTestFile( filename ) )
   common_request = {
@@ -381,8 +402,9 @@ def Subcommands_GoTo_Unity_test():
 
 
 @SharedYcmd
-def RunGetSemanticTest( app, filename, test, command):
-  contents = ReadFile( PathToTestFile( filename ) )
+def RunGetSemanticTest( app, filepath, filetype, test, command):
+  contents = ReadFile( filepath )
+  language = { 'cpp': 'c++', 'cuda': 'cuda' }
 
   # We use the -fno-delayed-template-parsing flag to not delay
   # parsing of templates on Windows.  This is the default on
@@ -392,15 +414,15 @@ def RunGetSemanticTest( app, filename, test, command):
     'completer_target' : 'filetype_default',
     'command_arguments': command,
     'compilation_flags': [ '-x',
-                           'c++',
+                           language[ filetype ],
                            # C++11 flag is needed for lambda functions
                            '-std=c++11',
                            '-fno-delayed-template-parsing' ],
     'line_num'         : 10,
     'column_num'       : 3,
-    'filepath'         : PathToTestFile( filename ),
+    'filepath'         : filepath,
     'contents'         : contents,
-    'filetype'         : 'cpp'
+    'filetype'         : filetype
   }
 
   args = test[ 0 ]
@@ -498,7 +520,8 @@ def Subcommands_GetType_test():
 
   for test in tests:
     yield ( RunGetSemanticTest,
-            'GetType_Clang_test.cc',
+            PathToTestFile( 'GetType_Clang_test.cc' ),
+            'cpp',
             test,
             [ 'GetType' ] )
 
@@ -506,9 +529,19 @@ def Subcommands_GetType_test():
   # just skips the reparse)
   for test in tests:
     yield ( RunGetSemanticTest,
-            'GetType_Clang_test.cc',
+            PathToTestFile( 'GetType_Clang_test.cc' ),
+            'cpp',
             test,
             [ 'GetTypeImprecise' ] )
+
+
+def SubCommands_GetType_CUDA_test():
+  test = [ { 'line_num': 8, 'column_num': 3, }, 'void ()' ]
+  yield ( RunGetSemanticTest,
+          PathToTestFile( 'cuda', 'basic.cu' ),
+          'cuda',
+          test,
+          [ 'GetType' ] )
 
 
 def SubCommands_GetType_Unity_test():
@@ -520,7 +553,11 @@ def SubCommands_GetType_Unity_test():
     },
     'int'
   ]
-  yield RunGetSemanticTest, 'unitya.cc', test, [ 'GetType' ]
+  yield ( RunGetSemanticTest,
+          PathToTestFile( 'unitya.cc' ),
+          'cpp',
+          test,
+          [ 'GetType' ] )
 
 
 def Subcommands_GetParent_test():
@@ -555,14 +592,15 @@ def Subcommands_GetParent_test():
 
   for test in tests:
     yield ( RunGetSemanticTest,
-            'GetParent_Clang_test.cc',
+            PathToTestFile( 'GetParent_Clang_test.cc' ),
+            'cpp',
             test,
             [ 'GetParent' ] )
 
 
 @SharedYcmd
-def RunFixItTest( app, line, column, lang, file_name, check ):
-  contents = ReadFile( PathToTestFile( file_name ) )
+def RunFixItTest( app, line, column, lang, file_path, check ):
+  contents = ReadFile( file_path )
 
   language_options = {
     'cpp11': {
@@ -573,6 +611,15 @@ def RunFixItTest( app, line, column, lang, file_name, check ):
                              '-Wextra',
                              '-pedantic' ],
       'filetype'         : 'cpp',
+    },
+    'cuda': {
+      'compilation_flags': [ '-x',
+                             'cuda',
+                             '-std=c++11',
+                             '-Wall',
+                             '-Wextra',
+                             '-pedantic' ],
+      'filetype'         : 'cuda',
     },
     'objective-c': {
       'compilation_flags': [ '-x',
@@ -588,7 +635,7 @@ def RunFixItTest( app, line, column, lang, file_name, check ):
   args = {
     'completer_target' : 'filetype_default',
     'contents'         : contents,
-    'filepath'         : PathToTestFile( file_name ),
+    'filepath'         : file_path,
     'command_arguments': [ 'FixIt' ],
     'line_num'         : line,
     'column_num'       : column,
@@ -881,10 +928,27 @@ def FixIt_Check_cpp11_SpellCheck( results ):
   } ) )
 
 
+def FixIt_Check_cuda( results ):
+  assert_that( results, has_entries( {
+    'fixits': contains(
+      has_entries( {
+        'text': contains_string(
+           "error: kernel function type 'int ()' must have void " ),
+        'chunks': contains(
+          ChunkMatcher( 'void',
+                        LineColMatcher( 3, 12 ),
+                        LineColMatcher( 3, 15 ) )
+        ),
+        'location': LineColMatcher( 3, 12 ),
+      } ) )
+  } ) )
+
+
 def Subcommands_FixIt_all_test():
-  cfile = 'FixIt_Clang_cpp11.cpp'
-  mfile = 'FixIt_Clang_objc.m'
-  ufile = 'unicode.cc'
+  cfile = PathToTestFile( 'FixIt_Clang_cpp11.cpp' )
+  mfile = PathToTestFile( 'FixIt_Clang_objc.m' )
+  cufile = PathToTestFile( 'cuda', 'fixit_test.cu' )
+  ufile = PathToTestFile( 'unicode.cc' )
 
   tests = [
     # L
@@ -902,6 +966,8 @@ def Subcommands_FixIt_all_test():
 
     [ 5, 3,   'objective-c', mfile, FixIt_Check_objc ],
     [ 7, 1,   'objective-c', mfile, FixIt_Check_objc_NoFixIt ],
+
+    [ 3, 12,  'cuda', cufile, FixIt_Check_cuda ],
 
     # multiple errors on a single line; both with fixits
     [ 54, 15, 'cpp11', cfile, FixIt_Check_cpp11_MultiFirst ],
@@ -1372,3 +1438,31 @@ Name: member_with_å_unicøde
 
 This method has unicøde in it
 """ } )
+
+
+@SharedYcmd
+def Subcommands_GetDoc_CUDA_test( app ):
+  filepath = PathToTestFile( 'cuda', 'basic.cu' )
+  contents = ReadFile( filepath )
+
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'cuda',
+                             compilation_flags = [ '-x', 'cuda' ],
+                             line_num = 8,
+                             column_num = 3,
+                             contents = contents,
+                             command_arguments = [ 'GetDoc' ],
+                             completer_target = 'filetype_default' )
+
+  response = app.post_json( '/run_completer_command', event_data ).json
+
+  pprint( response )
+
+  eq_( response, {
+    'detailed_info': """\
+void kernel()
+This is a test kernel
+Type: void ()
+Name: kernel
+---
+This is a test kernel""" } )

--- a/ycmd/tests/clang/testdata/cuda/basic.cu
+++ b/ycmd/tests/clang/testdata/cuda/basic.cu
@@ -1,0 +1,10 @@
+#include "cuda.h"
+
+/// This is a test kernel
+__global__ void kernel() {}
+
+int main()
+{
+  kernel<<<1, 1>>>();
+  return 0;
+}

--- a/ycmd/tests/clang/testdata/cuda/completion_test.cu
+++ b/ycmd/tests/clang/testdata/cuda/completion_test.cu
@@ -1,0 +1,18 @@
+#include "cuda.h"
+
+namespace Kernels
+{
+  __device__ void do_something(float* a) {}
+}
+
+template<typename F, class ...Args>
+__global__ void launch(F& fn, Args args...)
+{
+  fn(args...);
+}
+
+int main() {
+  // The location after the colon is line 16, col 29
+  launch<<<1, 1>>>(Kernels::
+  return 0;
+}

--- a/ycmd/tests/clang/testdata/cuda/cuda.h
+++ b/ycmd/tests/clang/testdata/cuda/cuda.h
@@ -1,0 +1,76 @@
+/* Modified by ycmd contributors */
+/*
+  University of Illinois/NCSA
+  Open Source License
+
+  Copyright (c) 2007-2016 University of Illinois at Urbana-Champaign.
+  All rights reserved.
+
+  Developed by:
+
+      LLVM Team
+
+      University of Illinois at Urbana-Champaign
+
+      http://llvm.org
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of
+  this software and associated documentation files (the "Software"), to deal with
+  the Software without restriction, including without limitation the rights to
+  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+  of the Software, and to permit persons to whom the Software is furnished to do
+  so, subject to the following conditions:
+
+      * Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimers.
+
+      * Redistributions in binary form must reproduce the above copyright notice,
+        this list of conditions and the following disclaimers in the
+        documentation and/or other materials provided with the distribution.
+
+      * Neither the names of the LLVM Team, University of Illinois at
+        Urbana-Champaign, nor the names of its contributors may be used to
+        endorse or promote products derived from this Software without specific
+        prior written permission.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+  CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+  SOFTWARE.
+*/
+
+
+/* Minimal declarations for CUDA support.  Testing purposes only. */
+
+typedef __SIZE_TYPE__ size_t;
+
+// Make this file work with nvcc, for testing compatibility.
+
+#ifndef __NVCC__
+#define __constant__ __attribute__((constant))
+#define __device__ __attribute__((device))
+#define __global__ __attribute__((global))
+#define __host__ __attribute__((host))
+#define __shared__ __attribute__((shared))
+#define __launch_bounds__(...) __attribute__((launch_bounds(__VA_ARGS__)))
+
+struct dim3 {
+  unsigned x, y, z;
+  __host__ __device__ dim3(unsigned x, unsigned y = 1, unsigned z = 1) : x(x), y(y), z(z) {}
+};
+
+typedef struct cudaStream *cudaStream_t;
+
+int cudaConfigureCall(dim3 gridSize, dim3 blockSize, size_t sharedSize = 0,
+                      cudaStream_t stream = 0);
+
+// Host- and device-side placement new overloads.
+void *operator new(__SIZE_TYPE__, void *p) { return p; }
+void *operator new[](__SIZE_TYPE__, void *p) { return p; }
+__device__ void *operator new(__SIZE_TYPE__, void *p) { return p; }
+__device__ void *operator new[](__SIZE_TYPE__, void *p) { return p; }
+
+#endif // !__NVCC__

--- a/ycmd/tests/clang/testdata/cuda/fixit_test.cu
+++ b/ycmd/tests/clang/testdata/cuda/fixit_test.cu
@@ -1,0 +1,9 @@
+#include "cuda.h"
+
+__global__ int kernel();
+
+int main()
+{
+  kernel<<<1, 1>>>();
+  return 0;
+}

--- a/ycmd/tests/clang/testdata/cuda/kernel_call.cu
+++ b/ycmd/tests/clang/testdata/cuda/kernel_call.cu
@@ -1,0 +1,71 @@
+/* Modified by ycmd contributors */
+/*
+  University of Illinois/NCSA
+  Open Source License
+
+  Copyright (c) 2007-2016 University of Illinois at Urbana-Champaign.
+  All rights reserved.
+
+  Developed by:
+
+      LLVM Team
+
+      University of Illinois at Urbana-Champaign
+
+      http://llvm.org
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of
+  this software and associated documentation files (the "Software"), to deal with
+  the Software without restriction, including without limitation the rights to
+  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+  of the Software, and to permit persons to whom the Software is furnished to do
+  so, subject to the following conditions:
+
+      * Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimers.
+
+      * Redistributions in binary form must reproduce the above copyright notice,
+        this list of conditions and the following disclaimers in the
+        documentation and/or other materials provided with the distribution.
+
+      * Neither the names of the LLVM Team, University of Illinois at
+        Urbana-Champaign, nor the names of its contributors may be used to
+        endorse or promote products derived from this Software without specific
+        prior written permission.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+  CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+  SOFTWARE.
+*/
+
+
+#include "cuda.h"
+
+__global__ void g1(int x) {}
+
+template <typename T> void t1(T arg) {
+  g1<<<arg, arg>>>(1);
+}
+
+void h1(int x) {}
+int h2(int x) { return 1; }
+
+int main(void) {
+  g1<<<1, 1>>>(42);
+  g1(42); // expected-error {{call to global function 'g1' not configured}}
+  g1<<<1>>>(42); // expected-error {{too few execution configuration arguments to kernel function call}}
+  g1<<<1, 1, 0, 0, 0>>>(42); // expected-error {{too many execution configuration arguments to kernel function call}}
+
+  t1(1);
+
+  h1<<<1, 1>>>(42); // expected-error {{kernel call to non-global function 'h1'}}
+
+  int (*fp)(int) = h2;
+  fp<<<1, 1>>>(42); // expected-error {{must have void return type}}
+
+  g1<<<undeclared, 1>>>(42); // expected-error {{use of undeclared identifier 'undeclared'}}
+}

--- a/ycmd/tests/clang/testdata/general_fallback/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/general_fallback/.ycm_extra_conf.py
@@ -12,6 +12,12 @@ ftopts = {
     '-x', 'c',
     '-I', '.',
   ],
+  'cuda': [
+    '-Wall',
+    '-Wextra',
+    '-x', 'cuda',
+    '--std=c++11',
+  ],
   'objc': [
     '-x', 'objective-c',
     '-I', '.',


### PR DESCRIPTION
Solves Valloric/YouCompleteMe#1766.

With this patch,
- completion will work without having to change the filetype
- CUDA kernel launch syntax (`<<<...>>>`) and attributes (`__host__`, `__device__`, etc.) will be recognized correctly

I believe another patch in Valloric/YouCompleteMe is also needed to enable linting for CUDA files. (https://github.com/Valloric/YouCompleteMe/blob/68611cf851ccee29b6df1d481df466dee3d89d00/python/ycm/buffer.py#L30)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1031)
<!-- Reviewable:end -->
