### PR TITLE
[READY] Use node only if tsserver is supposed to run through it

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -46,6 +46,7 @@ RESPONSE_TIMEOUT_SECONDS = 10
 
 # On Debian-based distributions, node is by default installed as nodejs.
 PATH_TO_NODE = utils.PathToFirstExistingExecutable( [ 'nodejs', 'node' ] )
+PATH_TO_TSSERVER = utils.FindExecutable( 'tsserver' )
 
 LOGFILE_FORMAT = 'tsserver_'
 
@@ -79,19 +80,14 @@ class DeferredResponse( object ):
       return self._message[ 'body' ]
 
 
-def FindTsserverBinary():
-  tsserver = utils.FindExecutable( 'tsserver' )
-  if not tsserver:
-    return None
-
-  if not utils.OnWindows():
-    return tsserver
-
-  # On Windows, tsserver is a batch script that calls the tsserver binary with
-  # node.
-  return os.path.abspath( os.path.join(
-    os.path.dirname( tsserver ), 'node_modules', 'typescript', 'bin',
-    'tsserver' ) )
+def TsserverCommand():
+  # Explicitly use node if the TSServer executable is supposed to be run through
+  # it. This handles the case where node is installed as nodejs.
+  with open( PATH_TO_TSSERVER ) as f:
+    first_line = f.readline()
+  if first_line.startswith( '#!/usr/bin/env node' ):
+    return [ PATH_TO_NODE, PATH_TO_TSSERVER ]
+  return [ PATH_TO_TSSERVER ]
 
 
 def ShouldEnableTypeScriptCompleter():
@@ -100,12 +96,11 @@ def ShouldEnableTypeScriptCompleter():
     return False
   _logger.info( 'Using node binary from {0}'.format( PATH_TO_NODE ) )
 
-  tsserver_binary_path = FindTsserverBinary()
-  if not tsserver_binary_path:
+  if not PATH_TO_TSSERVER:
     _logger.error( 'Not using TypeScript completer: unable to find TSServer.'
                    'TypeScript 1.5 or higher is required.' )
     return False
-  _logger.info( 'Using TSServer from {0}'.format( tsserver_binary_path ) )
+  _logger.info( 'Using TSServer from {0}'.format( PATH_TO_TSSERVER ) )
 
   return True
 
@@ -153,7 +148,7 @@ class TypeScriptCompleter( Completer ):
     self._logfile = None
 
     self._tsserver_lock = threading.RLock()
-    self._tsserver_binary_path = FindTsserverBinary()
+    self._tsserver_command = TsserverCommand()
     self._tsserver_handle = None
     self._tsserver_version = None
     # Used to read response only if TSServer is running.
@@ -213,8 +208,7 @@ class TypeScriptCompleter( Completer ):
       _logger.info( 'TSServer log file: {0}'.format( self._logfile ) )
 
       # We need to redirect the error stream to the output one on Windows.
-      self._tsserver_handle = utils.SafePopen( [ PATH_TO_NODE,
-                                                 self._tsserver_binary_path ],
+      self._tsserver_handle = utils.SafePopen( self._tsserver_command,
                                                stdin = subprocess.PIPE,
                                                stdout = subprocess.PIPE,
                                                stderr = subprocess.STDOUT,
@@ -841,12 +835,16 @@ class TypeScriptCompleter( Completer ):
       tsserver = responses.DebugInfoServer(
           name = 'TSServer',
           handle = self._tsserver_handle,
-          executable = self._tsserver_binary_path,
+          executable = PATH_TO_TSSERVER,
           logfiles = [ self._logfile ],
           extras = [ item_version ] )
 
+      node_executable = responses.DebugInfoItem( key = 'Node executable',
+                                                 value = PATH_TO_NODE )
+
       return responses.BuildDebugInfoResponse( name = 'TypeScript',
-                                               servers = [ tsserver ] )
+                                               servers = [ tsserver ],
+                                               items = [ node_executable ] )
 
 
 def _LogLevel():

--- a/ycmd/tests/typescript/debug_info_test.py
+++ b/ycmd/tests/typescript/debug_info_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017 ycmd contributors
+# Copyright (C) 2016-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -22,8 +22,8 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from hamcrest import ( any_of, assert_that, contains, empty, has_entries,
-                       has_entry, instance_of )
+from hamcrest import ( any_of, assert_that, contains, has_entries, has_entry,
+                       instance_of )
 
 from ycmd.tests.typescript import SharedYcmd
 from ycmd.tests.test_utils import BuildRequest
@@ -49,6 +49,11 @@ def DebugInfo_test( app ):
           'value': any_of( None, instance_of( str ) )
         } ) )
       } ) ),
-      'items': empty()
+      'items': contains(
+        has_entries( {
+          'key': 'Node executable',
+          'value': instance_of( str )
+        } )
+      )
     } ) )
   )

--- a/ycmd/tests/typescript/typescript_completer_test.py
+++ b/ycmd/tests/typescript/typescript_completer_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 ycmd contributors
+# Copyright (C) 2017-2018 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from mock import patch, DEFAULT
+from mock import patch
 from nose.tools import ok_
 
 from ycmd.completers.typescript.typescript_completer import (
@@ -38,7 +38,7 @@ def ShouldEnableTypeScriptCompleter_NodeNotFound_test( *args ):
   ok_( not ShouldEnableTypeScriptCompleter() )
 
 
-@patch( 'ycmd.utils.FindExecutable',
-        lambda exe: None if exe == 'tsserver' else DEFAULT )
+@patch( 'ycmd.completers.typescript.typescript_completer.PATH_TO_TSSERVER',
+        None )
 def ShouldEnableTypeScriptCompleter_TsserverNotFound_test( *args ):
   ok_( not ShouldEnableTypeScriptCompleter() )


### PR DESCRIPTION
TSServer is currently started through node to handle the case where node is installed as nodejs on Debian-based distributions. However, this doesn't work when the TSServer executable is a shim (e.g. when using [nodenv](https://github.com/nodenv/nodenv) or [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs)). See issue https://github.com/Valloric/ycmd/issues/1050. We fix that by only starting TSServer with node if it contains the line `#!/usr/bin/env node`.

Fixes #1050.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1058)
<!-- Reviewable:end -->
