### PR TITLE
[READY] Inform user if maximum number of diagnostics is exceeded

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -169,6 +169,8 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
   def __init__( self, user_options ):
     self.user_options = user_options
     self.min_num_chars = user_options[ 'min_num_of_chars_for_completion' ]
+    self.max_diagnostics_to_display = user_options[
+        'max_diagnostics_to_display' ]
     self.prepared_triggers = (
         completer_utils.PreparedTriggers(
             user_trigger_map = user_options[ 'semantic_triggers' ],

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -54,8 +54,6 @@ INCLUDE_REGEX = re.compile( '(\s*#\s*(?:include|import)\s*)(?:"[^"]*|<[^>]*)' )
 class ClangCompleter( Completer ):
   def __init__( self, user_options ):
     super( ClangCompleter, self ).__init__( user_options )
-    self._max_diagnostics_to_display = user_options[
-      'max_diagnostics_to_display' ]
     self._completer = ycm_core.ClangCompleter()
     self._flags = Flags()
     self._include_cache = IncludeCache()
@@ -357,8 +355,9 @@ class ClangCompleter( Completer ):
 
     diagnostics = _FilterDiagnostics( diagnostics )
     self._diagnostic_store = DiagnosticsToDiagStructure( diagnostics )
-    return [ responses.BuildDiagnosticData( x ) for x in
-             diagnostics[ : self._max_diagnostics_to_display ] ]
+    return responses.BuildDiagnosticResponse( diagnostics,
+                                              request_data[ 'filepath' ],
+                                              self.max_diagnostics_to_display )
 
 
   def OnBufferUnload( self, request_data ):

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -59,8 +59,6 @@ class CsharpCompleter( Completer ):
     self._solution_for_file = {}
     self._completer_per_solution = {}
     self._diagnostic_store = None
-    self._max_diagnostics_to_display = user_options[
-      'max_diagnostics_to_display' ]
     self._solution_state_lock = threading.Lock()
 
     if not os.path.isfile( PATH_TO_OMNISHARP_BINARY ):
@@ -203,8 +201,9 @@ class CsharpCompleter( Completer ):
 
     self._diagnostic_store = DiagnosticsToDiagStructure( diagnostics )
 
-    return [ responses.BuildDiagnosticData( x ) for x in
-             diagnostics[ : self._max_diagnostics_to_display ] ]
+    return responses.BuildDiagnosticResponse( diagnostics,
+                                              request_data[ 'filepath' ],
+                                              self.max_diagnostics_to_display )
 
 
   def _QuickFixToDiagnostic( self, request_data, quick_fix ):

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -183,9 +183,6 @@ class TypeScriptCompleter( Completer ):
 
     self._StartServer()
 
-    self._max_diagnostics_to_display = user_options[
-      'max_diagnostics_to_display' ]
-
     self._latest_diagnostics_for_file_lock = threading.Lock()
     self._latest_diagnostics_for_file = defaultdict( list )
 
@@ -452,7 +449,9 @@ class TypeScriptCompleter( Completer ):
     filepath = request_data[ 'filepath' ]
     with self._latest_diagnostics_for_file_lock:
       self._latest_diagnostics_for_file[ filepath ] = diagnostics
-    return [ responses.BuildDiagnosticData( x ) for x in diagnostics ]
+    return responses.BuildDiagnosticResponse( diagnostics,
+                                              filepath,
+                                              self.max_diagnostics_to_display )
 
 
   def GetTsDiagnosticsForCurrentFile( self, request_data ):
@@ -521,7 +520,7 @@ class TypeScriptCompleter( Completer ):
     ts_diagnostics = self.GetTsDiagnosticsForCurrentFile( request_data )
 
     return [ self._TsDiagnosticToYcmdDiagnostic( request_data, x )
-             for x in ts_diagnostics[ : self._max_diagnostics_to_display ] ]
+             for x in ts_diagnostics ]
 
 
   def GetDetailedDiagnostic( self, request_data ):

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -237,6 +237,24 @@ def BuildDiagnosticData( diagnostic ):
   }
 
 
