### PR TITLE
[READY] Don't specialize std::hash<std::vector<std::string>>>

### DIFF
--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.cpp
@@ -31,7 +31,14 @@ namespace YouCompleteMe {
 namespace {
 
 std::size_t HashForFlags( const std::vector< std::string > &flags ) {
-  return std::hash< std::vector< std::string > >()( flags );
+  // The algorithm has been taken straight from a TR1:
+  // "Library Extension Technical Report - Issue List" section 6.18.
+  // This is also the way Boost implements it.
+  size_t seed = 0;
+  for ( const auto &flag : flags )  {
+    seed ^= std::hash< std::string >()( flag ) + ( seed << 6 ) + ( seed >> 2 );
+  }
+  return seed;
 }
 
 }  // unnamed namespace

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.h
@@ -29,22 +29,6 @@
 
 using CXIndex = void*;
 
-namespace std {
-
-template <> struct hash< vector< string > > {
-  // The algorithm has been taken straight from a TR1.
-  // This is also the way Boost implements it.
-  size_t operator()( const vector< string > &string_vector ) const {
-    size_t seed = 0;
-    for ( const auto &element : string_vector )  {
-       seed ^= hash< string >()( element ) + ( seed << 6 ) + ( seed >> 2 );
-    }
-    return seed;
-  }
-};
-
-} // std namespace
-
 namespace YouCompleteMe {
 
 class TranslationUnitStore {


### PR DESCRIPTION
Since specializations in `std` namespace are allowed only with used defined types, our specialization of `std::hash< std::vector< std::string > >` is undefined behaviour. The solution is to inline the hash function and thus avoid UB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1076)
<!-- Reviewable:end -->
