### PR TITLE
Define __CUDACC__ for CUDA source files

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -390,7 +390,7 @@ def _AddLanguageFlagWhenAppropriate( flags, enable_windows_style_flags ):
   # compiling CUDA source files with a C++ compiler
   if any( fl.endswith( '.cu' ) or fl.endswith( '.cuh' )
           for fl in reversed( flags ) ):
-    return [ first_flag, '-x', 'cuda' ] + flags[ 1: ]
+    return [ first_flag, '-x', 'cuda', '-D__CUDACC__' ] + flags[ 1: ]
 
   # NOTE: This is intentionally NOT checking for enable_windows_style_flags.
   #

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -999,6 +999,7 @@ def CompilationDatabase_CUDALanguageFlags_test():
         contains( 'clang++',
                   '-x',
                   'cuda',
+                  '-D__CUDACC__',
                   '-Wall' ) )
 
 


### PR DESCRIPTION
Sorry for the repeated PRs. I've just noticed that the standard CUDA runtime library headers make extensive use of the `__CUDACC__` macro, which should be defined when clang or nvcc compiles CUDA source files [1]. For some reason, it appears that the clang completer doesn't define `__CUDACC__`, which causes problems when parsing headers such as `cuda_runtime_api.h`. The changes in this PR inject `-D__CUDACC__` when CUDA source files are found.

[1] https://llvm.org/docs/CompileCudaWithLLVM.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1043)
<!-- Reviewable:end -->