+def BuildDiagnosticResponse( diagnostics,
+                             filename,
+                             max_diagnostics_to_display ):
+  if ( max_diagnostics_to_display and
+       len( diagnostics ) > max_diagnostics_to_display ):
+    diagnostics = diagnostics[ : max_diagnostics_to_display ]
+    location = Location( 1, 1, filename )
+    location_extent = Range( location, location )
+    diagnostics.append( Diagnostic(
+      [ location_extent ],
+      location,
+      location_extent,
+      'Maximum number of diagnostics exceeded.',
+      'ERROR'
+    ) )
+  return [ BuildDiagnosticData( diagnostic ) for diagnostic in diagnostics ]
+
+
 def BuildFixItResponse( fixits ):
   """Build a response from a list of FixIt (aka Refactor) objects. This response
   can be used to apply arbitrary changes to arbitrary files and is suitable for

--- a/ycmd/tests/clang/diagnostics_test.py
+++ b/ycmd/tests/clang/diagnostics_test.py
@@ -34,7 +34,7 @@ from hamcrest import ( assert_that,
 from pprint import pprint
 
 from ycmd.tests.clang import SharedYcmd, IsolatedYcmd, PathToTestFile
-from ycmd.tests.test_utils import BuildRequest
+from ycmd.tests.test_utils import BuildRequest, LocationMatcher, RangeMatcher
 from ycmd.utils import ReadFile
 
 
@@ -51,39 +51,19 @@ void foo() {
   event_data = BuildRequest( compilation_flags = [ '-x', 'c++' ],
                              event_name = 'FileReadyToParse',
                              contents = contents,
+                             filepath = 'foo',
                              filetype = 'cpp' )
 
   results = app.post_json( '/event_notification', event_data ).json
-  assert_that( results,
-               contains(
-                  has_entries( {
-                    'kind': equal_to( 'ERROR' ),
-                    'text': contains_string( 'cannot initialize' ),
-                    'ranges': contains( has_entries( {
-                      'start': has_entries( {
-                        'line_num': 3,
-                        'column_num': 16,
-                      } ),
-                      'end': has_entries( {
-                        'line_num': 3,
-                        'column_num': 21,
-                      } ),
-                    } ) ),
-                    'location': has_entries( {
-                      'line_num': 3,
-                      'column_num': 10
-                    } ),
-                    'location_extent': has_entries( {
-                      'start': has_entries( {
-                        'line_num': 3,
-                        'column_num': 10,
-                      } ),
-                      'end': has_entries( {
-                        'line_num': 3,
-                        'column_num': 13,
-                      } ),
-                    } )
-                  } ) ) )
+  assert_that( results, contains(
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'text': contains_string( 'cannot initialize' ),
+      'ranges': contains( RangeMatcher( 'foo', ( 3, 16 ), ( 3, 21 ) ) ),
+      'location': LocationMatcher( 'foo', 3, 10 ),
+      'location_extent': RangeMatcher( 'foo', ( 3, 10 ), ( 3, 13 ) )
+    } )
+  ) )
 
 
 @IsolatedYcmd()
@@ -99,23 +79,15 @@ void foo() {
   event_data = BuildRequest( compilation_flags = [ '-x', 'c++' ],
                              event_name = 'FileReadyToParse',
                              contents = contents,
+                             filepath = 'foo',
                              filetype = 'cpp' )
 
   results = app.post_json( '/event_notification', event_data ).json
-  assert_that( results,
-               contains(
-                  has_entries( {
-                    'location_extent': has_entries( {
-                      'start': has_entries( {
-                        'line_num': 3,
-                        'column_num': 3,
-                      } ),
-                      'end': has_entries( {
-                        'line_num': 3,
-                        'column_num': 6,
-                      } ),
-                    } )
-                  } ) ) )
+  assert_that( results, contains(
+    has_entries( {
+      'location_extent': RangeMatcher( 'foo', ( 3, 3 ), ( 3, 6 ) )
+    } )
+  ) )
 
 
 @IsolatedYcmd()
@@ -198,10 +170,11 @@ int main() {
 
 @IsolatedYcmd()
 def Diagnostics_FixIt_Available_test( app ):
-  contents = ReadFile( PathToTestFile( 'FixIt_Clang_cpp11.cpp' ) )
+  filepath = PathToTestFile( 'FixIt_Clang_cpp11.cpp' )
 
-  event_data = BuildRequest( contents = contents,
+  event_data = BuildRequest( contents = ReadFile( filepath ),
                              event_name = 'FileReadyToParse',
+                             filepath = filepath,
                              filetype = 'cpp',
                              compilation_flags = [ '-x', 'c++',
                                                    '-std=c++03',
@@ -215,13 +188,13 @@ def Diagnostics_FixIt_Available_test( app ):
 
   assert_that( response, has_items(
     has_entries( {
-      'location': has_entries( { 'line_num': 16, 'column_num': 3 } ),
+      'location': LocationMatcher( filepath, 16, 3 ),
       'text': equal_to( 'switch condition type \'A\' '
                         'requires explicit conversion to \'int\'' ),
       'fixit_available': True
     } ),
     has_entries( {
-      'location': has_entries( { 'line_num': 11, 'column_num': 3 } ),
+      'location': LocationMatcher( filepath, 11, 3 ),
       'text': equal_to(
          'explicit conversion functions are a C++11 extension' ),
       'fixit_available': False
@@ -231,10 +204,11 @@ def Diagnostics_FixIt_Available_test( app ):
 
 @IsolatedYcmd()
 def Diagnostics_MultipleMissingIncludes_test( app ):
-  contents = ReadFile( PathToTestFile( 'multiple_missing_includes.cc' ) )
+  filepath = PathToTestFile( 'multiple_missing_includes.cc' )
 
-  event_data = BuildRequest( contents = contents,
+  event_data = BuildRequest( contents = ReadFile( filepath ),
                              event_name = 'FileReadyToParse',
+                             filepath = filepath,
                              filetype = 'cpp',
                              compilation_flags = [ '-x', 'c++' ] )
 
@@ -245,13 +219,13 @@ def Diagnostics_MultipleMissingIncludes_test( app ):
   assert_that( response, has_items(
     has_entries( {
       'kind': equal_to( 'ERROR' ),
-      'location': has_entries( { 'line_num': 1, 'column_num': 10 } ),
+      'location': LocationMatcher( filepath, 1, 10 ),
       'text': equal_to( "'first_missing_include' file not found" ),
       'fixit_available': False
     } ),
     has_entries( {
       'kind': equal_to( 'ERROR' ),
-      'location': has_entries( { 'line_num': 2, 'column_num': 10 } ),
+      'location': LocationMatcher( filepath, 2, 10 ),
       'text': equal_to( "'second_missing_include' file not found" ),
       'fixit_available': False
     } ),
@@ -260,12 +234,12 @@ def Diagnostics_MultipleMissingIncludes_test( app ):
 
 @IsolatedYcmd()
 def Diagnostics_LocationExtent_MissingSemicolon_test( app ):
-  contents = ReadFile( PathToTestFile( 'location_extent.cc' ) )
+  filepath = PathToTestFile( 'location_extent.cc' )
 
-  event_data = BuildRequest( contents = contents,
+  event_data = BuildRequest( contents = ReadFile( filepath ),
                              event_name = 'FileReadyToParse',
+                             filepath = filepath,
                              filetype = 'cpp',
-                             filepath = 'foo',
                              compilation_flags = [ '-x', 'c++' ] )
 
   response = app.post_json( '/event_notification', event_data ).json
@@ -275,95 +249,28 @@ def Diagnostics_LocationExtent_MissingSemicolon_test( app ):
   assert_that( response, contains(
     has_entries( {
       'kind': equal_to( 'ERROR' ),
-      'location': has_entries( {
-        'line_num': 2,
-        'column_num': 9,
-        'filepath': 'foo'
-      } ),
-      'location_extent': has_entries( {
-        'start': has_entries( {
-          'line_num': 2,
-          'column_num': 9,
-          'filepath': 'foo'
-        } ),
-        'end': has_entries( {
-          'line_num': 2,
-          'column_num': 9,
-          'filepath': 'foo'
-        } )
-      } ),
+      'location': LocationMatcher( filepath, 2, 9 ),
+      'location_extent': RangeMatcher( filepath, ( 2, 9 ), ( 2, 9 ) ),
       'ranges': empty(),
       'text': equal_to( "expected ';' at end of declaration list" ),
       'fixit_available': True
     } ),
     has_entries( {
       'kind': equal_to( 'ERROR' ),
-      'location': has_entries( {
-        'line_num': 5,
-        'column_num': 1,
-        'filepath': 'foo'
-      } ),
-      'location_extent': has_entries( {
-        'start': has_entries( {
-          'line_num': 5,
-          'column_num': 1,
-          'filepath': 'foo'
-        } ),
-        'end': has_entries( {
-          'line_num': 6,
-          'column_num': 11,
-          'filepath': 'foo'
-        } )
-      } ),
+      'location': LocationMatcher( filepath, 5, 1 ),
+      'location_extent': RangeMatcher( filepath, ( 5, 1 ), ( 6, 11 ) ),
       'ranges': empty(),
       'text': equal_to( "unknown type name 'multiline_identifier'" ),
       'fixit_available': False
     } ),
     has_entries( {
       'kind': equal_to( 'ERROR' ),
-      'location': has_entries( {
-        'line_num': 8,
-        'column_num': 7,
-        'filepath': 'foo'
-      } ),
-      'location_extent': has_entries( {
-        'start': has_entries( {
-          'line_num': 8,
-          'column_num': 7,
-          'filepath': 'foo'
-        } ),
-        'end': has_entries( {
-          'line_num': 8,
-          'column_num': 11,
-          'filepath': 'foo'
-        } )
-      } ),
+      'location': LocationMatcher( filepath, 8, 7 ),
+      'location_extent': RangeMatcher( filepath, ( 8, 7 ), ( 8, 11 ) ),
       'ranges': contains(
         # FIXME: empty ranges from libclang should be ignored.
-        has_entries( {
-          'start': has_entries( {
-            'line_num': 0,
-            'column_num': 0,
-            'filepath': ''
-          } ),
-          'end': has_entries( {
-            'line_num': 0,
-            'column_num': 0,
-            'filepath': ''
-          } )
-        } ),
-        has_entries( {
-          'start': has_entries( {
-            'line_num': 8,
-            'column_num': 7,
-            'filepath': 'foo'
-          } ),
-          'end': has_entries( {
-            'line_num': 8,
-            'column_num': 11,
-            'filepath': 'foo'
-          } )
-        } )
+        RangeMatcher( '', ( 0, 0 ), ( 0, 0 ) ),
+        RangeMatcher( filepath, ( 8, 7 ), ( 8, 11 ) )
       ),
       'text': equal_to( 'constructor cannot have a return type' ),
       'fixit_available': False
@@ -391,46 +298,20 @@ def Diagnostics_Unity_test( app ):
     assert_that( response, contains_inanyorder(
       has_entries( {
         'kind': equal_to( 'ERROR' ),
-        'location': has_entries( {
-          'line_num': 4,
-          'column_num': 3,
-          'filepath': PathToTestFile( 'unity.h' )
-        } ),
-        'location_extent': has_entries( {
-          'start': has_entries( {
-            'line_num': 4,
-            'column_num': 3,
-            'filepath': PathToTestFile( 'unity.h' )
-          } ),
-          'end': has_entries( {
-            'line_num': 4,
-            'column_num': 14,
-            'filepath': PathToTestFile( 'unity.h' )
-          } ),
-        } ),
+        'location': LocationMatcher( PathToTestFile( 'unity.h' ), 4, 3 ),
+        'location_extent': RangeMatcher( PathToTestFile( 'unity.h' ),
+                                         ( 4, 3 ),
+                                         ( 4, 14 ) ),
         'ranges': empty(),
         'text': equal_to( "use of undeclared identifier 'fake_method'" ),
         'fixit_available': False
       } ),
       has_entries( {
         'kind': equal_to( 'ERROR' ),
-        'location': has_entries( {
-          'line_num': 11,
-          'column_num': 18,
-          'filepath': PathToTestFile( 'unitya.cc' )
-        } ),
-        'location_extent': has_entries( {
-          'start': has_entries( {
-            'line_num': 11,
-            'column_num': 18,
-            'filepath': PathToTestFile( 'unitya.cc' )
-          } ),
-          'end': has_entries( {
-            'line_num': 11,
-            'column_num': 18,
-            'filepath': PathToTestFile( 'unitya.cc' )
-          } ),
-        } ),
+        'location': LocationMatcher( PathToTestFile( 'unitya.cc' ), 11, 18 ),
+        'location_extent': RangeMatcher( PathToTestFile( 'unitya.cc' ),
+                                         ( 11, 18 ),
+                                         ( 11, 18 ) ),
         'ranges': empty(),
         'text': equal_to( "expected ';' after expression" ),
         'fixit_available': True
@@ -441,10 +322,9 @@ def Diagnostics_Unity_test( app ):
 @SharedYcmd
 def Diagnostics_CUDA_Kernel_test( app ):
   filepath = PathToTestFile( 'cuda', 'kernel_call.cu' )
-  contents = ReadFile( filepath )
 
   event_data = BuildRequest( filepath = filepath,
-                             contents = contents,
+                             contents = ReadFile( filepath ),
                              event_name = 'FileReadyToParse',
                              filetype = 'cuda',
                              compilation_flags = [ '-x', 'cuda', '-nocudainc',
@@ -457,94 +337,128 @@ def Diagnostics_CUDA_Kernel_test( app ):
   assert_that( response, contains_inanyorder(
     has_entries( {
       'kind': equal_to( 'ERROR' ),
-      'location': has_entries( { 'line_num': 59, 'column_num': 5 } ),
-      'location_extent': has_entries( {
-          'start': has_entries( { 'line_num': 59, 'column_num': 5 } ),
-          'end': has_entries( { 'line_num': 59, 'column_num': 6 } ),
-      } ),
-      'ranges': contains( has_entries( {
-          'start': has_entries( { 'line_num': 59, 'column_num': 3 } ),
-          'end': has_entries( { 'line_num': 59, 'column_num': 5 } ),
-      } ) ),
+      'location': LocationMatcher( filepath, 59, 5 ),
+      'location_extent': RangeMatcher( filepath, ( 59, 5 ), ( 59, 6 ) ),
+      'ranges': contains( RangeMatcher( filepath, ( 59, 3 ), ( 59, 5 ) ) ),
       'text': equal_to( 'call to global function g1 not configured' ),
       'fixit_available': False
     } ),
     has_entries( {
       'kind': equal_to( 'ERROR' ),
-      'location': has_entries( { 'line_num': 60, 'column_num': 9 } ),
-      'location_extent': has_entries( {
-          'start': has_entries( { 'line_num': 60, 'column_num': 9 } ),
-          'end': has_entries( { 'line_num': 60, 'column_num': 12 } ),
-      } ),
-      'ranges': contains( has_entries( {
-          'start': has_entries( { 'line_num': 60, 'column_num': 5 } ),
-          'end': has_entries( { 'line_num': 60, 'column_num': 8 } ),
-      } ) ),
+      'location': LocationMatcher( filepath, 60, 9 ),
+      'location_extent': RangeMatcher( filepath, ( 60, 9 ), ( 60, 12 ) ),
+      'ranges': contains( RangeMatcher( filepath, ( 60, 5 ), ( 60, 8 ) ) ),
       'text': equal_to(
-          'too few execution configuration arguments to kernel function call,' +
-            ' expected at least 2, have 1'
+        'too few execution configuration arguments to kernel function call, '
+        'expected at least 2, have 1'
       ),
       'fixit_available': False
     } ),
     has_entries( {
       'kind': equal_to( 'ERROR' ),
-      'location': has_entries( { 'line_num': 61, 'column_num': 20 } ),
-      'location_extent': has_entries( {
-          'start': has_entries( { 'line_num': 61, 'column_num': 20 } ),
-          'end': has_entries( { 'line_num': 61, 'column_num': 21 } ),
-      } ),
+      'location': LocationMatcher( filepath, 61, 20 ),
+      'location_extent': RangeMatcher( filepath, ( 61, 20 ), ( 61, 21 ) ),
       'ranges': contains(
-          has_entries( {
-            'start': has_entries( { 'line_num': 61, 'column_num': 5 } ),
-            'end': has_entries( { 'line_num': 61, 'column_num': 8 } ),
-          } ),
-          has_entries( {
-            'start': has_entries( { 'line_num': 61, 'column_num': 20 } ),
-            'end': has_entries( { 'line_num': 61, 'column_num': 21 } ),
-          } ),
+        RangeMatcher( filepath, ( 61, 5 ), ( 61, 8 ) ),
+        RangeMatcher( filepath, ( 61, 20 ), ( 61, 21 ) )
       ),
-      'text': equal_to( 'too many execution configuration arguments to kernel' +
-                          ' function call, expected at most 4, have 5' ),
+      'text': equal_to( 'too many execution configuration arguments to kernel '
+                        'function call, expected at most 4, have 5' ),
       'fixit_available': False
     } ),
     has_entries( {
       'kind': equal_to( 'ERROR' ),
-      'location': has_entries( { 'line_num': 65, 'column_num': 15 } ),
-      'location_extent': has_entries( {
-          'start': has_entries( { 'line_num': 65, 'column_num': 15 } ),
-          'end': has_entries( { 'line_num': 65, 'column_num': 16 } ),
-      } ),
-      'ranges': contains( has_entries( {
-          'start': has_entries( { 'line_num': 65, 'column_num': 3 } ),
-          'end': has_entries( { 'line_num': 65, 'column_num': 5 } ),
-      } ) ),
+      'location': LocationMatcher( filepath, 65, 15 ),
+      'location_extent': RangeMatcher( filepath, ( 65, 15 ), ( 65, 16 ) ),
+      'ranges': contains( RangeMatcher( filepath, ( 65, 3 ), ( 65, 5 ) ) ),
       'text': equal_to( 'kernel call to non-global function h1' ),
       'fixit_available': False
     } ),
     has_entries( {
       'kind': equal_to( 'ERROR' ),
-      'location': has_entries( { 'line_num': 68, 'column_num': 15 } ),
-      'location_extent': has_entries( {
-          'start': has_entries( { 'line_num': 68, 'column_num': 15 } ),
-          'end': has_entries( { 'line_num': 68, 'column_num': 16 } ),
-      } ),
-      'ranges': contains( has_entries( {
-          'start': has_entries( { 'line_num': 68, 'column_num': 3 } ),
-          'end': has_entries( { 'line_num': 68, 'column_num': 5 } ),
-      } ) ),
+      'location': LocationMatcher( filepath, 68, 15 ),
+      'location_extent': RangeMatcher( filepath, ( 68, 15 ), ( 68, 16 ) ),
+      'ranges': contains( RangeMatcher( filepath, ( 68, 3 ), ( 68, 5 ) ) ),
       'text': equal_to( "kernel function type 'int (*)(int)' must have " +
                           "void return type" ),
       'fixit_available': False
     } ),
     has_entries( {
       'kind': equal_to( 'ERROR' ),
-      'location': has_entries( { 'line_num': 70, 'column_num': 8 } ),
-      'location_extent': has_entries( {
-          'start': has_entries( { 'line_num': 70, 'column_num': 8 } ),
-          'end': has_entries( { 'line_num': 70, 'column_num': 18 } ),
-      } ),
+      'location': LocationMatcher( filepath, 70, 8 ),
+      'location_extent': RangeMatcher( filepath, ( 70, 8 ), ( 70, 18 ) ),
       'ranges': empty(),
       'text': equal_to( "use of undeclared identifier 'undeclared'" ),
       'fixit_available': False
     } ),
+  ) )
+
+
+@IsolatedYcmd( { 'max_diagnostics_to_display': 1 } )
+def Diagnostics_MaximumDiagnosticsNumberExceeded_test( app ):
+  filepath = PathToTestFile( 'max_diagnostics.cc' )
+  contents = ReadFile( filepath )
+
+  event_data = BuildRequest( contents = contents,
+                             event_name = 'FileReadyToParse',
+                             filetype = 'cpp',
+                             filepath = filepath,
+                             compilation_flags = [ '-x', 'c++' ] )
+
+  response = app.post_json( '/event_notification', event_data ).json
+
+  pprint( response )
+
+  assert_that( response, contains(
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': LocationMatcher( filepath, 3, 9 ),
+      'location_extent': RangeMatcher( filepath, ( 3, 9 ), ( 3, 13 ) ),
+      'ranges': empty(),
+      'text': equal_to( "redefinition of 'test'" ),
+      'fixit_available': False
+    } ),
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': LocationMatcher( filepath, 1, 1 ),
+      'location_extent': RangeMatcher( filepath, ( 1, 1 ), ( 1, 1 ) ),
+      'ranges': contains( RangeMatcher( filepath, ( 1, 1 ), ( 1, 1 ) ) ),
+      'text': equal_to( 'Maximum number of diagnostics exceeded.' ),
+      'fixit_available': False
+    } )
+  ) )
+
+
+@IsolatedYcmd( { 'max_diagnostics_to_display': 0 } )
+def Diagnostics_NoLimitToNumberOfDiagnostics_test( app ):
+  filepath = PathToTestFile( 'max_diagnostics.cc' )
+  contents = ReadFile( filepath )
+
+  event_data = BuildRequest( contents = contents,
+                             event_name = 'FileReadyToParse',
+                             filetype = 'cpp',
+                             filepath = filepath,
+                             compilation_flags = [ '-x', 'c++' ] )
+
+  response = app.post_json( '/event_notification', event_data ).json
+
+  pprint( response )
+
+  assert_that( response, contains(
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': LocationMatcher( filepath, 3, 9 ),
+      'location_extent': RangeMatcher( filepath, ( 3, 9 ), ( 3, 13 ) ),
+      'ranges': empty(),
+      'text': equal_to( "redefinition of 'test'" ),
+      'fixit_available': False
+    } ),
+    has_entries( {
+      'kind': equal_to( 'ERROR' ),
+      'location': LocationMatcher( filepath, 4, 9 ),
+      'location_extent': RangeMatcher( filepath, ( 4, 9 ), ( 4, 13 ) ),
+      'ranges': empty(),
+      'text': equal_to( "redefinition of 'test'" ),
+      'fixit_available': False
+    } )
   ) )

--- a/ycmd/tests/clang/testdata/max_diagnostics.cc
+++ b/ycmd/tests/clang/testdata/max_diagnostics.cc
@@ -1,0 +1,5 @@
+int main() {
+    int test;
+    int test;
+    int test;
+}

--- a/ycmd/tests/cs/testdata/testy/MaxDiagnostics.cs
+++ b/ycmd/tests/cs/testdata/testy/MaxDiagnostics.cs
@@ -1,0 +1,6 @@
+public class MaxDiagnostics
+{
+    public int test;
+    public int test;
+    public int test;
+}

--- a/ycmd/tests/typescript/__init__.py
+++ b/ycmd/tests/typescript/__init__.py
@@ -68,7 +68,7 @@ def SharedYcmd( test ):
   return Wrapper
 
 
-def IsolatedYcmd( test ):
+def IsolatedYcmd( custom_options = {} ):
   """Defines a decorator to be attached to tests of this package. This decorator
   passes a unique ycmd application as a parameter. It should be used on tests
   that change the server state in a irreversible way (ex: a semantic subserver
@@ -76,11 +76,13 @@ def IsolatedYcmd( test ):
   started, no .ycm_extra_conf.py loaded, etc).
 
   Do NOT attach it to test generators but directly to the yielded tests."""
-  @functools.wraps( test )
-  def Wrapper( *args, **kwargs ):
-    with IsolatedApp() as app:
-      try:
-        test( app, *args, **kwargs )
-      finally:
-        StopCompleterServer( app, 'typescript' )
-  return Wrapper
+  def Decorator( test ):
+    @functools.wraps( test )
+    def Wrapper( *args, **kwargs ):
+      with IsolatedApp( custom_options ) as app:
+        try:
+          test( app, *args, **kwargs )
+        finally:
+          StopCompleterServer( app, 'typescript' )
+    return Wrapper
+  return Decorator

--- a/ycmd/tests/typescript/diagnostics_test.py
+++ b/ycmd/tests/typescript/diagnostics_test.py
@@ -28,7 +28,7 @@ from builtins import *  # noqa
 from hamcrest import ( assert_that, contains, contains_inanyorder, has_entries,
                        has_entry )
 
-from ycmd.tests.typescript import PathToTestFile, SharedYcmd
+from ycmd.tests.typescript import IsolatedYcmd, PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import BuildRequest, LocationMatcher, RangeMatcher
 from ycmd.utils import ReadFile
 
@@ -109,5 +109,44 @@ def Diagnostics_DetailedDiagnostics_test( app ):
     app.post_json( '/detailed_diagnostic', diagnostic_data ).json,
     has_entry(
       'message', "Property 'nonExistingMethod' does not exist on type 'Bar'."
+    )
+  )
+
+
+@IsolatedYcmd( { 'max_diagnostics_to_display': 1 } )
+def Diagnostics_MaximumDiagnosticsNumberExceeded_test( app ):
+  filepath = PathToTestFile( 'test.ts' )
+  contents = ReadFile( filepath )
+
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'typescript',
+                             contents = contents,
+                             event_name = 'BufferVisit' )
+  app.post_json( '/event_notification', event_data )
+
+  event_data = BuildRequest( filepath = filepath,
+                             filetype = 'typescript',
+                             contents = contents,
+                             event_name = 'FileReadyToParse' )
+
+  assert_that(
+    app.post_json( '/event_notification', event_data ).json,
+    contains_inanyorder(
+      has_entries( {
+        'kind': 'ERROR',
+        'text': "Property 'm' does not exist on type 'Foo'.",
+        'location': LocationMatcher( filepath, 17, 5 ),
+        'location_extent': RangeMatcher( filepath, ( 17, 5 ), ( 17, 6 ) ),
+        'ranges': contains( RangeMatcher( filepath, ( 17, 5 ), ( 17, 6 ) ) ),
+        'fixit_available': True
+      } ),
+      has_entries( {
+        'kind': 'ERROR',
+        'text': 'Maximum number of diagnostics exceeded.',
+        'location': LocationMatcher( filepath, 1, 1 ),
+        'location_extent': RangeMatcher( filepath, ( 1, 1 ), ( 1, 1 ) ),
+        'ranges': contains( RangeMatcher( filepath, ( 1, 1 ), ( 1, 1 ) ) ),
+        'fixit_available': False
+      } ),
     )
   )

--- a/ycmd/tests/typescript/event_notification_test.py
+++ b/ycmd/tests/typescript/event_notification_test.py
@@ -29,7 +29,7 @@ from ycmd.tests.test_utils import BuildRequest, CompletionEntryMatcher
 from ycmd.utils import ReadFile
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def EventNotification_OnBufferUnload_CloseFile_test( app ):
   # Open main.ts file in a buffer.
   main_filepath = PathToTestFile( 'buffer_unload', 'main.ts' )

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -195,7 +195,7 @@ def GetCompletions_AfterRestart_test( app ):
   )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 def GetCompletions_ServerIsNotRunning_test( app ):
   StopCompleterServer( app, filetype = 'typescript' )
 

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -938,7 +938,7 @@ def Subcommands_RefactorRename_SimpleUnicode_test( app ):
   } )
 
 
-@IsolatedYcmd
+@IsolatedYcmd()
 @patch( 'ycmd.utils.WaitUntilProcessIsTerminated',
         MockProcessTerminationTimingOut )
 def Subcommands_StopServer_Timeout_test( app ):


### PR DESCRIPTION
See issue https://github.com/Valloric/YouCompleteMe/issues/2392.

If the number of diagnostics exceed the value of `max_diagnostics_to_display`, a diagnostic with the message "Maximum number of diagnostics exceeded." is added at the top of the current file to inform the user.

The language server completer didn't honor the `max_diagnostics_to_display` option. It now does.

Similarly to [the `-ferror-limit` Clang flag](https://clang.llvm.org/docs/UsersManual.html#cmdoption-ferror-limit), a value of `0` for `max_diagnostics_to_display` now means that the number of diagnostics is unlimited.

Closes https://github.com/Valloric/YouCompleteMe/issues/2392.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1051)
<!-- Reviewable:end -->
