### PR TITLE
[READY] Fix TSServer 3.1.1 test failures

### DIFF
--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -24,7 +24,11 @@ from __future__ import division
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from hamcrest import ( assert_that, contains, contains_inanyorder, has_entries,
+from hamcrest import ( assert_that,
+                       contains,
+                       contains_inanyorder,
+                       contains_string,
+                       has_entries,
                        matches_regexp )
 from nose.tools import eq_
 import requests
@@ -35,6 +39,7 @@ from ycmd.tests.test_utils import ( BuildRequest,
                                     ChunkMatcher,
                                     CombineRequest,
                                     ErrorMatcher,
+                                    ExpectedFailure,
                                     LocationMatcher,
                                     MessageMatcher )
 from ycmd.utils import ReadFile
@@ -568,6 +573,9 @@ def Subcommands_RefactorRename_Missing_test( app ):
   } )
 
 
+@ExpectedFailure( 'TSServer 3.1.1 regression',
+                  contains_string( "Cannot read property "
+                                   "'start' of undefined" ) )
 @SharedYcmd
 def Subcommands_RefactorRename_NotPossible_test( app ):
   RunTest( app, {

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -24,8 +24,13 @@ from __future__ import division
 # Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
-from hamcrest import ( assert_that, contains, contains_inanyorder, has_entries,
-                       has_entry, matches_regexp )
+from hamcrest import ( assert_that,
+                       contains,
+                       contains_inanyorder,
+                       contains_string,
+                       has_entries,
+                       has_entry,
+                       matches_regexp )
 from mock import patch
 from nose.tools import eq_
 import requests
@@ -36,6 +41,7 @@ from ycmd.tests.test_utils import ( BuildRequest,
                                     ChunkMatcher,
                                     CombineRequest,
                                     ErrorMatcher,
+                                    ExpectedFailure,
                                     LocationMatcher,
                                     MessageMatcher,
                                     MockProcessTerminationTimingOut,
@@ -392,7 +398,7 @@ def Subcommands_GetType_HasNoType_test( app ):
     'description': 'GetType returns an error on a keyword',
     'request': {
       'command': 'GetType',
-      'line_num': 2,
+      'line_num': 32,
       'column_num': 1,
       'filepath': PathToTestFile( 'test.ts' ),
     },
@@ -748,6 +754,9 @@ def Subcommands_RefactorRename_Missing_test( app ):
   } )
 
 
+@ExpectedFailure( 'TSServer 3.1.1 regression',
+                  contains_string( "Cannot read property "
+                                   "'start' of undefined" ) )
 @SharedYcmd
 def Subcommands_RefactorRename_NotPossible_test( app ):
   RunTest( app, {


### PR DESCRIPTION
- TSServer 3.1.1 GetType does error on keyword, except `class`.
- https://github.com/Microsoft/TypeScript/issues/27373

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1112)
<!-- Reviewable:end -->
