### PR TITLE
[READY] Migrate the Clang completer to Settings in extra conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,66 +212,82 @@ Guide_][extra-conf-doc].
 
 The `.ycm_extra_conf.py` module may define the following functions:
 
-#### `FlagsForFile( filename, **kwargs )`
-
-Required for C-family language support.
-
-This function is called by the C-family completer to get the compiler flags to
-use when compiling the file with absolute path `filename`. The following
-additional arguments are optionally supplied depending on user configuration:
-
-- `client_data`: any additional data supplied by the client application.
-   See the [YouCompleteMe documentation][extra-conf-vim-data-doc] for an
-   example.
-
-The return value must be one of the following:
-
-- `None` meaning no flags are known for this file, or
-
-- a dictionary containing the following items:
-
-  - `flags`: (mandatory) a list of compiler flags.
-
-  - `include_paths_relative_to_dir`: (optional) the directory to which the
-    include paths in the list of flags are relative. Defaults to ycmd working
-    directory.
-
-  - `override_filename`: (optional) a string indicating the name of the file to
-    parse as the translation unit for the supplied file name. This fairly
-    advanced feature allows for projects that use a 'unity'-style build, or
-    for header files which depend on other includes in other files.
-
-  - `do_cache`: (optional) a boolean indicating whether or not the result of
-    this call (i.e. the list of flags) should be cached for this file name.
-    Defaults to `True`. If unsure, the default is almost always correct.
-
-  - `flags_ready`: (optional) a boolean indicating that the flags should be
-    used. Defaults to `True`. If unsure, the default is almost always correct.
-
-A minimal example which simply returns a list of flags is:
-
-```python
-def FlagsForFile( filename, **kwargs ):
-  return {
-    'flags': [ '-x', 'c++' ]
-  }
-```
-
 #### `Settings( **kwargs )`
 
-Optional for Python support.
+This function allows users to configure the language completers on a per project
+basis or globally. Currently, it is required by the C-family completer and
+optional for the Python completer. The following arguments can be retrieved from
+the `kwargs` dictionary and are common to all completers:
 
-This function allows users to configure the Python completer on a per project
-basis or globally. The following arguments are supplied:
+- `language`: an identifier of the completer that called the function. Its value
+  is `python` for the Python completer and `cfamily` for the C-family completer.
+  This argument is useful to configure several completers at once. For
+  instance:
 
-- `language`: the current language `python`. Useful when working on a project
-  with other languages than Python.
+  ```python
+  def Settings( **kwargs ):
+    language = kwargs[ 'language' ]
+    if language == 'cfamily':
+      return {
+        # Settings for the C-family completer.
+      }
+    if language == 'python':
+      return {
+        # Settings for the Python completer.
+      }
+    return {}
+  ```
 
 - `client_data`: any additional data supplied by the client application.
   See the [YouCompleteMe documentation][extra-conf-vim-data-doc] for an
   example.
 
-The return value is a dictionary containing the following items:
+The return value is a dictionary whose content depends on the completer.
+
+##### C-family settings
+
+The `Settings` function is called by the C-family completer to get the compiler
+flags to use when compiling the current file. The absolute path of this file is
+accessible under the `filename` key of the `kwargs` dictionary.
+
+The return value expected by the completer is a dictionary containing the
+following items:
+
+- `flags`: (mandatory) a list of compiler flags.
+
+- `include_paths_relative_to_dir`: (optional) the directory to which the
+  include paths in the list of flags are relative. Defaults to ycmd working
+  directory.
+
+- `override_filename`: (optional) a string indicating the name of the file to
+  parse as the translation unit for the supplied file name. This fairly
+  advanced feature allows for projects that use a 'unity'-style build, or
+  for header files which depend on other includes in other files.
+
+- `do_cache`: (optional) a boolean indicating whether or not the result of
+  this call (i.e. the list of flags) should be cached for this file name.
+  Defaults to `True`. If unsure, the default is almost always correct.
+
+- `flags_ready`: (optional) a boolean indicating that the flags should be
+  used. Defaults to `True`. If unsure, the default is almost always correct.
+
+A minimal example which simply returns a list of flags is:
+
+```python
+def Settings( **kwargs ):
+  return {
+    'flags': [ '-x', 'c++' ]
+  }
+```
+
+##### Python settings
+
+The `Settings` function allows users to specify the Python interpreter and
+the `sys.path` used by the completer to provide completion and code
+comprehension. No additional arguments are passed.
+
+The return value expected by the completer is a dictionary containing the
+following items:
 
 - `interpreter_path`: (optional) path to the Python interpreter. `~` and
   environment variables in the path are expanded. If not an absolute path, it
@@ -279,9 +295,8 @@ The return value is a dictionary containing the following items:
 
 - `sys_path`: (optional) list of paths prepended to `sys.path`.
 
-Usage examples:
+Usage example:
 
-On a pure Python project:
 ```python
 def Settings( **kwargs ):
   return {
@@ -289,24 +304,14 @@ def Settings( **kwargs ):
     'sys_path': [ '~/project/third_party/module' ]
   }
 ```
-On a project with other languages than Python:
-```python
-def Settings( **kwargs ):
-  language = kwargs[ 'language' ]
-  if language == 'python':
-    return {
-      'interpreter_path': '~/project/virtual_env/bin/python',
-      'sys_path': [ '~/project/third_party/module' ]
-    }
-  return {}
-```
 
 #### `PythonSysPath( **kwargs )`
 
 Optional for Python support.
 
 This function allows further customization of the Python path `sys.path`. Its
