### PR TITLE
[READY] Set break_property_ type to uint8_t

### DIFF
--- a/cpp/ycm/CodePoint.h
+++ b/cpp/ycm/CodePoint.h
@@ -28,7 +28,7 @@ namespace YouCompleteMe {
 // http://www.unicode.org/reports/tr29/#Grapheme_Cluster_Break_Property_Values
 // NOTE: The properties must take the same value as the ones defined in the
 // update_unicode.py script.
-enum class BreakProperty {
+enum class BreakProperty : uint8_t {
   OTHER              =  0,
   CR                 =  1,
   LF                 =  2,


### PR DESCRIPTION
As it stands now (on master), the `CodePoint::break_property_` is 4 bytes large, requiring one byte of padding before it and causing the whole class to require 7 bytes of padding at the end. If we change the type of the `enum class BreakProperty { ... }` to `enum class BreakProperty : uint8_t { ... } `, we save 3 bytes for the enum size, 1 byte of padding before the `break_property_` and 4 bytes of boundary alignment (which still leaves 3 bytes of boundary alignment) - leading to 8 bytes of saved memory per `CodePoint` instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1055)
<!-- Reviewable:end -->
