### PR TITLE
Add necessary client capability support for new completion item kinds

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1495,6 +1495,12 @@ class LanguageServerCompleter( Completer ):
 
 
 def _CompletionItemToCompletionData( insertion_text, item, fixits ):
+  # Since we send completionItemKind capabilities, we guarantee to handle
+  # values outside our value set and fall back to a default.
+  try:
+    kind = lsp.ITEM_KIND[ item.get( 'kind', 0 ) ]
+  except IndexError:
+    kind = lsp.ITEM_KIND[ 0 ] # Fallback to None for unsupported kinds.
   return responses.BuildCompletionData(
     insertion_text,
     extra_menu_info = item.get( 'detail', None ),
@@ -1502,7 +1508,7 @@ def _CompletionItemToCompletionData( insertion_text, item, fixits ):
                       '\n\n' +
                       item.get( 'documentation', '' ) ),
     menu_text = item[ 'label' ],
-    kind = lsp.ITEM_KIND[ item.get( 'kind', 0 ) ],
+    kind = kind,
     extra_data = fixits )
 
 

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -203,8 +203,14 @@ def Initialize( request_id, project_directory ):
       # We don't currently support any server-specific options.
     },
     'capabilities': {
-      # We don't currently support any of the client capabilities, so we don't
-      # include anything in here.
+      'textDocument': {
+        'completion': {
+          'completionItemKind': {
+            # ITEM_KIND list is 1-based.
+            'valueSet': list( range( 1, len( ITEM_KIND ) + 1 ) ),
+          }
+        }
+      }
     },
   } )
 


### PR DESCRIPTION
Implemented necessary capability support for new completion item kinds as mentioned in the [Initialize Params/ClientCapabilities/TextDocumentClientCapabilities/completionItemKind](https://microsoft.github.io/language-server-protocol/specification#initialize)
```typescript
                        /**
			 * The completion item kind values the client supports. When this
			 * property exists the client also guarantees that it will
			 * handle values outside its set gracefully and falls back
			 * to a default value when unknown.
			 *
			 * If this property is not present the client only supports
			 * the completion items kinds from `Text` to `Reference` as defined in
			 * the initial version of the protocol.
			 */
```

After the change java tests were getting stuck and timing out. Updating version of jdt.ls resolves that issue but found out that there were some regressions as mentioned in Valloric/ycmd#1109. So need to wait until it is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1113)
<!-- Reviewable:end -->
