### PR TITLE
[RFC] Add option to disable the filepath completer

### DIFF
--- a/ycmd/completers/general/filename_completer.py
+++ b/ycmd/completers/general/filename_completer.py
@@ -79,7 +79,17 @@ class FilenameCompleter( Completer ):
       """ % { 'sep': '/\\\\' if OnWindows() else '/' }, re.X )
 
 
+  def CurrentFiletypeCompletionDisabled( self, request_data ):
+    disabled_filetypes = self.user_options[ 'filepath_blacklist' ]
+    filetypes = request_data[ 'filetypes' ]
+    return ( '*' in disabled_filetypes or
+             any( x in disabled_filetypes for x in filetypes ) )
+
+
   def ShouldUseNowInner( self, request_data ):
+    if self.CurrentFiletypeCompletionDisabled( request_data ):
+      return False
+
     current_line = request_data[ 'line_value' ]
     start_codepoint = request_data[ 'start_codepoint' ]
 

--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -34,6 +34,11 @@
     "infolog": 1,
     "mail": 1
   },
+  "filepath_blacklist": {
+    "html": 1,
+    "jsx": 1,
+    "xml": 1
+  },
   "auto_start_csharp_server": 1,
   "auto_stop_csharp_server": 1,
   "use_ultisnips_completer": 1,

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -66,6 +66,7 @@ def BuildRequest( **kwargs ):
   filepath = kwargs[ 'filepath' ] if 'filepath' in kwargs else '/foo'
   contents = kwargs[ 'contents' ] if 'contents' in kwargs else ''
   filetype = kwargs[ 'filetype' ] if 'filetype' in kwargs else 'foo'
+  filetypes = kwargs[ 'filetypes' ] if 'filetypes' in kwargs else [ filetype ]
 
   request = {
     'line_num': 1,
@@ -74,7 +75,7 @@ def BuildRequest( **kwargs ):
     'file_data': {
       filepath: {
         'contents': contents,
-        'filetypes': [ filetype ]
+        'filetypes': filetypes
       }
     }
   }


### PR DESCRIPTION
This PR adds the option `filepath_blacklist` to allow users to disable the filepath completer from triggering on the `/` character (and `\` on Windows) for a list of filetypes. This option works like [the `filetype_blacklist` option](https://github.com/Valloric/YouCompleteMe#the-gycm_filetype_blacklist-option) where keys are the filetypes for which the completer should be disabled and the values are unimportant. The special key `*` can be used to blacklist all filetypes. 

Contrarily to the `filetype_*` options, there is no `filepath_whitelist` counterpart as I don't really see the use case but nothing prevents us from adding it later.

The `html`, `jsx`, and `xml` filetypes are blacklisted by default as there are the ones mentioned in issues https://github.com/Valloric/YouCompleteMe/issues/708 and https://github.com/Valloric/YouCompleteMe/issues/3057. There are probably other filetypes that should be ignored by default but they can always be added later.

The next step is to give a way to manually trigger filepath completion through a mapping so that even if the `filepath_blacklist` option is set for a filetype, it's still possible to trigger filepath completion. See issue https://github.com/Valloric/YouCompleteMe/issues/986.

Closes https://github.com/Valloric/YouCompleteMe/issues/708.
Closes https://github.com/Valloric/YouCompleteMe/issues/3057.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1061)
<!-- Reviewable:end -->
