### PR TITLE
GetHoverResponse should handle null response from server.

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -41,6 +41,8 @@ _logger = logging.getLogger( __name__ )
 
 SERVER_LOG_PREFIX = 'Server reported: '
 
+NO_HOVER_INFORMATION = 'No hover information.'
+
 # All timeout values are in seconds
 REQUEST_TIMEOUT_COMPLETION = 5
 REQUEST_TIMEOUT_INITIALISE = 30
@@ -1304,7 +1306,10 @@ class LanguageServerCompleter( Completer ):
       lsp.Hover( request_id, request_data ),
       REQUEST_TIMEOUT_COMMAND )
 
-    return response[ 'result' ][ 'contents' ]
+    result = response[ 'result' ]
+    if result:
+      return result[ 'contents' ]
+    raise RuntimeError( NO_HOVER_INFORMATION )
 
 
   def GoToDeclaration( self, request_data ):


### PR DESCRIPTION
As mentioned in [Hover Request](https://microsoft.github.io/language-server-protocol/specification#textDocument_hover)
```
Response:

result: Hover | null
```
Current implementation was failing with None object has no _getitem_ method, with this patch it will provide more useful information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1110)
<!-- Reviewable:end -->