-parameters are the possible items returned by the `Settings` function:
+parameters are the possible items returned by the `Settings` function for the
+Python completer:
 
 - `interpreter_path`: path to the Python interpreter.
 

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -84,7 +84,7 @@ EMPTY_FLAGS = {
 class Flags( object ):
   """Keeps track of the flags necessary to compile a file.
   The flags are loaded from user-created python files (hereafter referred to as
-  'modules') that contain a method FlagsForFile( filename )."""
+  'modules') that contain a method Settings( **kwargs )."""
 
   def __init__( self ):
     # We cache the flags by a tuple of filename and client data.
@@ -290,9 +290,13 @@ def _CallExtraConfFlagsForFile( module, filename, client_data ):
   else:
     filename = native( ToUnicode( filename ) )
 
+  if hasattr( module, 'Settings' ):
+    results = module.Settings( language = 'cfamily',
+                               filename = filename,
+                               client_data = client_data )
   # For the sake of backwards compatibility, we need to first check whether the
   # FlagsForFile function in the extra conf module even allows keyword args.
-  if inspect.getargspec( module.FlagsForFile ).keywords:
+  elif inspect.getargspec( module.FlagsForFile ).keywords:
     results = module.FlagsForFile( filename, client_data = client_data )
   else:
     results = module.FlagsForFile( filename )

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -79,7 +79,7 @@ def RunTest( app, test ):
   # Because we aren't testing this command, we *always* ignore errors. This
   # is mainly because we (may) want to test scenarios where the completer
   # throws an exception and the easiest way to do that is to throw from
-  # within the FlagsForFile function.
+  # within the Settings function.
   app.post_json( '/event_notification',
                  CombineRequest( request, {
                    'event_name': 'FileReadyToParse',

--- a/ycmd/tests/clang/testdata/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/.ycm_extra_conf.py
@@ -8,7 +8,8 @@ unity_files = [
 ]
 
 
-def FlagsForFile( filename ):
+def Settings( **kwargs ):
+  filename = kwargs[ 'filename' ]
   if os.path.basename( filename ) in unity_files:
     return {
       'flags': [ '-x', 'c++', '-I', '.' ],

--- a/ycmd/tests/clang/testdata/client_data/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/client_data/.ycm_extra_conf.py
@@ -1,2 +1,2 @@
-def FlagsForFile( filename, **kwargs ):
+def Settings( **kwargs ):
   return { 'flags': kwargs[ 'client_data' ].get( 'flags', [] ) }

--- a/ycmd/tests/clang/testdata/driver_mode_cl/executable/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/driver_mode_cl/executable/.ycm_extra_conf.py
@@ -2,6 +2,6 @@ import os
 
 DIR_OF_THIS_SCRIPT = os.path.dirname( os.path.abspath( __file__ ) )
 
-def FlagsForFile( filename ):
+def Settings( **kwargs ):
   return { 'flags': [ 'clang-cl', '-xc++', '/c', '/I', 'driver_mode_cl_include' ],
            'include_paths_relative_to_dir': DIR_OF_THIS_SCRIPT }

--- a/ycmd/tests/clang/testdata/driver_mode_cl/flag/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/driver_mode_cl/flag/.ycm_extra_conf.py
@@ -2,6 +2,6 @@ import os
 
 DIR_OF_THIS_SCRIPT = os.path.dirname( os.path.abspath( __file__ ) )
 
-def FlagsForFile( filename ):
+def Settings( **kwargs ):
   return { 'flags': [ 'g++', '-xc++', '--driver-mode=cl', '/c', '/I', 'driver_mode_cl_include' ],
            'include_paths_relative_to_dir': DIR_OF_THIS_SCRIPT }

--- a/ycmd/tests/clang/testdata/general_fallback/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/general_fallback/.ycm_extra_conf.py
@@ -24,7 +24,7 @@ ftopts = {
   ],
 }
 
-def FlagsForFile(filename, **kwargs):
+def Settings(**kwargs):
   client_data = kwargs['client_data']
   ft = client_data['&filetype']
 

--- a/ycmd/tests/clang/testdata/noflags/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/noflags/.ycm_extra_conf.py
@@ -1,2 +1,2 @@
-def FlagsForFile( filename ):
+def Settings( **kwargs ):
   return { 'flags': [] }

--- a/ycmd/tests/clang/testdata/test-include/.ycm_extra_conf.py
+++ b/ycmd/tests/clang/testdata/test-include/.ycm_extra_conf.py
@@ -1,7 +1,7 @@
 import os.path
 
 
-def FlagsForFile( filename, **kwargs ):
-  d = os.path.dirname( filename )
+def Settings( **kwargs ):
+  d = os.path.dirname( kwargs[ 'filename' ] )
   return { 'flags': [ '-iquote', os.path.join( d, 'quote' ),
                       '-I', os.path.join( d, 'system' ) ] }

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -122,8 +122,7 @@ def RunTest( app, test, contents = None ):
 
   # Because we aren't testing this command, we *always* ignore errors. This
   # is mainly because we (may) want to test scenarios where the completer
-  # throws an exception and the easiest way to do that is to throw from
-  # within the FlagsForFile function.
+  # throws an exception.
   app.post_json( '/event_notification',
                  CombineRequest( test[ 'request' ], {
                                  'event_name': 'FileReadyToParse',

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -65,8 +65,7 @@ def RunTest( app, test, contents = None ):
 
   # Because we aren't testing this command, we *always* ignore errors. This
   # is mainly because we (may) want to test scenarios where the completer
-  # throws an exception and the easiest way to do that is to throw from
-  # within the FlagsForFile function.
+  # throws an exception.
   app.post_json( '/event_notification',
                  CombineRequest( test[ 'request' ], {
                                  'event_name': 'FileReadyToParse',


### PR DESCRIPTION
Migrate the Clang completer from `FlagsForFile` to `Settings` in the extra conf file. We still support `FlagsForFile` for backward compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1057)
<!-- Reviewable:end -->
