### PR TITLE
[READY] Add the regex module to sys.path in ycmd exclusively

### DIFF
--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -124,6 +124,16 @@ def CompatibleWithCurrentCore():
 def SetUpPythonPath():
   sys.path.insert( 0, os.path.join( DIR_OF_CURRENT_SCRIPT, '..' ) )
 
+  # We don't add this path in AddNearestThirdPartyFoldersToSysPath because
+  # loading the regex module in YCM may cause a segmentation fault if the module
+  # is compiled for a different version of Python than the one running YCM.
+  regex_folder = os.path.join( DIR_OF_CURRENT_SCRIPT,
+                               '..',
+                               'third_party',
+                               'cregex',
+                               'regex_{}'.format( sys.version_info[ 0 ] ) )
+  sys.path.insert( 0, regex_folder )
+
   AddNearestThirdPartyFoldersToSysPath( __file__ )
 
 
@@ -189,9 +199,9 @@ def AddNearestThirdPartyFoldersToSysPath( filepath ):
                                                        folder ) ) )
       continue
 
+    # The regex module is already included in SetUpPythonPath.
     if folder == 'cregex':
-      folder = os.path.join( folder,
-                             'regex_{}'.format( sys.version_info[ 0 ] ) )
+      continue
 
     sys.path.insert( 0, os.path.realpath( os.path.join( path_to_third_party,
                                                         folder ) ) )

--- a/ycmd/tests/server_utils_test.py
+++ b/ycmd/tests/server_utils_test.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from future.utils import PY2
 from hamcrest import ( assert_that, calling, contains, contains_inanyorder,
                        empty, equal_to, has_length, raises )
 from mock import patch
@@ -51,13 +50,6 @@ THIRD_PARTY_FOLDERS = [
   os.path.join( DIR_OF_THIRD_PARTY, 'waitress' ),
   os.path.join( DIR_OF_THIRD_PARTY, 'eclipse.jdt.ls' ),
 ]
-if PY2:
-  THIRD_PARTY_FOLDERS.append(
-    os.path.join( DIR_OF_THIRD_PARTY, 'cregex', 'regex_2' ) )
-else:
-  THIRD_PARTY_FOLDERS.append(
-    os.path.join( DIR_OF_THIRD_PARTY, 'cregex', 'regex_3' ) )
-
 
 
 @patch( 'ycmd.server_utils._logger', autospec = True )


### PR DESCRIPTION
Since the `regex` module has a compiled component, adding it to `sys.path` in YCM may lead to a segmentation fault if the version of Python that YCM is running on is different than the one used to compile the module (e.g. YCM running on Python 3.6 while the `regex` module is compiled for Python 3.5). Note that the crash only seems to happen on macOS.

This is most likely going to fix issue https://github.com/Valloric/YouCompleteMe/issues/3048.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1052)
<!-- Reviewable:end -->
