### PR TITLE
[READY] Handle FlagsForFile returning nothing

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -143,7 +143,7 @@ class Flags( object ):
         raise NoExtraConfDetected
       return [], filename
 
-    if not results or not results.get( 'flags_ready', True ):
+    if not results.get( 'flags_ready', True ):
       return [], filename
 
     return self._ParseFlagsFromExtraConfOrDatabase( filename,
@@ -298,6 +298,9 @@ def _CallExtraConfFlagsForFile( module, filename, client_data ):
     results = module.FlagsForFile( filename, client_data = client_data )
   else:
     results = module.FlagsForFile( filename )
+
+  if not isinstance( results, dict ) or 'flags' not in results:
+    return EMPTY_FLAGS
 
   results[ 'flags' ] = _MakeRelativePathsInFlagsAbsolute(
       results[ 'flags' ],

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -37,6 +37,7 @@ from ycmd.completers.cpp.flags import _ShouldAllowWinStyleFlags
 from hamcrest import ( assert_that,
                        calling,
                        contains,
+                       empty,
                        equal_to,
                        has_item,
                        not_,
@@ -50,6 +51,18 @@ def MockExtraConfModule( flags_for_file_function ):
   with patch( 'ycmd.extra_conf_store.ModuleForSourceFile',
               return_value = module ):
     yield
+
+
+def FlagsForFile_NothingReturned_test():
+  flags_object = flags.Flags()
+
+  def FlagsForFile( filename ):
+    pass
+
+  with MockExtraConfModule( FlagsForFile ):
+    flags_list, filename = flags_object.FlagsForFile( '/foo' )
+    assert_that( flags_list, empty() )
+    assert_that( filename, equal_to( '/foo' ) )
 
 
 def FlagsForFile_FlagsNotReady_test():


### PR DESCRIPTION
Assume an empty list of flags if `FlagsForFile` doesn't return anything or if the `flags` key is missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1039)
<!-- Reviewable:end -->
