### PR TITLE
[READY] Fix builds on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,19 +22,20 @@ aliases:
   # Increase the version key to clear the cache.
   save-cache: &save-cache
     save_cache:
-      key: v4-ycmd-{{ .Environment.CIRCLE_JOB }}
+      key: v5-ycmd-{{ .Environment.CIRCLE_JOB }}
       paths:
         - ~/Library/Caches/Homebrew
         - ~/Library/Caches/pip
         - ~/.npm
         - ~/.cargo
         - ~/.pyenv
+        - ~/mono
         - clang_archives
         - third_party/racerd/target
         - third_party/eclipse.jdt.ls/target/cache
   restore-cache: &restore-cache
     restore_cache:
-      key: v4-ycmd-{{ .Environment.CIRCLE_JOB }}
+      key: v5-ycmd-{{ .Environment.CIRCLE_JOB }}
 jobs:
   python2:
     <<: *common

--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -7,23 +7,24 @@ set -e
 # Homebrew setup
 ################
 
-# There's a homebrew bug which causes brew update to fail the first time. Run
+# There's a Homebrew bug which causes brew update to fail the first time. Run
 # it twice to workaround. https://github.com/Homebrew/homebrew/issues/42553
 brew update || brew update
 
-# List of homebrew formulae to install in the order they appear.
-# We require CMake, Node, Go, and Mono for our build and tests, and all
-# the others are dependencies of pyenv.
+# List of Homebrew formulae to install in the order they appear.
+# We require CMake, Node, and Go for our build and tests, and all
+# the others are dependencies of pyenv. Mono is not installed through Homebrew
+# because the latest version (5.12.0.226_1) fails to build the OmniSharp server
+# with CS7027 signing errors.
 REQUIREMENTS="cmake
               node.js
               go
-              mono
               readline
               autoconf
               pkg-config
               openssl"
 
-# Install CMake, Node, Go, Mono, pyenv and dependencies.
+# Install CMake, Node, Go, pyenv and dependencies.
 for pkg in $REQUIREMENTS; do
   # Install package, or upgrade it if it is already installed.
   brew install $pkg || brew outdated $pkg || brew upgrade $pkg
@@ -84,6 +85,18 @@ pip install -r test_requirements.txt
 # http://coverage.readthedocs.io/en/latest/subprocess.html
 echo -e "import coverage\ncoverage.process_startup()" > \
   ${PYENV_ROOT}/versions/${PYENV_VERSION}/lib/python${YCMD_PYTHON_VERSION}/site-packages/sitecustomize.py
+
+##########
+# C# setup
+##########
+
+MONO_PATH="${HOME}/mono"
+if [ ! -f "${MONO_PATH}/mono-5.12.0.pkg" ]; then
+  mkdir -p ${MONO_PATH}
+  curl https://download.mono-project.com/archive/5.12.0/macos-10-universal/MonoFramework-MDK-5.12.0.226.macos10.xamarin.universal.pkg -o ${MONO_PATH}/mono-5.12.0.pkg
+fi
+sudo installer -pkg ${MONO_PATH}/mono-5.12.0.pkg -target /
+echo "export PATH=/Library/Frameworks/Mono.framework/Versions/Current/Commands:\$PATH" >> $BASH_ENV
 
 ############
 # Rust setup


### PR DESCRIPTION
Building the OmniSharp server with the latest version of Mono from Homebrew (5.12.0.226_1) fails with the following errors:
```
"/Users/distiller/project/third_party/OmniSharpServer/OmniSharp.sln" (default target) (1) ->
"/Users/distiller/project/third_party/OmniSharpServer/OmniSharp/OmniSharp.csproj" (default target) (2) ->
"/Users/distiller/project/third_party/OmniSharpServer/NRefactory/ICSharpCode.NRefactory.Cecil/ICSharpCode.NRefactory.Cecil.csproj" (default target) (4:2) ->
"/Users/distiller/project/third_party/OmniSharpServer/NRefactory/ICSharpCode.NRefactory/ICSharpCode.NRefactory.csproj" (default target) (6:3) ->
(CoreCompile target) -> 
  CSC : error CS7027: Error signing output with public key from file '../ICSharpCode.NRefactory.snk' -- mscoree.dll [/Users/distiller/project/third_party/OmniSharpServer/NRefactory/ICSharpCode.NRefactory/ICSharpCode.NRefactory.csproj]



"/Users/distiller/project/third_party/OmniSharpServer/OmniSharp.sln" (default target) (1) ->
"/Users/distiller/project/third_party/OmniSharpServer/cecil/Mono.Cecil.csproj" (default target) (8:3) ->
  CSC : error CS7027: Error signing output with public key from file 'mono.snk' -- mscoree.dll [/Users/distiller/project/third_party/OmniSharpServer/cecil/Mono.Cecil.csproj]
```
Attempt to install Mono from the official website on CircleCI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1060)
<!-- Reviewable:end -->
