### PR TITLE
[READY] Prioritize compilation database over global extra conf

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -35,7 +35,6 @@ from ycmd import responses
 from ycmd.utils import re, ToBytes, ToCppStringCompatible, ToUnicode
 from ycmd.completers.completer import Completer
 from ycmd.completers.cpp.flags import ( Flags, PrepareFlagsForClang,
-                                        NoCompilationDatabase,
                                         UserIncludePaths )
 from ycmd.completers.cpp.ephemeral_values_set import EphemeralValuesSet
 from ycmd.completers.cpp.include_cache import IncludeCache, IncludeList
@@ -416,11 +415,8 @@ class ClangCompleter( Completer ):
       flags = []
       filename = request_data[ 'filepath' ]
 
-    try:
-      database_directory = self._flags.FindCompilationDatabase(
-          os.path.dirname( filename ) ).database_directory
-    except NoCompilationDatabase:
-      database_directory = None
+    database = self._flags.FindCompilationDatabase( filename )
+    database_directory = database.database_directory if database else None
 
     database_item = responses.DebugInfoItem(
       key = 'compilation database path',

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -81,10 +81,6 @@ EMPTY_FLAGS = {
 }
 
 
-class NoCompilationDatabase( Exception ):
-  pass
-
-
 class Flags( object ):
   """Keeps track of the flags necessary to compile a file.
   The flags are loaded from user-created python files (hereafter referred to as
@@ -132,17 +128,7 @@ class Flags( object ):
     except KeyError:
       pass
 
-    module = extra_conf_store.ModuleForSourceFile( filename )
-    try:
-      results = self._GetFlagsFromExtraConfOrDatabase( module,
-                                                       filename,
-                                                       client_data )
-    except NoCompilationDatabase:
-      if not self.no_extra_conf_file_warning_posted:
-        self.no_extra_conf_file_warning_posted = True
-        raise NoExtraConfDetected
-      return [], filename
-
+    results = self._GetFlagsFromExtraConfOrDatabase( filename, client_data )
     if not results or not results.get( 'flags_ready', True ):
       return [], filename
 
@@ -179,11 +165,25 @@ class Flags( object ):
     return sanitized_flags, filename
 
 
-  def _GetFlagsFromExtraConfOrDatabase( self, module, filename, client_data ):
-    if not module:
-      return self._GetFlagsFromCompilationDatabase( filename )
+  def _GetFlagsFromExtraConfOrDatabase( self, filename, client_data ):
+    module = extra_conf_store.ModuleForSourceFile( filename )
+    if module and not module.is_global_ycm_extra_conf:
+      return _CallExtraConfFlagsForFile( module, filename, client_data )
 
-    return _CallExtraConfFlagsForFile( module, filename, client_data )
+    database = self.FindCompilationDatabase( filename )
+    if database:
+      return self._GetFlagsFromCompilationDatabase( database, filename )
+
+    if module:
+      return _CallExtraConfFlagsForFile( module, filename, client_data )
+
+    # No compilation database and no extra conf found. Warn the user if not
+    # already warned.
+    if not self.no_extra_conf_file_warning_posted:
+      self.no_extra_conf_file_warning_posted = True
+      raise NoExtraConfDetected
+
+    return None
 
 
   def Clear( self ):
@@ -192,11 +192,10 @@ class Flags( object ):
     self.file_directory_heuristic_map.clear()
 
 
-  def _GetFlagsFromCompilationDatabase( self, file_name ):
+  def _GetFlagsFromCompilationDatabase( self, database, file_name ):
     file_dir = os.path.dirname( file_name )
-    file_root, file_extension = os.path.splitext( file_name )
+    _, file_extension = os.path.splitext( file_name )
 
-    database = self.FindCompilationDatabase( file_dir )
     compilation_info = _GetCompilationInfoForFile( database,
                                                    file_name,
                                                    file_extension )
@@ -229,8 +228,8 @@ class Flags( object ):
     }
 
 
-  # Return a compilation database object for the supplied path. Raises
-  # NoCompilationDatabase if no compilation database can be found.
+  # Return a compilation database object for the supplied path or None if no
+  # compilation database is found.
   def FindCompilationDatabase( self, file_dir ):
     # We search up the directory hierarchy, to first see if we have a
     # compilation database already for that path, or if a compile_commands.json
@@ -238,11 +237,7 @@ class Flags( object ):
     for folder in PathsToAllParentFolders( file_dir ):
       # Try/catch to syncronise access to cache
       try:
-        database = self.compilation_database_dir_map[ folder ]
-        if database:
-          return database
-
-        raise NoCompilationDatabase
+        return self.compilation_database_dir_map[ folder ]
       except KeyError:
         pass
 
@@ -258,7 +253,7 @@ class Flags( object ):
     # Note: we cache the fact that none was found for this folder to speed up
     # subsequent searches.
     self.compilation_database_dir_map[ file_dir ] = None
-    raise NoCompilationDatabase
+    return None
 
 
 def _ExtractFlagsList( flags_for_file_output ):

--- a/ycmd/extra_conf_store.py
+++ b/ycmd/extra_conf_store.py
@@ -129,13 +129,12 @@ def Disable( module_file ):
     _module_for_module_file[ module_file ] = None
 
 
-def _ShouldLoad( module_file ):
+def _ShouldLoad( module_file, is_global ):
   """Checks if a module is safe to be loaded. By default this will try to
   decide using a white-/blacklist and ask the user for confirmation as a
   fallback."""
 
-  if ( module_file == _GlobalYcmExtraConfFileLocation() or
-       not user_options_store.Value( 'confirm_extra_conf' ) ):
+  if is_global or not user_options_store.Value( 'confirm_extra_conf' ):
     return True
 
   globlist = user_options_store.Value( 'extra_conf_globlist' )
@@ -160,7 +159,8 @@ def Load( module_file, force = False ):
     if module_file in _module_for_module_file:
       return _module_for_module_file[ module_file ]
 
-  if not force and not _ShouldLoad( module_file ):
+  is_global = module_file == _GlobalYcmExtraConfFileLocation()
+  if not force and not _ShouldLoad( module_file, is_global ):
     Disable( module_file )
     return None
 
@@ -181,6 +181,7 @@ def Load( module_file, force = False ):
   sys.dont_write_bytecode = True
   try:
     module = LoadPythonSource( _RandomName(), module_file )
+    module.is_global_ycm_extra_conf = is_global
   finally:
     sys.dont_write_bytecode = old_dont_write_bytecode
 

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -46,6 +46,7 @@ from hamcrest import ( assert_that,
 @contextlib.contextmanager
 def MockExtraConfModule( flags_for_file_function ):
   module = MagicMock( spec = ModuleType )
+  module.is_global_ycm_extra_conf = False
   module.FlagsForFile = flags_for_file_function
   with patch( 'ycmd.extra_conf_store.ModuleForSourceFile',
               return_value = module ):

--- a/ycmd/tests/extra_conf_store_test.py
+++ b/ycmd/tests/extra_conf_store_test.py
@@ -25,8 +25,8 @@ from builtins import *  # noqa
 import inspect
 from mock import patch
 
-from hamcrest import ( assert_that, calling, equal_to, has_length, none, raises,
-                       same_instance )
+from hamcrest import ( assert_that, calling, equal_to, has_length, has_property,
+                       none, raises, same_instance )
 from ycmd import extra_conf_store
 from ycmd.responses import UnknownExtraConf
 from ycmd.tests import IsolatedYcmd, PathToTestFile
@@ -55,6 +55,8 @@ def ExtraConfStore_ModuleForSourceFile_NoConfirmation_test( app ):
   module = extra_conf_store.ModuleForSourceFile( filename )
   assert_that( inspect.ismodule( module ) )
   assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+  assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
+  assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
 
 
 @IsolatedYcmd( { 'extra_conf_globlist': [ PROJECT_EXTRA_CONF ] } )
@@ -63,6 +65,8 @@ def ExtraConfStore_ModuleForSourceFile_Whitelisted_test( app ):
   module = extra_conf_store.ModuleForSourceFile( filename )
   assert_that( inspect.ismodule( module ) )
   assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+  assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
+  assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
 
 
 @IsolatedYcmd( { 'extra_conf_globlist': [ '!' + PROJECT_EXTRA_CONF ] } )
@@ -78,6 +82,8 @@ def ExtraConfStore_ModuleForSourceFile_UnixVarEnv_test( app ):
   module = extra_conf_store.ModuleForSourceFile( filename )
   assert_that( inspect.ismodule( module ) )
   assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+  assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
+  assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
 
 
 @WindowsOnly
@@ -88,6 +94,8 @@ def ExtraConfStore_ModuleForSourceFile_WinVarEnv_test( app ):
   module = extra_conf_store.ModuleForSourceFile( filename )
   assert_that( inspect.ismodule( module ) )
   assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+  assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
+  assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
 
 
 @UnixOnly
@@ -100,6 +108,8 @@ def ExtraConfStore_ModuleForSourceFile_SupportSymlink_test( app ):
     module = extra_conf_store.ModuleForSourceFile( filename )
     assert_that( inspect.ismodule( module ) )
     assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+    assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
+    assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
 
 
 @IsolatedYcmd( { 'global_ycm_extra_conf': GLOBAL_EXTRA_CONF } )
@@ -108,6 +118,8 @@ def ExtraConfStore_ModuleForSourceFile_GlobalExtraConf_test( app ):
   module = extra_conf_store.ModuleForSourceFile( filename )
   assert_that( inspect.ismodule( module ) )
   assert_that( inspect.getfile( module ), equal_to( GLOBAL_EXTRA_CONF ) )
+  assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
+  assert_that( module.is_global_ycm_extra_conf, equal_to( True ) )
 
 
 @patch.dict( 'os.environ', { 'YCMD_TEST': GLOBAL_EXTRA_CONF } )
@@ -117,6 +129,8 @@ def ExtraConfStore_ModuleForSourceFile_GlobalExtraConf_UnixEnvVar_test( app ):
   module = extra_conf_store.ModuleForSourceFile( filename )
   assert_that( inspect.ismodule( module ) )
   assert_that( inspect.getfile( module ), equal_to( GLOBAL_EXTRA_CONF ) )
+  assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
+  assert_that( module.is_global_ycm_extra_conf, equal_to( True ) )
 
 
 @WindowsOnly
@@ -127,6 +141,8 @@ def ExtraConfStore_ModuleForSourceFile_GlobalExtraConf_WinEnvVar_test( app ):
   module = extra_conf_store.ModuleForSourceFile( filename )
   assert_that( inspect.ismodule( module ) )
   assert_that( inspect.getfile( module ), equal_to( GLOBAL_EXTRA_CONF ) )
+  assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
+  assert_that( module.is_global_ycm_extra_conf, equal_to( True ) )
 
 
 @IsolatedYcmd( { 'global_ycm_extra_conf': NO_EXTRA_CONF } )
@@ -187,6 +203,8 @@ def Load_DoNotReloadExtraConf_NoForce_test( app ):
     module = extra_conf_store.Load( PROJECT_EXTRA_CONF )
     assert_that( inspect.ismodule( module ) )
     assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+    assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
+    assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
     assert_that(
       extra_conf_store.Load( PROJECT_EXTRA_CONF ),
       same_instance( module )
@@ -199,6 +217,8 @@ def Load_DoNotReloadExtraConf_ForceEqualsTrue_test( app ):
     module = extra_conf_store.Load( PROJECT_EXTRA_CONF )
     assert_that( inspect.ismodule( module ) )
     assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
+    assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
+    assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
     assert_that(
       extra_conf_store.Load( PROJECT_EXTRA_CONF, force = True ),
       same_instance( module )


### PR DESCRIPTION
Add the property `is_global_ycm_extra_conf` to the extra conf module and use this property to load flags in this order of priority:
 - from a `.ycm_extra_conf.py` file in the current directory or any parent directory;
 - from a `compile_commands.json` file in the current directory or any parent directory;
 - from the file set by the `global_ycm_extra_conf` option.

Closes https://github.com/Valloric/YouCompleteMe/issues/2777.