### PR TITLE
[READY] Ignore extra conf files outside tests directory

### DIFF
--- a/ycmd/tests/__init__.py
+++ b/ycmd/tests/__init__.py
@@ -27,8 +27,7 @@ import os
 
 from ycmd.tests.test_utils import ( ClearCompletionsCache,
                                     IsolatedApp,
-                                    SetUpApp,
-                                    YCMD_EXTRA_CONF )
+                                    SetUpApp )
 
 shared_app = None
 
@@ -84,8 +83,6 @@ def IsolatedYcmd( custom_options = {} ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
       with IsolatedApp( custom_options ) as app:
-        app.post_json( '/ignore_extra_conf_file',
-                       { 'filepath': YCMD_EXTRA_CONF } )
         test( app, *args, **kwargs )
     return Wrapper
   return Decorator

--- a/ycmd/tests/clang/__init__.py
+++ b/ycmd/tests/clang/__init__.py
@@ -31,8 +31,7 @@ import json
 from ycmd.utils import ToUnicode
 from ycmd.tests.test_utils import ( ClearCompletionsCache,
                                     IsolatedApp,
-                                    SetUpApp,
-                                    YCMD_EXTRA_CONF )
+                                    SetUpApp )
 
 shared_app = None
 
@@ -88,8 +87,6 @@ def IsolatedYcmd( custom_options = {} ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
       with IsolatedApp( custom_options ) as app:
-        app.post_json( '/ignore_extra_conf_file',
-                       { 'filepath': YCMD_EXTRA_CONF } )
         test( app, *args, **kwargs )
     return Wrapper
   return Decorator

--- a/ycmd/tests/cs/__init__.py
+++ b/ycmd/tests/cs/__init__.py
@@ -27,12 +27,12 @@ import functools
 import os
 
 from ycmd.tests.test_utils import ( ClearCompletionsCache,
+                                    IgnoreExtraConfOutsideTestsFolder,
                                     IsolatedApp,
                                     SetUpApp,
                                     StartCompleterServer,
                                     StopCompleterServer,
-                                    WaitUntilCompleterServerReady,
-                                    YCMD_EXTRA_CONF )
+                                    WaitUntilCompleterServerReady )
 
 shared_app = None
 shared_filepaths = []
@@ -51,10 +51,6 @@ def setUpPackage():
   global shared_app
 
   shared_app = SetUpApp()
-  shared_app.post_json( '/ignore_extra_conf_file',
-                        { 'filepath': YCMD_EXTRA_CONF } )
-  shared_app.post_json( '/ignore_extra_conf_file',
-                        { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
 
 
 def tearDownPackage():
@@ -87,7 +83,8 @@ def SharedYcmd( test ):
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
     ClearCompletionsCache()
-    return test( shared_app, *args, **kwargs )
+    with IgnoreExtraConfOutsideTestsFolder():
+      return test( shared_app, *args, **kwargs )
   return Wrapper
 
 
@@ -113,10 +110,6 @@ def IsolatedYcmd( custom_options = {} ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
       with IsolatedApp( custom_options ) as app:
-        app.post_json( '/ignore_extra_conf_file',
-                       { 'filepath': YCMD_EXTRA_CONF } )
-        app.post_json( '/ignore_extra_conf_file',
-                       { 'filepath': PathToTestFile( '.ycm_extra_conf.py' ) } )
         test( app, *args, **kwargs )
     return Wrapper
   return Decorator

--- a/ycmd/tests/python/__init__.py
+++ b/ycmd/tests/python/__init__.py
@@ -26,9 +26,9 @@ import functools
 import os
 
 from ycmd.tests.test_utils import ( ClearCompletionsCache,
+                                    IgnoreExtraConfOutsideTestsFolder,
                                     IsolatedApp,
-                                    SetUpApp,
-                                    YCMD_EXTRA_CONF )
+                                    SetUpApp )
 
 shared_app = None
 
@@ -46,8 +46,6 @@ def setUpPackage():
   global shared_app
 
   shared_app = SetUpApp()
-  shared_app.post_json( '/ignore_extra_conf_file',
-                        { 'filepath': YCMD_EXTRA_CONF } )
 
 
 def SharedYcmd( test ):
@@ -60,7 +58,8 @@ def SharedYcmd( test ):
   @functools.wraps( test )
   def Wrapper( *args, **kwargs ):
     ClearCompletionsCache()
-    return test( shared_app, *args, **kwargs )
+    with IgnoreExtraConfOutsideTestsFolder():
+      return test( shared_app, *args, **kwargs )
   return Wrapper
 
 
@@ -86,8 +85,6 @@ def IsolatedYcmd( custom_options = {} ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
       with IsolatedApp( custom_options ) as app:
-        app.post_json( '/ignore_extra_conf_file',
-                       { 'filepath': YCMD_EXTRA_CONF } )
         test( app, *args, **kwargs )
     return Wrapper
   return Decorator

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -338,13 +338,17 @@ def CloseStandardStreams( handle ):
       stream.close()
 
 
+def IsRootDirectory( path, parent ):
+  return path == parent
+
+
 def PathsToAllParentFolders( path ):
   folder = os.path.normpath( path )
   if os.path.isdir( folder ):
     yield folder
   while True:
     parent = os.path.dirname( folder )
-    if parent == folder:
+    if IsRootDirectory( folder, parent ):
       break
     folder = parent
     yield folder


### PR DESCRIPTION
Some tests fail if a `.ycm_extra_conf.py` file is found outside the ycmd directory (e.g. YCM's `.ycm_extra_conf.py` file). We prevent that by mocking the `PathsToAllParentFolder` function so that it considers the `tests` folder as the root directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1087)
<!-- Reviewable:end -->
