### PR TITLE
[READY] Fix TypeScript FixIt subcommand test

### DIFF
--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -709,12 +709,13 @@ def Subcommands_FixIt_test( app ):
             'chunks': contains(
               ChunkMatcher(
                 matches_regexp(
-                  '^    nonExistingMethod\(\): any {\r?\n'
+                  '^\r?\n'
+                  '    nonExistingMethod\(\): any {\r?\n'
                   '        throw new Error\("Method not implemented."\);\r?\n'
-                  '    }\r?\n$',
+                  '    }$',
                 ),
-                LocationMatcher( PathToTestFile( 'test.ts' ), 27, 1 ),
-                LocationMatcher( PathToTestFile( 'test.ts' ), 27, 1 ) )
+                LocationMatcher( PathToTestFile( 'test.ts' ), 25, 12 ),
+                LocationMatcher( PathToTestFile( 'test.ts' ), 25, 12 ) )
             ),
             'location': LocationMatcher( PathToTestFile( 'test.ts' ), 35, 12 )
           } ),
@@ -722,9 +723,10 @@ def Subcommands_FixIt_test( app ):
             'text': "Declare property 'nonExistingMethod'",
             'chunks': contains(
               ChunkMatcher(
-                matches_regexp( '^    nonExistingMethod: any;\r?\n$' ),
-                LocationMatcher( PathToTestFile( 'test.ts' ), 27, 1 ),
-                LocationMatcher( PathToTestFile( 'test.ts' ), 27, 1 ) )
+                matches_regexp( '^\r?\n'
+                                '    nonExistingMethod: any;$' ),
+                LocationMatcher( PathToTestFile( 'test.ts' ), 25, 12 ),
+                LocationMatcher( PathToTestFile( 'test.ts' ), 25, 12 ) )
             ),
             'location': LocationMatcher( PathToTestFile( 'test.ts' ), 35, 12 )
           } ),
@@ -732,9 +734,10 @@ def Subcommands_FixIt_test( app ):
             'text': "Add index signature for property 'nonExistingMethod'",
             'chunks': contains(
               ChunkMatcher(
-                matches_regexp( '^    \[x: string\]: any;\r?\n$' ),
-                LocationMatcher( PathToTestFile( 'test.ts' ), 27, 1 ),
-                LocationMatcher( PathToTestFile( 'test.ts' ), 27, 1 ) )
+                matches_regexp( '^\r?\n'
+                                '    \[x: string\]: any;$' ),
+                LocationMatcher( PathToTestFile( 'test.ts' ), 25, 12 ),
+                LocationMatcher( PathToTestFile( 'test.ts' ), 25, 12 ) )
             ),
             'location': LocationMatcher( PathToTestFile( 'test.ts' ), 35, 12 )
           } )


### PR DESCRIPTION
[TypeScript 2.9.1](https://blogs.msdn.microsoft.com/typescript/2018/05/31/announcing-typescript-2-9/) has improved the way FixIts are applied:

![typescript-2 8 4-fixit](https://user-images.githubusercontent.com/10026824/40873983-e6a824b0-6669-11e8-87da-95dc72612d16.gif)
*TypeScript 2.8.4*

![typescript-2 9 1-fixit](https://user-images.githubusercontent.com/10026824/40873986-eb4e7c08-6669-11e8-8111-6dd6fe0a9b1a.gif)
*TypeScript 2.9.1*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1048)
<!-- Reviewable:end -->
