### PR TITLE
[READY] Replace Boost canonical function with our own implementation

### DIFF
--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -19,6 +19,7 @@
 #include "ClangHelpers.h"
 #include "CompletionData.h"
 #include "TranslationUnit.h"
+#include "Utils.h"
 
 #include <algorithm>
 #include <boost/filesystem.hpp>
@@ -521,16 +522,15 @@ std::vector< FixIt > TranslationUnit::GetFixItsForLocationInFile(
 
   std::vector< FixIt > fixits;
 
-  auto canonical_filename = boost::filesystem::canonical( filename );
+  auto normal_filename = NormalizePath( filename );
 
   {
     unique_lock< mutex > lock( diagnostics_mutex_ );
 
     for ( const Diagnostic& diagnostic : latest_diagnostics_ ) {
-      auto this_filename = boost::filesystem::canonical(
-        diagnostic.location_.filename_ );
+      auto this_filename = NormalizePath( diagnostic.location_.filename_ );
 
-      if ( canonical_filename != this_filename ) {
+      if ( normal_filename != this_filename ) {
         continue;
       }
 

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -191,8 +191,7 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
 
     std::string identifier( matches[ 1 ] );
     fs::path path( matches[ 2 ].str() );
-    path = fs::absolute( path, path_to_tag_file.parent_path() )
-           .make_preferred();
+    path = NormalizePath( path, path_to_tag_file.parent_path() );
 
     filetype_identifier_map[ filetype ][ path.string() ].push_back( identifier );
   }

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -56,6 +56,15 @@ YCM_EXPORT inline std::string Lowercase( const std::string &text ) {
 // an exception is thrown.
 std::string ReadUtf8File( const fs::path &filepath );
 
+
+// Normalizes a path by making it absolute relative to |base|, resolving
+// symbolic links, removing '.' and '..' in the path, and converting slashes
+// into backslashes on Windows. Contrarily to boost::filesystem::canonical, this
+// works even if the file doesn't exist.
+YCM_EXPORT fs::path NormalizePath( const fs::path &filepath,
+                                   const fs::path &base = fs::current_path() );
+
+
 template <class Container, class Key>
 typename Container::mapped_type &
 GetValueElseInsert( Container &container,

--- a/cpp/ycm/tests/TestUtils.cpp
+++ b/cpp/ycm/tests/TestUtils.cpp
@@ -17,9 +17,19 @@
 
 #include "TestUtils.h"
 
-namespace YouCompleteMe {
+namespace boost {
 
-namespace fs = boost::filesystem;
+namespace filesystem {
+
+void PrintTo( const fs::path &path, std::ostream *os ) {
+  *os << path;
+}
+
+} // namespace filesystem
+
+} // namespace boost
+
+namespace YouCompleteMe {
 
 std::ostream& operator<<( std::ostream& os, const CodePointTuple &code_point ) {
   os << "{ " << PrintToString( code_point.normal_ ) << ", "
@@ -85,7 +95,13 @@ std::ostream& operator<<( std::ostream& os, const WordTuple &word ) {
 }
 
 
-boost::filesystem::path PathToTestFile( const std::string &filepath ) {
+std::ostream& operator<<( std::ostream& os, const fs::path *path ) {
+  os << *path;
+  return os;
+}
+
+
+fs::path PathToTestFile( const std::string &filepath ) {
   fs::path path_to_testdata = fs::current_path() / fs::path( "testdata" );
   return path_to_testdata / fs::path( filepath );
 }

--- a/cpp/ycm/tests/TestUtils.h
+++ b/cpp/ycm/tests/TestUtils.h
@@ -29,6 +29,20 @@
 
 using ::testing::PrintToString;
 
+namespace fs = boost::filesystem;
+
+// A segmentation fault occurs when gtest tries to print a
+// boost::filesystem::path. Teach gtest how to print it.
+namespace boost {
+
+namespace filesystem {
+
+void PrintTo( const fs::path &path, std::ostream *os );
+
+}
+
+}
+
 namespace YouCompleteMe {
 
 // Tuple-like structures to help writing tests for CodePoint, Character, and
@@ -210,7 +224,7 @@ MATCHER_P( ContainsPointees, expected, PrintToString( expected ) ) {
 }
 
 
-boost::filesystem::path PathToTestFile( const std::string &filepath );
+fs::path PathToTestFile( const std::string &filepath );
 
 } // namespace YouCompleteMe
 

--- a/cpp/ycm/tests/Utils_test.cpp
+++ b/cpp/ycm/tests/Utils_test.cpp
@@ -15,12 +15,35 @@
 // You should have received a copy of the GNU General Public License
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <gtest/gtest.h>
+#include "TestUtils.h"
 #include "Utils.h"
+
+#include <gtest/gtest.h>
 
 namespace YouCompleteMe {
 
-TEST( UtilsTest, IsUppercase ) {
+class UtilsTest : public ::testing::Test {
+protected:
+  virtual void SetUp() {
+    // The returned temporary path is a symlink on macOS.
+    tmp_dir = fs::canonical( fs::temp_directory_path() ) / fs::unique_path();
+    existing_path = tmp_dir / "existing_path";
+    symlink = tmp_dir / "symlink";
+    fs::create_directories( existing_path );
+    fs::create_directory_symlink( existing_path, symlink );
+  }
+
+  virtual void TearDown() {
+    fs::remove_all( tmp_dir );
+  }
+
+  fs::path tmp_dir;
+  fs::path existing_path;
+  fs::path symlink;
+};
+
+
+TEST_F( UtilsTest, IsUppercase ) {
   EXPECT_TRUE( IsUppercase( 'A' ) );
   EXPECT_TRUE( IsUppercase( 'B' ) );
   EXPECT_TRUE( IsUppercase( 'Z' ) );
@@ -34,7 +57,7 @@ TEST( UtilsTest, IsUppercase ) {
   EXPECT_FALSE( IsUppercase( '~' ) );
 }
 
-TEST( UtilsTest, Lowercase ) {
+TEST_F( UtilsTest, Lowercase ) {
   EXPECT_EQ( Lowercase( 'a' ), 'a' );
   EXPECT_EQ( Lowercase( 'z' ), 'z' );
   EXPECT_EQ( Lowercase( 'A' ), 'a' );
@@ -43,5 +66,29 @@ TEST( UtilsTest, Lowercase ) {
 
   EXPECT_EQ( Lowercase( "lOwER_CasE" ), "lower_case" );
 }
+
+
+TEST_F( UtilsTest, NormalizePath ) {
+  EXPECT_THAT( NormalizePath( "" ),   Equals( fs::current_path() ) );
+  EXPECT_THAT( NormalizePath( "." ),  Equals( fs::current_path() ) );
+  EXPECT_THAT( NormalizePath( "./" ), Equals( fs::current_path() ) );
+  EXPECT_THAT( NormalizePath( existing_path ),       Equals( existing_path ) );
+  EXPECT_THAT( NormalizePath( "", existing_path ),   Equals( existing_path ) );
+  EXPECT_THAT( NormalizePath( ".", existing_path ),  Equals( existing_path ) );
+  EXPECT_THAT( NormalizePath( "./", existing_path ), Equals( existing_path ) );
+  EXPECT_THAT( NormalizePath( symlink ),             Equals( existing_path ) );
+  EXPECT_THAT( NormalizePath( "", symlink ),         Equals( existing_path ) );
+  EXPECT_THAT( NormalizePath( ".", symlink ),        Equals( existing_path ) );
+  EXPECT_THAT( NormalizePath( "./", symlink ),       Equals( existing_path ) );
+  EXPECT_THAT( NormalizePath( existing_path / "foo/../bar/./xyz//" ),
+               Equals( existing_path / "bar" / "xyz" ) );
+  EXPECT_THAT( NormalizePath( "foo/../bar/./xyz//", existing_path ),
+               Equals( existing_path / "bar" / "xyz" ) );
+  EXPECT_THAT( NormalizePath( symlink / "foo/../bar/./xyz//" ),
+               Equals( existing_path / "bar" / "xyz" ) );
+  EXPECT_THAT( NormalizePath( "foo/../bar/./xyz//", symlink ),
+               Equals( existing_path / "bar" / "xyz" ) );
+}
+
 
 } // namespace YouCompleteMe

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -659,7 +659,7 @@ def RunFixItTest( app, line, column, lang, file_path, check ):
   }
   args.update( language_options[ lang ] )
 
-  # Get the diagnostics for the file.
+  # Get the fixes for the file.
   event_data = BuildRequest( **args )
 
   results = app.post_json( '/run_completer_command', event_data ).json
@@ -1028,7 +1028,7 @@ def Subcommands_FixIt_Unity_test( app ):
     'filepath': PathToTestFile( '.ycm_extra_conf.py' ),
   } )
 
-  # Get the diagnostics for the file.
+  # Get the fixes for the file.
   event_data = BuildRequest( **args )
 
   results = app.post_json( '/run_completer_command', event_data ).json
@@ -1065,7 +1065,7 @@ def Subcommands_FixIt_UnityDifferentFile_test( app ):
     'filepath': PathToTestFile( '.ycm_extra_conf.py' ),
   } )
 
-  # Get the diagnostics for the file.
+  # Get the fixes for the file.
   event_data = BuildRequest( **args )
 
   results = app.post_json( '/run_completer_command', event_data ).json
@@ -1073,6 +1073,44 @@ def Subcommands_FixIt_UnityDifferentFile_test( app ):
   pprint( results )
   assert_that( results, has_entries( {
     'fixits': empty()
+  } ) )
+
+
+@SharedYcmd
+def Subcommands_FixIt_NonExistingFile_test( app ):
+  # This checks that FixIt is working for a non-existing file and that the path
+  # is properly normalized ('.' and '..' are removed from the path).
+  file_path = PathToTestFile( 'non_existing_dir', '..', '.', 'non_existing.cc' )
+  normal_file_path = PathToTestFile( 'non_existing.cc' )
+  args = {
+    'filetype'         : 'cpp',
+    'completer_target' : 'filetype_default',
+    'contents'         : 'int test',
+    'filepath'         : file_path,
+    'command_arguments': [ 'FixIt' ],
+    'line_num'         : 1,
+    'column_num'       : 1,
+  }
+  app.post_json( '/load_extra_conf_file', {
+    'filepath': PathToTestFile( '.ycm_extra_conf.py' ),
+  } )
+
+  # Get the fixes for the file.
+  event_data = BuildRequest( **args )
+
+  results = app.post_json( '/run_completer_command', event_data ).json
+
+  pprint( results )
+  assert_that( results, has_entries( {
+    'fixits': contains( has_entries( {
+      'text': contains_string( "expected ';' after top level declarator" ),
+      'chunks': contains(
+        ChunkMatcher( ';',
+                      LocationMatcher( normal_file_path, 1, 9 ),
+                      LocationMatcher( normal_file_path, 1, 9 ) ),
+      ),
+      'location': LocationMatcher( normal_file_path, 1, 9 ),
+    } ) )
   } ) )
 
 


### PR DESCRIPTION
The following error occurs when applying a FixIt in a C/C++ buffer that's not yet saved to disk:
```
RuntimeError: boost::filesystem::canonical: No such file or directory
```
This happens because `boost::filesystem::canonical` raises an exception if the file does not exist. We need our own implementation that works on non-existing files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1080)
<!-- Reviewable:end -->
