### PR TITLE
[READY] Raise proper exception for commands when file is still being parsed in Clang completer

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -41,8 +41,8 @@ from ycmd.completers.cpp.include_cache import IncludeCache, IncludeList
 from ycmd.responses import NoExtraConfDetected, UnknownExtraConf
 
 CLANG_FILETYPES = { 'c', 'cpp', 'cuda', 'objc', 'objcpp' }
-PARSING_FILE_MESSAGE = 'Still parsing file, no completions yet.'
-NO_COMPILE_FLAGS_MESSAGE = 'Still no compile flags, no completions yet.'
+PARSING_FILE_MESSAGE = 'Still parsing file.'
+NO_COMPILE_FLAGS_MESSAGE = 'Still no compile flags.'
 NO_COMPLETIONS_MESSAGE = 'No completions found; errors in the file?'
 NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 PRAGMA_DIAG_TEXT_TO_IGNORE = '#pragma once in main file'
@@ -197,6 +197,10 @@ class ClangCompleter( Completer ):
     if not flags:
       raise ValueError( NO_COMPILE_FLAGS_MESSAGE )
 
+    if self._completer.UpdatingTranslationUnit(
+        ToCppStringCompatible( filename ) ):
+      raise RuntimeError( PARSING_FILE_MESSAGE )
+
     files = self.GetUnsavedFilesVector( request_data )
     line = request_data[ 'line_num' ]
     column = request_data[ 'column_num' ]
@@ -295,6 +299,10 @@ class ClangCompleter( Completer ):
     if not flags:
       raise ValueError( NO_COMPILE_FLAGS_MESSAGE )
 
+    if self._completer.UpdatingTranslationUnit(
+        ToCppStringCompatible( filename ) ):
+      raise RuntimeError( PARSING_FILE_MESSAGE )
+
     files = self.GetUnsavedFilesVector( request_data )
     line = request_data[ 'line_num' ]
     column = request_data[ 'column_num' ]
@@ -322,6 +330,10 @@ class ClangCompleter( Completer ):
     flags, filename = self._FlagsForRequest( request_data )
     if not flags:
       raise ValueError( NO_COMPILE_FLAGS_MESSAGE )
+
+    if self._completer.UpdatingTranslationUnit(
+        ToCppStringCompatible( filename ) ):
+      raise RuntimeError( PARSING_FILE_MESSAGE )
 
     files = self.GetUnsavedFilesVector( request_data )
     line = request_data[ 'line_num' ]

--- a/ycmd/tests/clang/__init__.py
+++ b/ycmd/tests/clang/__init__.py
@@ -126,3 +126,31 @@ def TemporaryClangProject( tmp_dir, compile_commands ):
     yield
   finally:
     os.remove( path )
+
+
+# A mock of ycm_core.ClangCompleter with translation units still being parsed.
+class MockCoreClangCompleter( object ):
+
+  def GetDefinitionLocation( self, *args ):
+    pass
+
+  def GetDeclarationLocation( self, *args ):
+    pass
+
+  def GetDefinitionOrDeclarationLocation( self, *args ):
+    pass
+
+  def GetTypeAtLocation( self, *args ):
+    pass
+
+  def GetEnclosingFunctionAtLocation( self, *args ):
+    pass
+
+  def GetDocsForLocationInFile( self, *args ):
+    pass
+
+  def GetFixItsForLocationInFile( self, *args ):
+    pass
+
+  def UpdatingTranslationUnit( self, filename ):
+    return True

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -27,14 +27,19 @@ from builtins import *  # noqa
 from hamcrest import ( assert_that, calling, contains, contains_string,
                        empty, equal_to, has_entry, has_entries, raises,
                        matches_regexp )
+from mock import patch
 from nose.tools import eq_
 from pprint import pprint
 from webtest import AppError
 import requests
 import os.path
 
-from ycmd.completers.cpp.clang_completer import NO_DOCUMENTATION_MESSAGE
-from ycmd.tests.clang import PathToTestFile, SharedYcmd
+from ycmd import handlers
+from ycmd.completers.cpp.clang_completer import ( NO_DOCUMENTATION_MESSAGE,
+                                                  PARSING_FILE_MESSAGE )
+from ycmd.tests.clang import ( MockCoreClangCompleter,
+                               PathToTestFile,
+                               SharedYcmd )
 from ycmd.tests.test_utils import ( BuildRequest,
                                     ErrorMatcher,
                                     ChunkMatcher,
@@ -1529,3 +1534,42 @@ Type: void ()
 Name: kernel
 ---
 This is a test kernel""" } )
+
+
+@SharedYcmd
+def Subcommands_StillParsingError( app, command ):
+  filepath = PathToTestFile( 'test.cpp' )
+
+  data = BuildRequest( command_arguments = [ command ],
+                       compilation_flags = [ '-x', 'c++' ],
+                       line_num = 1,
+                       column_num = 1,
+                       filepath = filepath,
+                       contents = '',
+                       filetype = 'cpp' )
+
+  response = app.post_json( '/run_completer_command',
+                            data,
+                            expect_errors = True )
+
+  eq_( response.status_code, requests.codes.internal_server_error )
+
+  pprint( response.json )
+
+  assert_that( response.json, ErrorMatcher( RuntimeError,
+                                            PARSING_FILE_MESSAGE ) )
+
+
+def Subcommands_StillParsingError_test():
+  completer = handlers._server_state.GetFiletypeCompleter( [ 'cpp' ] )
+  with patch.object( completer, '_completer', MockCoreClangCompleter() ):
+    yield Subcommands_StillParsingError, 'FixIt'
+    yield Subcommands_StillParsingError, 'GetDoc'
+    yield Subcommands_StillParsingError, 'GetDocImprecise'
+    yield Subcommands_StillParsingError, 'GetParent'
+    yield Subcommands_StillParsingError, 'GetType'
+    yield Subcommands_StillParsingError, 'GetTypeImprecise'
+    yield Subcommands_StillParsingError, 'GoTo'
+    yield Subcommands_StillParsingError, 'GoToDeclaration'
+    yield Subcommands_StillParsingError, 'GoToDefinition'
+    yield Subcommands_StillParsingError, 'GoToImprecise'


### PR DESCRIPTION
Same as PR https://github.com/Valloric/ycmd/pull/966 but extended to all commands (not only the `GoTo*` ones) and with tests. Error messages are updated since they are not specific to completion.

Closes https://github.com/Valloric/ycmd/pull/966.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1088)
<!-- Reviewable:end -->
