### PR TITLE
[READY] Simplify GoToInclude

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -116,6 +116,28 @@ ClangCompleter::CandidatesForLocationInFile(
 }
 
 
+Location ClangCompleter::GetIncludedFileLocation(
+  const std::string &translation_unit,
+  const std::string &filename,
+  int line,
+  int column,
+  const std::vector< UnsavedFile > &unsaved_files,
+  const std::vector< std::string > &flags,
+  bool reparse ) {
+  pybind11::gil_scoped_release unlock;
+  shared_ptr< TranslationUnit > unit =
+    translation_unit_store_.GetOrCreate( translation_unit,
+                                         unsaved_files,
+                                         flags );
+
+  return unit->GetIncludedFileLocation( filename,
+                                        line,
+                                        column,
+                                        unsaved_files,
+                                        reparse );
+}
+
+
 Location ClangCompleter::GetDeclarationLocation(
   const std::string &translation_unit,
   const std::string &filename,

--- a/cpp/ycm/ClangCompleter/ClangCompleter.h
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.h
@@ -59,6 +59,15 @@ public:
     const std::vector< UnsavedFile > &unsaved_files,
     const std::vector< std::string > &flags );
 
+  YCM_EXPORT Location GetIncludedFileLocation(
+    const std::string &translation_unit,
+    const std::string &filename,
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    const std::vector< std::string > &flags,
+    bool reparse = true );
+
   YCM_EXPORT Location GetDeclarationLocation(
     const std::string &translation_unit,
     const std::string &filename,

--- a/cpp/ycm/ClangCompleter/TranslationUnit.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.h
@@ -64,6 +64,13 @@ public:
     int column,
     const std::vector< UnsavedFile > &unsaved_files );
 
