### PR TITLE
[RFC] Use Clang thread safety analysis annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ addons:
      # 4.8 is the first version of GCC with good enough C++11 support.
      - g++-4.8
      # Install Clang 3.4 and its standard library.
-     - clang
+     - clang-3.5
      - clang-tidy-3.9
      - libc++-dev
      # Required to build the OmniSharp server.

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -18,8 +18,8 @@ unset -f cd popd pushd
 mkdir -p ${HOME}/bin
 
 if [ "${YCM_COMPILER}" == "clang" ]; then
-  ln -s /usr/bin/clang++ ${HOME}/bin/c++
-  ln -s /usr/bin/clang ${HOME}/bin/cc
+  ln -s /usr/bin/clang++-3.5 ${HOME}/bin/c++
+  ln -s /usr/bin/clang-3.5 ${HOME}/bin/cc
   # Tell CMake to compile with libc++ when using Clang.
   export EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DHAS_LIBCXX11=ON"
 else

--- a/cpp/ycm/.ycm_extra_conf.py
+++ b/cpp/ycm/.ycm_extra_conf.py
@@ -42,6 +42,7 @@ flags = [
 '-Werror',
 '-Wno-long-long',
 '-Wno-variadic-macros',
+'-Wthread-safety',
 '-fexceptions',
 '-DNDEBUG',
 # You 100% do NOT need -DUSE_CLANG_COMPLETER and/or -DYCM_EXPORT in your flags;

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -451,6 +451,12 @@ endif()
 
 #############################################################################
 
+if( COMPILER_IS_CLANG )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wthread-safety" )
+endif()
+
+#############################################################################
+
 if( SYSTEM_IS_SUNOS )
   # SunOS needs this setting for thread support
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthreads" )

--- a/cpp/ycm/CandidateRepository.h
+++ b/cpp/ycm/CandidateRepository.h
@@ -19,9 +19,9 @@
 #define CANDIDATEREPOSITORY_H_K9OVCMHG
 
 #include "Candidate.h"
+#include "Mutex.h"
 
 #include <memory>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -53,7 +53,7 @@ public:
     const std::vector< std::string > &strings );
 
   // This should only be used to isolate tests and benchmarks.
-  YCM_EXPORT void ClearCandidates();
+  YCM_EXPORT void ClearCandidates() NO_THREAD_SAFETY_ANALYSIS;
 
 private:
   CandidateRepository() = default;
@@ -62,16 +62,16 @@ private:
   const std::string &ValidatedCandidateText(
       const std::string &candidate_text );
 
-  static CandidateRepository *instance_;
-  static std::mutex instance_mutex_;
+  static CandidateRepository *instance_ GUARDED_BY( instance_mutex_ );
+  static Mutex instance_mutex_;
 
   // MSVC 12 complains that no appropriate default constructor is available if
   // this property is not initialized.
   const std::string empty_{};
 
   // This data structure owns all the Candidate pointers
-  CandidateHolder candidate_holder_;
-  std::mutex candidate_holder_mutex_;
+  CandidateHolder candidate_holder_ GUARDED_BY( candidate_holder_mutex_ );
+  Mutex candidate_holder_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/CharacterRepository.cpp
+++ b/cpp/ycm/CharacterRepository.cpp
@@ -21,15 +21,18 @@
 
 #include <mutex>
 
