### PR TITLE
[READY] Add tests simulating completer's server shutdown timing out

### DIFF
--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 ycmd contributors
+# Copyright (C) 2015-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -22,10 +22,10 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-
+from hamcrest import assert_that, has_entry, has_entries, contains
+from mock import patch
 from nose.tools import eq_, ok_
 from webtest import AppError
-from hamcrest import assert_that, has_entries, contains
 import pprint
 import os.path
 
@@ -35,7 +35,7 @@ from ycmd.tests.cs import ( IsolatedYcmd, PathToTestFile, SharedYcmd,
 from ycmd.tests.test_utils import ( BuildRequest,
                                     ChunkMatcher,
                                     LocationMatcher,
-                                    StopCompleterServer,
+                                    MockProcessTerminationTimingOut,
                                     WaitUntilCompleterServerReady )
 from ycmd.utils import ReadFile
 
@@ -501,8 +501,23 @@ def Subcommands_FixIt_Unicode_test( app ):
 @IsolatedYcmd()
 def Subcommands_StopServer_NoErrorIfNotStarted_test( app ):
   filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
-  StopCompleterServer( app, 'cs', filepath )
-  # Success = no raise
+  app.post_json(
+    '/run_completer_command',
+    BuildRequest(
+      filetype = 'cs',
+      filepath = filepath,
+      command_arguments = [ 'StopServer' ]
+    )
+  )
+
+  request_data = BuildRequest( filetype = 'cs', filepath = filepath )
+  assert_that( app.post_json( '/debug_info', request_data ).json,
+               has_entry(
+                 'completer',
+                 has_entry( 'servers', contains(
+                   has_entry( 'is_running', False )
+                 ) )
+               ) )
 
 
 def StopServer_KeepLogFiles( app ):
@@ -529,7 +544,14 @@ def StopServer_KeepLogFiles( app ):
       ok_( os.path.exists( logfile ),
            'Logfile should exist at {0}'.format( logfile ) )
   finally:
-    StopCompleterServer( app, 'cs', filepath )
+    app.post_json(
+      '/run_completer_command',
+      BuildRequest(
+        filetype = 'cs',
+        filepath = filepath,
+        command_arguments = [ 'StopServer' ]
+      )
+    )
 
   if user_options_store.Value( 'server_keep_logfiles' ):
     for logfile in logfiles:
@@ -549,3 +571,36 @@ def Subcommands_StopServer_KeepLogFiles_test( app ):
 @IsolatedYcmd( { 'server_keep_logfiles': 0 } )
 def Subcommands_StopServer_DoNotKeepLogFiles_test( app ):
   StopServer_KeepLogFiles( app )
+
+
+@IsolatedYcmd()
+@patch( 'ycmd.utils.WaitUntilProcessIsTerminated',
+        MockProcessTerminationTimingOut )
+def Subcommands_StopServer_Timeout_test( app ):
+  filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
+  contents = ReadFile( filepath )
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'cs',
+                             contents = contents,
+                             event_name = 'FileReadyToParse' )
+
+  app.post_json( '/event_notification', event_data )
+  WaitUntilCompleterServerReady( app, 'cs' )
+
+  app.post_json(
+    '/run_completer_command',
+    BuildRequest(
+      filetype = 'cs',
+      filepath = filepath,
+      command_arguments = [ 'StopServer' ]
+    )
+  )
+
+  request_data = BuildRequest( filetype = 'cs', filepath = filepath )
+  assert_that( app.post_json( '/debug_info', request_data ).json,
+               has_entry(
+                 'completer',
+                 has_entry( 'servers', contains(
+                   has_entry( 'is_running', False )
+                 ) )
+               ) )

--- a/ycmd/tests/java/server_management_test.py
+++ b/ycmd/tests/java/server_management_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 ycmd contributors
+# Copyright (C) 2017-2018 ycmd contributors
 # encoding: utf-8
 #
 # This file is part of ycmd.
@@ -42,6 +42,7 @@ from ycmd.tests.java import ( PathToTestFile,
                               StartJavaCompleterServerInDirectory )
 from ycmd.tests.test_utils import ( BuildRequest,
                                     ErrorMatcher,
+                                    MockProcessTerminationTimingOut,
                                     TemporaryTestDir,
                                     WaitUntilCompleterServerReady )
 from ycmd import utils, handlers
