### PR TITLE
[READY] Improve FromWatchdogWithSubservers test robustness

### DIFF
--- a/ycmd/tests/shutdown_test.py
+++ b/ycmd/tests/shutdown_test.py
@@ -23,8 +23,12 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 from hamcrest import assert_that, equal_to
+from threading import Event
+import time
+import requests
 
 from ycmd.tests.client_test import Client_test
+from ycmd.utils import StartThread
 
 # Time to wait for all the servers to shutdown. Tweak for the CI environment.
 #
@@ -81,17 +85,33 @@ class Shutdown_test( Client_test ):
 
   @Client_test.CaptureLogfiles
   def FromWatchdogWithSubservers_test( self ):
-    self.Start( idle_suicide_seconds = 5, check_interval_seconds = 1 )
+    all_servers_are_running = Event()
 
-    filetypes = [ 'cs',
-                  'go',
-                  'java',
-                  'javascript',
-                  'typescript',
-                  'rust' ]
-    for filetype in filetypes:
-      self.StartSubserverForFiletype( filetype )
-    self.AssertServersAreRunning()
+    def KeepServerAliveInAnotherThread():
+      while not all_servers_are_running.is_set():
+        try:
+          self.GetRequest( 'ready' )
+        except requests.exceptions.ConnectionError:
+          pass
+        finally:
+          time.sleep( 0.1 )
+
+    self.Start( idle_suicide_seconds = 2, check_interval_seconds = 1 )
+
+    StartThread( KeepServerAliveInAnotherThread )
+
+    try:
+      filetypes = [ 'cs',
+                    'go',
+                    'java',
+                    'javascript',
+                    'typescript',
+                    'rust' ]
+      for filetype in filetypes:
+        self.StartSubserverForFiletype( filetype )
+      self.AssertServersAreRunning()
+    finally:
+      all_servers_are_running.set()
 
     self.AssertServersShutDown( timeout = SUBSERVER_SHUTDOWN_TIMEOUT + 10 )
     self.AssertLogfilesAreRemoved()


### PR DESCRIPTION
The `FromWatchdogWithSubservers` test sometimes fail on AppVeyor because the server may become inactive for more than 5 seconds (i.e. no requests are sent within 5 seconds) while waiting for the completer servers (in particular TSServer) to be ready. We prevent that by keeping the server alive in a separate thread until all sub-servers are up and running. This should make the test more robust but also slightly faster as this allow us to stop the server after a shorter time of inactivity (2 seconds instead of 5).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1054)
<!-- Reviewable:end -->
