### PR TITLE
[READY] Avoid pointers in RawCodePoint struct

### DIFF
--- a/cpp/ycm/CodePoint.h
+++ b/cpp/ycm/CodePoint.h
@@ -18,6 +18,7 @@
 #ifndef CODE_POINT_H_3W0LNCLY
 #define CODE_POINT_H_3W0LNCLY
 
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -50,15 +51,34 @@ enum class BreakProperty : uint8_t {
 // This is the structure used to store the data in the Unicode table. See the
 // CodePoint class for a description of the members.
 struct RawCodePoint {
-  const char *original;
-  const char *normal;
-  const char *folded_case;
-  const char *swapped_case;
+  char original[ 5 ];
+  char normal[ 13 ];
+  char folded_case[ 13 ];
+  char swapped_case[ 13 ];
   bool is_letter;
   bool is_punctuation;
   bool is_uppercase;
   uint8_t break_property;
   uint8_t combining_class;
+  RawCodePoint( const char orig[ 5 ],
+                const char norm[ 13 ],
+                const char folded[ 13 ],
+                const char swapped[ 13 ],
+                bool letter,
+                bool punctuation,
+                bool uppercase,
+                uint8_t br_prop,
+                uint8_t combi_class )
+    : is_letter( letter ),
+      is_punctuation( punctuation ),
+      is_uppercase( uppercase ),
+      break_property( br_prop ),
+      combining_class( combi_class ) {
+    memcpy( original, orig, 5 );
+    memcpy( normal, norm, 13 );
+    memcpy( folded_case, folded, 13 );
+    memcpy( swapped_case, swapped, 13 );
+  }
 };
 
 

--- a/update_unicode.py
+++ b/update_unicode.py
@@ -42,9 +42,21 @@ DIR_OF_CPP_SOURCES = os.path.join( DIR_OF_THIS_SCRIPT, 'cpp', 'ycm' )
 UNICODE_TABLE_TEMPLATE = (
   """// This file was automatically generated with the update_unicode.py script
 // using version {unicode_version} of the Unicode Character Database.
-static const std::array< const RawCodePoint, {size} > code_points = {{ {{
-{code_points}
-}} }};""" )
+static const char code_points_original[][5] = {{
+{code_points_original}
+}};
+static const char code_points_normal[][13] = {{
+{code_points_normal}
+}};
+static const char code_points_folded_case[][13] = {{
+{code_points_folded_case}
+}};
+static const char code_points_swapped_case[][13] = {{
+{code_points_swapped_case}
+}};
+static const CodePointMisc code_points_misc[] = {{
+{code_points_misc}
+}};""" )
 UNICODE_VERSION_REGEX = re.compile( r'Version (?P<version>\d+(?:\.\d+){2})' )
 GRAPHEME_BREAK_PROPERTY_REGEX = re.compile(
   r'^(?P<value>[A-F0-9.]+)\s+; (?P<property>\w+) # .*$' )
@@ -488,21 +500,31 @@ def CppBool( statement ):
 
 def GenerateUnicodeTable( header_path, code_points ):
   unicode_version = GetUnicodeVersion()
-  size = len( code_points )
-  code_points = '\n'.join( [
-    ( '{' + CppChar( code_point[ 'original' ] ) + ',' +
-            CppChar( code_point[ 'normal' ] ) + ',' +
-            CppChar( code_point[ 'folded_case' ] ) + ',' +
-            CppChar( code_point[ 'swapped_case' ] ) + ',' +
-            CppBool( code_point[ 'is_letter' ] ) + ',' +
+  code_points_original = '\n'.join( [
+    ( '{' + CppChar( code_point[ 'original' ] ) + '},' )
+    for code_point in code_points ] )
+  code_points_normal = '\n'.join( [
+    ( '{' + CppChar( code_point[ 'normal' ] ) + '},' )
+    for code_point in code_points ] )
+  code_points_folded_case = '\n'.join( [
+    ( '{' + CppChar( code_point[ 'folded_case' ] ) + '},' )
+    for code_point in code_points ] )
+  code_points_swapped_case = '\n'.join( [
+    ( '{' + CppChar( code_point[ 'swapped_case' ] ) + '},' )
+    for code_point in code_points ] )
+  code_points_misc = '\n'.join( [
+    ( '{' + CppBool( code_point[ 'is_letter' ] ) + ',' +
             CppBool( code_point[ 'is_punctuation' ] ) + ',' +
             CppBool( code_point[ 'is_uppercase' ] ) + ',' +
             str( code_point[ 'break_property' ] ) + ',' +
             str( code_point[ 'combining_class' ] ) + '},' )
     for code_point in code_points ] )
   contents = UNICODE_TABLE_TEMPLATE.format( unicode_version = unicode_version,
-                                            size = size,
-                                            code_points = code_points )
+                                            code_points_original = code_points_original ,
+                                            code_points_normal = code_points_normal ,
+                                            code_points_folded_case = code_points_folded_case ,
+                                            code_points_swapped_case = code_points_swapped_case ,
+                                            code_points_misc = code_points_misc )
   with open( header_path, 'w', newline = '\n', encoding='utf8' ) as header_file:
     header_file.write( contents )
 


### PR DESCRIPTION
- Use fixed-size arrays in RawCodePoint structure.
  - This solves the problem of linux having 12MB of relocation data.
    However, this make MSVC hang.
- Split code_points into 5 arrays of which it used to be made.
  - This is one of the steps taken to prevent MSVC from hanging.
- Use C style array instead of std::array.
  - This is the other step that allowed MSVC to compile the code again.
- Add a constructor to RawCodePoint.
  - A convenience constructor.

Note that I wasn't able to measure any performance difference between this PR and the current master.

### Why avoid pointers?

They result in 12MB of relocation data being embedded into `ycm_core.so` on Linux. Considering that this PR only "shuffles" static data, the change in `ycm_core` size should directly correlate to the change in memory consupmtion.

### Effect on OSs?

- Linux loses 12MB of useless weight.
- Windows net loses ~800kB.
- macOS *gains* 385kB. (I'd call this a reasonable sacrifice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1064)
<!-- Reviewable:end -->