@@ -342,8 +343,10 @@ def ServerManagement_ProjectDetection_NoParent_test():
 
 
 @IsolatedYcmd
-@patch( 'ycmd.utils.WaitUntilProcessIsTerminated', side_effect = RuntimeError )
-def ServerManagement_CloseServer_Unclean_test( app, stop_server_cleanly ):
+@patch( 'shutil.rmtree', side_effect = OSError )
+@patch( 'ycmd.utils.WaitUntilProcessIsTerminated',
+        MockProcessTerminationTimingOut )
+def ServerManagement_CloseServer_Unclean_test( app, *args ):
   StartJavaCompleterServerInDirectory(
     app, PathToTestFile( 'simple_eclipse_project' ) )
 
@@ -351,8 +354,8 @@ def ServerManagement_CloseServer_Unclean_test( app, stop_server_cleanly ):
     '/run_completer_command',
     BuildRequest(
       filetype = 'java',
-      command_arguments = [ 'StopServer' ],
-    ),
+      command_arguments = [ 'StopServer' ]
+    )
   )
 
   request_data = BuildRequest( filetype = 'java' )

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 ycmd contributors
+# Copyright (C) 2015-2018 ycmd contributors
 # encoding: utf-8
 #
 # This file is part of ycmd.
@@ -23,7 +23,12 @@ from __future__ import division
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from hamcrest import assert_that, contains, contains_inanyorder, has_entries
+from hamcrest import ( assert_that,
+                       contains,
+                       contains_inanyorder,
+                       has_entry,
+                       has_entries )
+from mock import patch
 from nose.tools import eq_
 from pprint import pformat
 import requests
@@ -33,7 +38,8 @@ from ycmd.tests.javascript import ( IsolatedYcmd, PathToTestFile, SharedYcmd,
 from ycmd.tests.test_utils import ( BuildRequest,
                                     ChunkMatcher,
                                     ErrorMatcher,
-                                    LocationMatcher )
+                                    LocationMatcher,
+                                    MockProcessTerminationTimingOut )
 from ycmd.utils import ReadFile
 
 
@@ -511,3 +517,27 @@ def Subcommands_RefactorRename_Unicode_test( app ):
       } )
     }
   } )
+
+
+@IsolatedYcmd
+@patch( 'ycmd.utils.WaitUntilProcessIsTerminated',
+        MockProcessTerminationTimingOut )
+def Subcommands_StopServer_Timeout_test( app ):
+  StartJavaScriptCompleterServerInDirectory( app, PathToTestFile() )
+
+  app.post_json(
+    '/run_completer_command',
+    BuildRequest(
+      filetype = 'javascript',
+      command_arguments = [ 'StopServer' ]
+    )
+  )
+
+  request_data = BuildRequest( filetype = 'javascript' )
+  assert_that( app.post_json( '/debug_info', request_data ).json,
+               has_entry(
+                 'completer',
+                 has_entry( 'servers', contains(
+                   has_entry( 'is_running', False )
+                 ) )
+               ) )

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2013 Google Inc.
-#               2015 ycmd contributors
+# Copyright (C) 2013-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -41,7 +40,8 @@ import shutil
 from ycmd import extra_conf_store, handlers, user_options_store
 from ycmd.completers.completer import Completer
 from ycmd.responses import BuildCompletionData
-from ycmd.utils import GetCurrentDirectory, OnMac, OnWindows, ToUnicode
+from ycmd.utils import ( GetCurrentDirectory, OnMac, OnWindows, ToUnicode,
+                         WaitUntilProcessIsTerminated )
 import ycm_core
 
 try:
@@ -238,6 +238,12 @@ def WaitUntilCompleterServerReady( app, filetype, timeout = 30 ):
       return
 
     time.sleep( 0.1 )
+
+
+def MockProcessTerminationTimingOut( handle, timeout = 5 ):
+  WaitUntilProcessIsTerminated( handle, timeout )
+  raise RuntimeError( 'Waited process to terminate for {0} seconds, '
+                      'aborting.'.format( timeout ) )
 
 
 def ClearCompletionsCache():


### PR DESCRIPTION
This should fix the unexpected coverage changes from codecov. Also, this may potentially fix the "handle is invalid" exception that (rarely) occurs on AppVeyor when running the Java tests.

Not adding a test for JediHTTP because of PR https://github.com/Valloric/ycmd/pull/1028.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1032)
<!-- Reviewable:end -->
