### PR TITLE
[READY] Use equals default on structs

### DIFF
--- a/cpp/ycm/ClangCompleter/CompletionData.h
+++ b/cpp/ycm/ClangCompleter/CompletionData.h
@@ -50,7 +50,7 @@ enum class CompletionKind {
 // The user can also enable a "preview" window that will show extra information
 // about a completion at the top of the buffer.
 struct CompletionData {
-  CompletionData() {}
+  CompletionData() = default;
   CompletionData( const CXCompletionResult &completion_result );
 
   // What should actually be inserted into the buffer. For a function like

--- a/cpp/ycm/ClangCompleter/Documentation.h
+++ b/cpp/ycm/ClangCompleter/Documentation.h
@@ -28,7 +28,7 @@ namespace YouCompleteMe {
 /// for a given cursor
 struct DocumentationData {
   /// Construct an empty object
-  DocumentationData() {}
+  DocumentationData() = default;
 
   /// Construct and extract information from the supplied cursor. The cursor
   /// should be pointing to a canonical declaration, such as returned by

--- a/cpp/ycm/ClangCompleter/Range.h
+++ b/cpp/ycm/ClangCompleter/Range.h
@@ -24,7 +24,7 @@ namespace YouCompleteMe {
 
 // Half-open, [start, end>
 struct Range {
-  Range() {}
+  Range() = default;
 
   Range( const Location &start_location, const Location &end_location )
     : start_( start_location ),


### PR DESCRIPTION
Clang-tidy fails to detect these for `struct`s. More importantly, if a constructor is declared as `Foo(){};`, even though it is no-op, it needs to be called upon object creation, but if it is declared as `Foo() = default;` then the standard calls it a constructor with a trivial ABI and the compiler is allowed to skip calling a trivial ABI constructor. This optimisation is present in all three compilers that we support.

If we want to have cang-tidy report these consistently, we have to ban `struct{int foo;};` in favour of `class{public: int foo;};`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1040)
<!-- Reviewable:end -->
