### PR TITLE
GetType on C++ member functions should return their type.

### DIFF
--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -327,6 +327,13 @@ std::string TranslationUnit::GetTypeAtLocation(
     return "Internal error: cursor not valid";
   }
 
+  if (clang_getCursorKind(cursor) == CXCursor_MemberRefExpr) {
+    CXCursor ref = clang_getCursorReferenced(cursor);
+    if (clang_getCursorKind(ref) == CXCursor_CXXMethod) {
+      cursor = ref;
+    }
+  }
+
   CXType type = clang_getCursorType( cursor );
 
   std::string type_description =

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -327,9 +327,14 @@ std::string TranslationUnit::GetTypeAtLocation(
     return "Internal error: cursor not valid";
   }
 
-  if (clang_getCursorKind(cursor) == CXCursor_MemberRefExpr) {
-    CXCursor ref = clang_getCursorReferenced(cursor);
-    if (clang_getCursorKind(ref) == CXCursor_CXXMethod) {
+  // Cursors on member functions return a rather unhelpful type text of
+  // "bound member function type".  To get a meaningful type, we must examine
+  // the referenced cursor.  We must be careful though, as both member variables
+  // and member functions are of kind MemberRefExpr, and getting the referenced
+  // cursor of a cv-qualified type discards the cv-qualification.
+  if ( clang_getCursorKind( cursor ) == CXCursor_MemberRefExpr ) {
+    CXCursor ref = clang_getCursorReferenced( cursor );
+    if ( clang_getCursorKind( ref ) == CXCursor_CXXMethod ) {
       cursor = ref;
     }
   }

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -447,7 +447,7 @@ def RunGetSemanticTest( app, filepath, filetype, test, command ):
 def Subcommands_GetType_test():
   tests = [
     # Basic pod types
-    [ { 'line_num': 20, 'column_num':  3 }, 'Foo' ],
+    [ { 'line_num': 24, 'column_num':  3 }, 'Foo' ],
     [ { 'line_num':  1, 'column_num':  1 }, 'Internal error: '
                                             'cursor not valid' ],
     [ { 'line_num': 12, 'column_num':  2 }, 'Foo' ],
@@ -459,64 +459,68 @@ def Subcommands_GetType_test():
     [ { 'line_num': 15, 'column_num':  7 }, 'char' ],
 
     # Function
-    [ { 'line_num': 18, 'column_num':  2 }, 'int ()' ],
-    [ { 'line_num': 18, 'column_num':  6 }, 'int ()' ],
+    [ { 'line_num': 22, 'column_num':  2 }, 'int ()' ],
+    [ { 'line_num': 22, 'column_num':  6 }, 'int ()' ],
 
     # Declared and canonical type
     # On Ns:: (Unknown)
-    [ { 'line_num': 21, 'column_num':  3 }, 'Unknown type' ], # sic
+    [ { 'line_num': 25, 'column_num':  3 }, 'Unknown type' ], # sic
     # On Type (Type)
-    [ { 'line_num': 21, 'column_num':  8 }, 'Ns::Type => Ns::BasicType<char>' ],
+    [ { 'line_num': 25, 'column_num':  8 }, 'Ns::Type => Ns::BasicType<char>' ],
     # On "a" (Ns::Type)
-    [ { 'line_num': 21, 'column_num': 15 }, 'Ns::Type => Ns::BasicType<char>' ],
-    [ { 'line_num': 22, 'column_num': 13 }, 'Ns::Type => Ns::BasicType<char>' ],
+    [ { 'line_num': 25, 'column_num': 15 }, 'Ns::Type => Ns::BasicType<char>' ],
+    [ { 'line_num': 26, 'column_num': 13 }, 'Ns::Type => Ns::BasicType<char>' ],
 
     # Cursor on decl for refs & pointers
-    [ { 'line_num': 35, 'column_num':  3 }, 'Foo' ],
-    [ { 'line_num': 35, 'column_num': 11 }, 'Foo &' ],
-    [ { 'line_num': 35, 'column_num': 15 }, 'Foo' ],
-    [ { 'line_num': 36, 'column_num':  3 }, 'Foo' ],
-    [ { 'line_num': 36, 'column_num': 11 }, 'Foo *' ],
-    [ { 'line_num': 36, 'column_num': 18 }, 'Foo' ],
-    [ { 'line_num': 38, 'column_num':  3 }, 'const Foo &' ],
-    [ { 'line_num': 38, 'column_num': 16 }, 'const Foo &' ],
-    [ { 'line_num': 39, 'column_num':  3 }, 'const Foo *' ],
-    [ { 'line_num': 39, 'column_num': 16 }, 'const Foo *' ],
+    [ { 'line_num': 39, 'column_num':  3 }, 'Foo' ],
+    [ { 'line_num': 39, 'column_num': 11 }, 'Foo &' ],
+    [ { 'line_num': 39, 'column_num': 15 }, 'Foo' ],
+    [ { 'line_num': 40, 'column_num':  3 }, 'Foo' ],
+    [ { 'line_num': 40, 'column_num': 11 }, 'Foo *' ],
+    [ { 'line_num': 40, 'column_num': 18 }, 'Foo' ],
+    [ { 'line_num': 42, 'column_num':  3 }, 'const Foo &' ],
+    [ { 'line_num': 42, 'column_num': 16 }, 'const Foo &' ],
+    [ { 'line_num': 43, 'column_num':  3 }, 'const Foo *' ],
+    [ { 'line_num': 43, 'column_num': 16 }, 'const Foo *' ],
 
     # Cursor on usage
-    [ { 'line_num': 41, 'column_num': 13 }, 'const Foo' ],
-    [ { 'line_num': 41, 'column_num': 19 }, 'const int' ],
-    [ { 'line_num': 42, 'column_num': 13 }, 'const Foo *' ],
-    [ { 'line_num': 42, 'column_num': 20 }, 'const int' ],
-    [ { 'line_num': 43, 'column_num': 12 }, 'Foo' ],
-    [ { 'line_num': 43, 'column_num': 17 }, 'int' ],
-    [ { 'line_num': 44, 'column_num': 12 }, 'Foo *' ],
-    [ { 'line_num': 44, 'column_num': 18 }, 'int' ],
+    [ { 'line_num': 45, 'column_num': 13 }, 'const Foo' ],
+    [ { 'line_num': 45, 'column_num': 19 }, 'const int' ],
+    [ { 'line_num': 46, 'column_num': 13 }, 'const Foo *' ],
+    [ { 'line_num': 46, 'column_num': 20 }, 'const int' ],
+    [ { 'line_num': 47, 'column_num': 12 }, 'Foo' ],
+    [ { 'line_num': 47, 'column_num': 17 }, 'int' ],
+    [ { 'line_num': 48, 'column_num': 12 }, 'Foo *' ],
+    [ { 'line_num': 48, 'column_num': 18 }, 'int' ],
 
     # Auto in declaration
-    [ { 'line_num': 24, 'column_num':  3 }, 'Foo &' ],
-    [ { 'line_num': 24, 'column_num': 11 }, 'Foo &' ],
-    [ { 'line_num': 24, 'column_num': 18 }, 'Foo' ],
-    [ { 'line_num': 25, 'column_num':  3 }, 'Foo *' ],
-    [ { 'line_num': 25, 'column_num': 11 }, 'Foo *' ],
-    [ { 'line_num': 25, 'column_num': 18 }, 'Foo' ],
-    [ { 'line_num': 27, 'column_num':  3 }, 'const Foo &' ],
-    [ { 'line_num': 27, 'column_num': 16 }, 'const Foo &' ],
-    [ { 'line_num': 28, 'column_num':  3 }, 'const Foo *' ],
-    [ { 'line_num': 28, 'column_num': 16 }, 'const Foo *' ],
+    [ { 'line_num': 28, 'column_num':  3 }, 'Foo &' ],
+    [ { 'line_num': 28, 'column_num': 11 }, 'Foo &' ],
+    [ { 'line_num': 28, 'column_num': 18 }, 'Foo' ],
+    [ { 'line_num': 29, 'column_num':  3 }, 'Foo *' ],
+    [ { 'line_num': 29, 'column_num': 11 }, 'Foo *' ],
+    [ { 'line_num': 29, 'column_num': 18 }, 'Foo' ],
+    [ { 'line_num': 31, 'column_num':  3 }, 'const Foo &' ],
+    [ { 'line_num': 31, 'column_num': 16 }, 'const Foo &' ],
+    [ { 'line_num': 32, 'column_num':  3 }, 'const Foo *' ],
+    [ { 'line_num': 32, 'column_num': 16 }, 'const Foo *' ],
 
     # Auto in usage
-    [ { 'line_num': 30, 'column_num': 14 }, 'const Foo' ],
-    [ { 'line_num': 30, 'column_num': 21 }, 'const int' ],
-    [ { 'line_num': 31, 'column_num': 14 }, 'const Foo *' ],
-    [ { 'line_num': 31, 'column_num': 22 }, 'const int' ],
-    [ { 'line_num': 32, 'column_num': 13 }, 'Foo' ],
-    [ { 'line_num': 32, 'column_num': 19 }, 'int' ],
-    [ { 'line_num': 33, 'column_num': 13 }, 'Foo *' ],
-    [ { 'line_num': 33, 'column_num': 20 }, 'int' ],
+    [ { 'line_num': 34, 'column_num': 14 }, 'const Foo' ],
+    [ { 'line_num': 34, 'column_num': 21 }, 'const int' ],
+    [ { 'line_num': 35, 'column_num': 14 }, 'const Foo *' ],
+    [ { 'line_num': 35, 'column_num': 22 }, 'const int' ],
+    [ { 'line_num': 36, 'column_num': 13 }, 'Foo' ],
+    [ { 'line_num': 36, 'column_num': 19 }, 'int' ],
+    [ { 'line_num': 37, 'column_num': 13 }, 'Foo *' ],
+    [ { 'line_num': 37, 'column_num': 20 }, 'int' ],
 
     # Unicode
-    [ { 'line_num': 47, 'column_num': 13 }, 'Unicøde *' ],
+    [ { 'line_num': 51, 'column_num': 13 }, 'Unicøde *' ],
+
+    # Bound methods
+    [ { 'line_num': 53, 'column_num': 15 }, 'int (int)' ],
+    [ { 'line_num': 54, 'column_num': 18 }, 'int (int)' ],
   ]
 
   for test in tests:

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -26,7 +26,7 @@ from builtins import *  # noqa
 
 from hamcrest import ( assert_that, calling, contains, contains_string,
                        empty, equal_to, has_entry, has_entries, raises,
-                       is_, any_of )
+                       matches_regexp )
 from nose.tools import eq_
 from pprint import pprint
 from webtest import AppError
@@ -442,8 +442,7 @@ def RunGetSemanticTest( app, filepath, filetype, test, command ):
 
   response = app.post_json( '/run_completer_command', request_data ).json
   pprint( response )
-  assert_that( response, has_entry( 'message', is_(expected) ) )
-  eq_( list( response.keys() ), [ 'message' ] )
+  assert_that( response, has_entry( 'message', expected ) )
 
 
 def Subcommands_GetType_test():
@@ -524,12 +523,10 @@ def Subcommands_GetType_test():
     # On Win32, methods pick up an __attribute__((thiscall)) to annotate their
     # calling convention.  This shows up in the type, which isn't ideal, but
     # also prohibitively complex to try and strip out.
-    [ { 'line_num': 53, 'column_num': 15 }, any_of(
-        equal_to( 'int (int)' ),
-        equal_to( 'int (int) __attribute__((thiscall))' ) ) ],
-    [ { 'line_num': 54, 'column_num': 18 }, any_of(
-        equal_to( 'int (int)' ),
-        equal_to( 'int (int) __attribute__((thiscall))' ) ) ],
+    [ { 'line_num': 53, 'column_num': 15 },
+      matches_regexp( r'int \(int\)(?: __attribute__\(\(thiscall\)\))?' ) ],
+    [ { 'line_num': 54, 'column_num': 18 },
+      matches_regexp( r'int \(int\)(?: __attribute__\(\(thiscall\)\))?' ) ],
   ]
 
   for test in tests:

--- a/ycmd/tests/clang/testdata/GetType_Clang_test.cc
+++ b/ycmd/tests/clang/testdata/GetType_Clang_test.cc
@@ -13,6 +13,10 @@ struct Foo {
   int x;
   int y;
   char c;
+
+  int bar(int i) {
+    return i+1;
+  }
 };
 
 int main()
@@ -45,6 +49,9 @@ int main()
 
   struct Unicøde;
   Unicøde *ø;
+
+  int i = foo.bar(1);
+  int j = apFoo->bar(1);
 
   return 0;
 }


### PR DESCRIPTION
Previously, GetType on a C++ member function would always show the text
"bound member function type".  This is because a cursor on an instance
method is of kind MemberRefExpr, which itself is a reference to a
declaration of a function that has a type.  Undoing that layer of
referencing will return a useful result.

We need to be careful though, as member variables also show up as
MemberRefExpr, and undoing the layer of ref on them will remove
cv-qualification.  Checking explicitly if the cursor is pointing to a
CXXMethod seems to work fine, but honestly the clang API seems a little
weird in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1081)
<!-- Reviewable:end -->