+using std::lock_guard;
+using std::mutex;
+
 namespace YouCompleteMe {
 
 CharacterRepository *CharacterRepository::instance_ = nullptr;
-std::mutex CharacterRepository::instance_mutex_;
+Mutex CharacterRepository::instance_mutex_;
 
 CharacterRepository &CharacterRepository::Instance() {
   // This lock is required as magic statics are not thread-safe on MSVC 12.
   // See https://msdn.microsoft.com/en-us/library/hh567368#concurrencytable
-  std::lock_guard< std::mutex > locker( instance_mutex_ );
+  LockWrapper< lock_guard< mutex > > locker( instance_mutex_ );
 
   if ( !instance_ ) {
     static CharacterRepository repo;
@@ -41,7 +44,7 @@ CharacterRepository &CharacterRepository::Instance() {
 
 
 size_t CharacterRepository::NumStoredCharacters() {
-  std::lock_guard< std::mutex > locker( character_holder_mutex_ );
+  LockWrapper< lock_guard< mutex > > locker( character_holder_mutex_ );
   return character_holder_.size();
 }
 
@@ -52,7 +55,7 @@ CharacterSequence CharacterRepository::GetCharacters(
   character_objects.reserve( characters.size() );
 
   {
-    std::lock_guard< std::mutex > locker( character_holder_mutex_ );
+    LockWrapper< lock_guard< mutex > > locker( character_holder_mutex_ );
 
     for ( const std::string & character : characters ) {
       std::unique_ptr< Character > &character_object = GetValueElseInsert(

--- a/cpp/ycm/CharacterRepository.h
+++ b/cpp/ycm/CharacterRepository.h
@@ -19,9 +19,9 @@
 #define CHARACTER_REPOSITORY_H_36TXTS6C
 
 #include "Character.h"
+#include "Mutex.h"
 
 #include <memory>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -50,18 +50,18 @@ public:
     const std::vector< std::string > &characters );
 
   // This should only be used to isolate tests and benchmarks.
-  YCM_EXPORT void ClearCharacters();
+  YCM_EXPORT void ClearCharacters() NO_THREAD_SAFETY_ANALYSIS;
 
 private:
   CharacterRepository() = default;
   ~CharacterRepository() = default;
 
-  static CharacterRepository *instance_;
-  static std::mutex instance_mutex_;
+  static CharacterRepository *instance_ GUARDED_BY( instance_mutex_ );
+  static Mutex instance_mutex_;
 
   // This data structure owns all the Character pointers
-  CharacterHolder character_holder_;
-  std::mutex character_holder_mutex_;
+  CharacterHolder character_holder_ GUARDED_BY( character_holder_mutex_ );
+  Mutex character_holder_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/ClangCompleter/CompilationDatabase.cpp
+++ b/cpp/ycm/ClangCompleter/CompilationDatabase.cpp
@@ -23,7 +23,7 @@
 
 using std::lock_guard;
 using std::unique_lock;
-using std::try_to_lock_t;
+using std::try_to_lock;
 using std::remove_pointer;
 using std::shared_ptr;
 using std::mutex;
@@ -57,7 +57,8 @@ bool CompilationDatabase::DatabaseSuccessfullyLoaded() {
 
 
 bool CompilationDatabase::AlreadyGettingFlags() {
-  unique_lock< mutex > lock( compilation_database_mutex_, try_to_lock_t() );
+  LockWrapper< unique_lock< mutex > > lock( compilation_database_mutex_,
+                                            try_to_lock );
   return !lock.owns_lock();
 }
 
@@ -73,7 +74,7 @@ CompilationInfoForFile CompilationDatabase::GetCompilationInfoForFile(
   std::string path_to_file_string = GetUtf8String( path_to_file );
   pybind11::gil_scoped_release unlock;
 
-  lock_guard< mutex > lock( compilation_database_mutex_ );
+  LockWrapper< lock_guard< mutex > > lock( compilation_database_mutex_ );
 
   CompileCommandsWrap commands(
     clang_CompilationDatabase_getCompileCommands(

--- a/cpp/ycm/ClangCompleter/CompilationDatabase.h
+++ b/cpp/ycm/ClangCompleter/CompilationDatabase.h
@@ -18,8 +18,9 @@
 #ifndef COMPILATIONDATABASE_H_ZT7MQXPG
 #define COMPILATIONDATABASE_H_ZT7MQXPG
 
+#include "Mutex.h"
+
 #include <clang-c/CXCompilationDatabase.h>
-#include <mutex>
 #include <pybind11/pybind11.h>
 #include <string>
 #include <vector>
@@ -61,8 +62,11 @@ private:
 
   bool is_loaded_;
   std::string path_to_directory_;
-  CXCompilationDatabase compilation_database_;
-  std::mutex compilation_database_mutex_;
+
+  CXCompilationDatabase compilation_database_
+    GUARDED_BY( compilation_database_mutex_ );
+
+  Mutex compilation_database_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
@@ -63,7 +63,8 @@ shared_ptr< TranslationUnit > TranslationUnitStore::GetOrCreate(
   bool &translation_unit_created ) {
   translation_unit_created = false;
   {
-    lock_guard< mutex > lock( filename_to_translation_unit_and_flags_mutex_ );
+    LockWrapper< lock_guard< mutex > > lock(
+      filename_to_translation_unit_and_flags_mutex_ );
     shared_ptr< TranslationUnit > current_unit = GetNoLock( filename );
 
     if ( current_unit &&
@@ -96,7 +97,8 @@ shared_ptr< TranslationUnit > TranslationUnitStore::GetOrCreate(
   }
 
   {
-    lock_guard< mutex > lock( filename_to_translation_unit_and_flags_mutex_ );
+    LockWrapper< lock_guard< mutex > > lock(
+      filename_to_translation_unit_and_flags_mutex_ );
     filename_to_translation_unit_[ filename ] = unit;
     // Flags have already been stored.
   }
@@ -108,20 +110,23 @@ shared_ptr< TranslationUnit > TranslationUnitStore::GetOrCreate(
 
 shared_ptr< TranslationUnit > TranslationUnitStore::Get(
   const std::string &filename ) {
-  lock_guard< mutex > lock( filename_to_translation_unit_and_flags_mutex_ );
+  LockWrapper< lock_guard< mutex > > lock(
+    filename_to_translation_unit_and_flags_mutex_ );
   return GetNoLock( filename );
 }
 
 
 bool TranslationUnitStore::Remove( const std::string &filename ) {
-  lock_guard< mutex > lock( filename_to_translation_unit_and_flags_mutex_ );
+  LockWrapper< lock_guard< mutex > > lock(
+    filename_to_translation_unit_and_flags_mutex_ );
   Erase( filename_to_flags_hash_, filename );
   return Erase( filename_to_translation_unit_, filename );
 }
 
 
 void TranslationUnitStore::RemoveAll() {
-  lock_guard< mutex > lock( filename_to_translation_unit_and_flags_mutex_ );
+  LockWrapper< lock_guard< mutex > > lock(
+    filename_to_translation_unit_and_flags_mutex_ );
   filename_to_translation_unit_.clear();
   filename_to_flags_hash_.clear();
 }

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.h
@@ -18,10 +18,10 @@
 #ifndef TRANSLATIONUNITSTORE_H_NGN0MCKB
 #define TRANSLATIONUNITSTORE_H_NGN0MCKB
 
+#include "Mutex.h"
 #include "TranslationUnit.h"
 #include "UnsavedFile.h"
 
-#include <mutex>
 #include <string>
 #include <vector>
 #include <memory>
@@ -80,7 +80,8 @@ public:
 private:
 
   // WARNING: This accesses filename_to_translation_unit_ without a lock!
-  std::shared_ptr< TranslationUnit > GetNoLock( const std::string &filename );
+  std::shared_ptr< TranslationUnit > GetNoLock( const std::string &filename )
+    REQUIRES( filename_to_translation_unit_and_flags_mutex_ );
 
 
   using TranslationUnitForFilename =
@@ -90,8 +91,11 @@ private:
 
   CXIndex clang_index_;
   TranslationUnitForFilename filename_to_translation_unit_;
-  FlagsHashForFilename filename_to_flags_hash_;
-  std::mutex filename_to_translation_unit_and_flags_mutex_;
+
+  FlagsHashForFilename filename_to_flags_hash_
+    GUARDED_BY( filename_to_translation_unit_and_flags_mutex_ );
+
+  Mutex filename_to_translation_unit_and_flags_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/CodePointRepository.cpp
+++ b/cpp/ycm/CodePointRepository.cpp
@@ -21,15 +21,18 @@
 
 #include <mutex>
 
+using std::mutex;
+using std::lock_guard;
+
 namespace YouCompleteMe {
 
 CodePointRepository *CodePointRepository::instance_ = nullptr;
-std::mutex CodePointRepository::instance_mutex_;
+Mutex CodePointRepository::instance_mutex_;
 
 CodePointRepository &CodePointRepository::Instance() {
   // This lock is required as magic statics are not thread-safe on MSVC 12.
   // See https://msdn.microsoft.com/en-us/library/hh567368#concurrencytable
-  std::lock_guard< std::mutex > locker( instance_mutex_ );
+  LockWrapper< lock_guard< mutex > > locker( instance_mutex_ );
 
   if ( !instance_ ) {
     static CodePointRepository repo;
@@ -41,7 +44,7 @@ CodePointRepository &CodePointRepository::Instance() {
 
 
 size_t CodePointRepository::NumStoredCodePoints() {
-  std::lock_guard< std::mutex > locker( code_point_holder_mutex_ );
+  LockWrapper< lock_guard< mutex > > locker( code_point_holder_mutex_ );
   return code_point_holder_.size();
 }
 
@@ -52,7 +55,7 @@ CodePointSequence CodePointRepository::GetCodePoints(
   code_point_objects.reserve( code_points.size() );
 
   {
-    std::lock_guard< std::mutex > locker( code_point_holder_mutex_ );
+    LockWrapper< lock_guard< mutex > > locker( code_point_holder_mutex_ );
 
     for ( const std::string & code_point : code_points ) {
       std::unique_ptr< CodePoint > &code_point_object = GetValueElseInsert(

--- a/cpp/ycm/CodePointRepository.h
+++ b/cpp/ycm/CodePointRepository.h
@@ -19,9 +19,9 @@
 #define CODE_POINT_REPOSITORY_H_ENE9FWXL
 
 #include "CodePoint.h"
+#include "Mutex.h"
 
 #include <memory>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -50,18 +50,18 @@ public:
     const std::vector< std::string > &code_points );
 
   // This should only be used to isolate tests and benchmarks.
-  YCM_EXPORT void ClearCodePoints();
+  YCM_EXPORT void ClearCodePoints() NO_THREAD_SAFETY_ANALYSIS;
 
 private:
   CodePointRepository() = default;
   ~CodePointRepository() = default;
 
-  static CodePointRepository *instance_;
-  static std::mutex instance_mutex_;
+  static CodePointRepository *instance_ GUARDED_BY( instance_mutex_ );
+  static Mutex instance_mutex_;
 
   // This data structure owns all the CodePoint pointers
-  CodePointHolder code_point_holder_;
-  std::mutex code_point_holder_mutex_;
+  CodePointHolder code_point_holder_ GUARDED_BY( code_point_holder_mutex_ );
+  Mutex code_point_holder_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -25,6 +25,9 @@
 
 #include <unordered_set>
 
+using std::mutex;
+using std::lock_guard;
+
 namespace YouCompleteMe {
 
 IdentifierDatabase::IdentifierDatabase()
@@ -34,7 +37,7 @@ IdentifierDatabase::IdentifierDatabase()
 
 void IdentifierDatabase::AddIdentifiers(
   const FiletypeIdentifierMap &filetype_identifier_map ) {
-  std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
+  LockWrapper< lock_guard< mutex > > locker( filetype_candidate_map_mutex_ );
 
   for ( const FiletypeIdentifierMap::value_type & filetype_and_map :
             filetype_identifier_map ) {
@@ -52,7 +55,7 @@ void IdentifierDatabase::AddIdentifiers(
   const std::vector< std::string > &new_candidates,
   const std::string &filetype,
   const std::string &filepath ) {
-  std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
+  LockWrapper< lock_guard< mutex > > locker( filetype_candidate_map_mutex_ );
   AddIdentifiersNoLock( new_candidates, filetype, filepath );
 }
 
@@ -60,7 +63,7 @@ void IdentifierDatabase::AddIdentifiers(
 void IdentifierDatabase::ClearCandidatesStoredForFile(
   const std::string &filetype,
   const std::string &filepath ) {
-  std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
+  LockWrapper< lock_guard< mutex > > locker( filetype_candidate_map_mutex_ );
   GetCandidateSet( filetype, filepath ).clear();
 }
 
@@ -72,7 +75,7 @@ void IdentifierDatabase::ResultsForQueryAndType(
   const size_t max_results ) const {
   FiletypeCandidateMap::const_iterator it;
   {
-    std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
+    LockWrapper< lock_guard< mutex > > locker( filetype_candidate_map_mutex_ );
     it = filetype_candidate_map_.find( filetype );
 
     if ( it == filetype_candidate_map_.end() ) {
@@ -85,7 +88,7 @@ void IdentifierDatabase::ResultsForQueryAndType(
   seen_candidates.reserve( candidate_repository_.NumStoredCandidates() );
 
   {
-    std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
+    LockWrapper< lock_guard< mutex > > locker( filetype_candidate_map_mutex_ );
     for ( const FilepathToCandidates::value_type & path_and_candidates :
               *it->second ) {
       for ( const Candidate * candidate : *path_and_candidates.second ) {

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -18,9 +18,10 @@
 #ifndef IDENTIFIERDATABASE_H_ZESX3CVR
 #define IDENTIFIERDATABASE_H_ZESX3CVR
 
+#include "Mutex.h"
+
 #include <unordered_map>
 #include <memory>
-#include <mutex>
 #include <vector>
 #include <string>
 #include <map>
@@ -74,12 +75,12 @@ public:
 private:
   std::set< const Candidate * > &GetCandidateSet(
     const std::string &filetype,
-    const std::string &filepath );
+    const std::string &filepath ) NO_THREAD_SAFETY_ANALYSIS;
 
   void AddIdentifiersNoLock(
     const std::vector< std::string > &new_candidates,
     const std::string &filetype,
-    const std::string &filepath );
+    const std::string &filepath ) REQUIRES( filetype_candidate_map_mutex_ );
 
 
   // filepath -> *( *candidate )
@@ -94,8 +95,9 @@ private:
 
   CandidateRepository &candidate_repository_;
 
-  FiletypeCandidateMap filetype_candidate_map_;
-  mutable std::mutex filetype_candidate_map_mutex_;
+  FiletypeCandidateMap filetype_candidate_map_
+    GUARDED_BY( filetype_candidate_map_mutex_ );
+  mutable Mutex filetype_candidate_map_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/Mutex.h
+++ b/cpp/ycm/Mutex.h
@@ -1,0 +1,107 @@
+#ifndef YCM_MUTEX_H
+#define YCM_MUTEX_H
+
+#include <mutex>
+
+// Enable thread safety attributes only with clang.
+// The attributes can be safely erased when compiling with other compilers.
+#if defined( __clang__ ) && ( !defined( SWIG ) )
+#define THREAD_ANNOTATION_ATTRIBUTE__( x )   __attribute__( ( x ) )
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE__( x )   // no-op
+#endif
+
+#define CAPABILITY( x ) THREAD_ANNOTATION_ATTRIBUTE__( capability( x ) )
+
+#define SCOPED_CAPABILITY THREAD_ANNOTATION_ATTRIBUTE__( scoped_lockable )
+
+#define GUARDED_BY( x ) THREAD_ANNOTATION_ATTRIBUTE__( guarded_by( x ) )
+
+#define PT_GUARDED_BY( x ) THREAD_ANNOTATION_ATTRIBUTE__( pt_guarded_by( x ) )
+
+#define ACQUIRED_BEFORE( ... ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( acquired_before( __VA_ARGS__ ) )
+
+#define ACQUIRED_AFTER( ... ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( acquired_after( __VA_ARGS__ ) )
+
+#define REQUIRES( ... ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( requires_capability( __VA_ARGS__ ) )
+
+#define REQUIRES_SHARED( ... ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( requires_shared_capability( __VA_ARGS__ ) )
+
+#define ACQUIRE( ... ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( acquire_capability( __VA_ARGS__ ) )
+
+#define ACQUIRE_SHARED( ... ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( acquire_shared_capability( __VA_ARGS__ ) )
+
+#define RELEASE( ... ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( release_capability( __VA_ARGS__ ) )
+
+#define RELEASE_SHARED( ... ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( release_shared_capability( __VA_ARGS__ ) )
+
+#define TRY_ACQUIRE( ... ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( try_acquire_capability( __VA_ARGS__ ) )
+
+#define TRY_ACQUIRE_SHARED( ... ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( try_acquire_shared_capability( __VA_ARGS__ ) )
+
+#define EXCLUDES( ... ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( locks_excluded( __VA_ARGS__ ) )
+
+#define ASSERT_CAPABILITY( x ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( assert_capability( x ) )
+
+#define ASSERT_SHARED_CAPABILITY( x ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( assert_shared_capability( x ) )
+
+#define RETURN_CAPABILITY( x ) \
+  THREAD_ANNOTATION_ATTRIBUTE__( lock_returned( x ) )
+
+#define NO_THREAD_SAFETY_ANALYSIS \
+  THREAD_ANNOTATION_ATTRIBUTE__( no_thread_safety_analysis )
+
+namespace YouCompleteMe {
+
+// NOTE: Wrappers for std::mutex, std::lock_guard andstd::unique_lock
+// are provided so that we can annotate them with thread safety attributes
+// and use the -Wthread-safety warning with clang.
+// The standard library types cannot be
+// used directly because they do not provided the required annotations.
+class CAPABILITY( "mutex" ) Mutex {
+ public:
+  Mutex() = default;
+
+  void lock() ACQUIRE() { mut_.lock(); }
+  void unlock() RELEASE() { mut_.unlock(); }
+  std::mutex &native_handle() { return mut_; }
+
+ private:
+  std::mutex mut_;
+};
+
+
+template <class LockType>
+class SCOPED_CAPABILITY LockWrapper {
+public:
+  LockWrapper( Mutex &m ) ACQUIRE( m ) : lt_( m.native_handle() ) {}
+
+  template < typename T = LockType, typename std::enable_if<
+    std::is_same< T, std::unique_lock< std::mutex > >::value, int >::type = 0 >
+  LockWrapper( Mutex &m, std::try_to_lock_t ) ACQUIRE( m )
+    : lt_( m.native_handle(), std::try_to_lock ) {}
+
+  ~LockWrapper() RELEASE() = default;
+  template < typename T = LockType, typename std::enable_if<
+    std::is_same< T, std::unique_lock< std::mutex > >::value, int >::type = 0 >
+  bool owns_lock() { return lt_.owns_lock(); }
+private:
+  LockType lt_;
+};
+
+} // namespace YouCompleteMe
+
+#endif


### PR DESCRIPTION
This PR
- Adds `-Wthread-safety` to CMake and extra conf.
- Wraps STL mutexes with annotated classes in `cpp/ycm/Mutex.h`.
- Places appropriate annotations on member variables and methods.
- Places NO_THREAD_SAFETY_ANALYSIS on methods deemed unsafe.
- Bumps travis clang version to 3.5

### Wrapping STL

I'm not too happy about this because, as it stands now, nothing prevents anyone from using `std::mutex` and thus avoid the thread safety annotations.

Libc++ is supposed to have its `<mutex>` header properly annotated since 2016 according to this [PR](https://reviews.llvm.org/D14731), but I couldn't get it to work when I tried passing `-stdlib=libc++` to clang. [This gist](https://gist.github.com/bstaletic/9084c975107db6c5d1b5e7396514ca11) can be used for testing non-wrapped STL mutexes and needs to be compiled with `-Wthread-safety`. If successful, it should produce exactly one warning with the following content:

```
foo.cpp:24:3: warning: mutex 'mu' is still held at the end of function [-Wthread-safety-analysis]
  }                          // WARNING!  Failed to unlock mu. - Not triggered with UniqueLock or LockGuard
  ^
foo.cpp:22:8: note: mutex acquired here
    mu.lock();
       ^
1 warning generated.
```

### NO_THREAD_SAFETY_ANALYSIS

This appeared in six places throughout our codebase:
- `CandidateRepository::ClearCandidates`
- `CharacterRepository::ClearCharacters`
- `CodePointRepository::ClearCodePoints`
- `IdentifierDatabase::GetCandidateSet`
- `TranslationUnit::IsCurrentlyUpdating`
- `TranslationUnit::Reparse( std::vector< CXUnsavedFile > )`

`NO_THREAD_SAFETY_ANALYSIS` simply silences the thread safety warnings inside a single function. Other options include really adding the locks that clang says are missing or specifying that the caller of these six functions must already hold a mutex before making the call.
The reason I didn't just put locks whenever clang complained is because some of these are in places where performance really matters and we all know that another word for "a mutex" is "a bottleneck".

### Clang 3.5

Clang 3.4 doen't have support for thread annotations, so I had to increase the clang version on travis. We could introduce `-DTHREAD_SAFETY_ANNOTATIONS` which would be guarded by `if( COMPILER_IS_CLANG AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.4 )`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1045)
<!-- Reviewable:end -->
