### PR TITLE
[READY] Allow completion of the core library in Python code

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -125,8 +125,20 @@ def FindCorrespondingSourceFile( filename ):
   return filename
 
 
+def PathToPythonUsedDuringBuild():
+  try:
+    filepath = os.path.join( DIR_OF_THIS_SCRIPT, 'PYTHON_USED_DURING_BUILDING' )
+    with open( filepath ) as f:
+      return f.read().strip()
+  # We need to check for IOError for Python 2 and OSError for Python 3.
+  except ( IOError, OSError ):
+    return None
+
+
 def Settings( **kwargs ):
-  if kwargs[ 'language' ] == 'cfamily':
+  language = kwargs[ 'language' ]
+
+  if language == 'cfamily':
     # If the file is a header, try to find the corresponding source file and
     # retrieve its flags from the compilation database if using one. This is
     # necessary since compilation databases don't have entries for header files.
@@ -163,6 +175,12 @@ def Settings( **kwargs ):
       'include_paths_relative_to_dir': compilation_info.compiler_working_dir_,
       'override_filename': filename
     }
+
+  if language == 'python':
+    return {
+      'interpreter_path': PathToPythonUsedDuringBuild()
+    }
+
   return {}
 
 
@@ -175,6 +193,9 @@ def GetStandardLibraryIndexInSysPath( sys_path ):
 
 def PythonSysPath( **kwargs ):
   sys_path = kwargs[ 'sys_path' ]
+
+  sys_path.insert( 0, DIR_OF_THIS_SCRIPT )
+
   for folder in os.listdir( DIR_OF_THIRD_PARTY ):
     if folder == 'python-future':
       folder = os.path.join( folder, 'src' )


### PR DESCRIPTION
This PR improves ycmd's extra conf by adding the root directory to `sys.path` and by setting the interpreter path to the value stored in the `PYTHON_USED_DURING_BUILDING` file (if it exists). These two changes allow completion of the `ycm_core` module in the Python code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1101)
<!-- Reviewable:end -->