+  YCM_EXPORT Location GetIncludedFileLocation(
+    const std::string &filename,
+    int line,
+    int column,
+    const std::vector< UnsavedFile > &unsaved_files,
+    bool reparse = true );
+
   YCM_EXPORT Location GetDeclarationLocation(
     const std::string &filename,
     int line,

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -111,6 +111,7 @@ PYBIND11_MODULE( ycm_core, mod )
     .def( "GetDefinitionLocation", &ClangCompleter::GetDefinitionLocation )
     .def( "GetDefinitionOrDeclarationLocation",
           &ClangCompleter::GetDefinitionOrDeclarationLocation )
+    .def( "GetIncludedFileLocation", &ClangCompleter::GetIncludedFileLocation )
     .def( "DeleteCachesForFile", &ClangCompleter::DeleteCachesForFile )
     .def( "UpdatingTranslationUnit", &ClangCompleter::UpdatingTranslationUnit )
     .def( "UpdateTranslationUnit", &ClangCompleter::UpdateTranslationUnit )

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -51,6 +51,12 @@ NO_DOCUMENTATION_MESSAGE = 'No documentation available for current context'
 INCLUDE_REGEX = re.compile( '(\s*#\s*(?:include|import)\s*)(?:"[^"]*|<[^>]*)' )
 
 
+def _IsIncludeStatement( request_data ):
+  line = request_data[ 'line_value' ]
+  return ( re.search( '^\s*#\s*include\s*<.*>', line ) or
+           re.search( '^\s*#\s*include\s*".*"', line ) )
+
+
 class ClangCompleter( Completer ):
   def __init__( self, user_options ):
     super( ClangCompleter, self ).__init__( user_options )
@@ -229,9 +235,12 @@ class ClangCompleter( Completer ):
 
 
   def _GoTo( self, request_data ):
-    include_response = self._ResponseForInclude( request_data )
-    if include_response:
-      return include_response
+    if _IsIncludeStatement( request_data ):
+      location = self._LocationForGoTo( 'GetIncludedFileLocation', request_data )
+      if not ( location and location.IsValid() ):
+        raise RuntimeError( 'Include file not found' )
+      else:
+        return _ResponseForLocation( location )
 
     location = self._LocationForGoTo( 'GetDefinitionOrDeclarationLocation',
                                       request_data )
@@ -241,9 +250,14 @@ class ClangCompleter( Completer ):
 
 
   def _GoToImprecise( self, request_data ):
-    include_response = self._ResponseForInclude( request_data )
-    if include_response:
-      return include_response
+    if _IsIncludeStatement( request_data ):
+      location = self._LocationForGoTo( 'GetIncludedFileLocation',
+                                        request_data,
+                                        reparse = False )
+      if not ( location and location.IsValid() ):
+        raise RuntimeError( 'Include file not found.' )
+      else:
+        return _ResponseForLocation( location )
 
     location = self._LocationForGoTo( 'GetDefinitionOrDeclarationLocation',
                                       request_data,
@@ -253,40 +267,13 @@ class ClangCompleter( Completer ):
     return _ResponseForLocation( location )
 
 
-  def _ResponseForInclude( self, request_data ):
-    """Returns response for include file location if cursor is on the
-    include statement, None otherwise.
-    Throws RuntimeError if cursor is on include statement and corresponding
-    include file not found."""
-    current_line = request_data[ 'line_value' ]
-    include_file_name, quoted_include = GetFullIncludeValue( current_line )
-    if not include_file_name:
-      return None
-
-    flags, current_file_path = self._FlagsForRequest( request_data )
-    quoted_include_paths, include_paths = UserIncludePaths( flags,
-                                                            current_file_path )
-    if quoted_include:
-      include_file_path = _GetAbsolutePath( include_file_name,
-                                            quoted_include_paths )
-      if include_file_path:
-        return responses.BuildGoToResponse( include_file_path,
-                                            line_num = 1,
-                                            column_num = 1 )
-
-    include_file_path = _GetAbsolutePath( include_file_name, include_paths )
-    if include_file_path:
-      return responses.BuildGoToResponse( include_file_path,
-                                          line_num = 1,
-                                          column_num = 1 )
-    raise RuntimeError( 'Include file not found.' )
-
-
   def _GoToInclude( self, request_data ):
-    include_response = self._ResponseForInclude( request_data )
-    if not include_response:
+    if not _IsIncludeStatement( request_data ):
       raise RuntimeError( 'Not an include/import line.' )
-    return include_response
+    location = self._LocationForGoTo( 'GetIncludedFileLocation', request_data )
+    if not location or not location.IsValid():
+      raise RuntimeError( 'Include file not found.' )
+    return _ResponseForLocation( location )
 
 
   def _GetSemanticInfo(

--- a/ycmd/tests/clang/subcommands_test.py
+++ b/ycmd/tests/clang/subcommands_test.py
@@ -349,6 +349,8 @@ def Subcommands_GoToInclude_test():
     { 'request': [ 1, 1 ], 'response': 'a.hpp' },
     { 'request': [ 2, 1 ], 'response': os.path.join( 'system', 'a.hpp' ) },
     { 'request': [ 3, 1 ], 'response': os.path.join( 'quote',  'b.hpp' ) },
+    # Should be an error, but libclang finds the b.hpp in local directory
+    { 'request': [ 4, 1 ], 'response': os.path.join( 'quote',  'b.hpp' ) },
     { 'request': [ 5, 1 ], 'response': os.path.join( 'system', 'c.hpp' ) },
     { 'request': [ 6, 1 ], 'response': os.path.join( 'system', 'c.hpp' ) },
   ]
@@ -359,7 +361,7 @@ def Subcommands_GoToInclude_test():
 
 
 def Subcommands_GoToInclude_Fail_test():
-  test = { 'request': [ 4, 1 ], 'response': '' }
+  test = { 'request': [ 12, 1 ], 'response': '' }
   assert_that(
     calling( RunGoToIncludeTest ).with_args( 'GoToInclude', test ),
     raises( AppError, 'Include file not found.' ) )

--- a/ycmd/tests/clang/testdata/test-include/main.cpp
+++ b/ycmd/tests/clang/testdata/test-include/main.cpp
@@ -9,3 +9,4 @@
 #include "dir with spaces/d.hpp"
 #include <system/
 #include :"
+#include <d.hpp>


### PR DESCRIPTION
Uses `clang_getIncludedFile` instead of our own implementation.

The only difference compared to the current implementation is that when there's a `foo.h` in local directory, but the file has been included with `<foo.h>`, goto with reparse jumps to the local file.

This might also allow https://github.com/Valloric/YouCompleteMe/issues/2647 to work, but since I have no macOS (and am not sure what's going on with frameworks) I couldn't test it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1102)
<!-- Reviewable:end -->
