### PR TITLE
[READY] Move GIL release to bindings

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -26,7 +26,6 @@
 
 #include <clang-c/Index.h>
 #include <memory>
-#include <pybind11/pybind11.h>
 
 
 using std::shared_ptr;
@@ -57,7 +56,6 @@ ClangCompleter::~ClangCompleter() {
 
 
 bool ClangCompleter::UpdatingTranslationUnit( const std::string &filename ) {
-  pybind11::gil_scoped_release unlock;
   shared_ptr< TranslationUnit > unit = translation_unit_store_.Get( filename );
 
   if ( !unit ) {
@@ -75,7 +73,6 @@ std::vector< Diagnostic > ClangCompleter::UpdateTranslationUnit(
   const std::string &translation_unit,
   const std::vector< UnsavedFile > &unsaved_files,
   const std::vector< std::string > &flags ) {
-  pybind11::gil_scoped_release unlock;
   bool translation_unit_created;
   shared_ptr< TranslationUnit > unit = translation_unit_store_.GetOrCreate(
                                          translation_unit,
@@ -103,7 +100,6 @@ ClangCompleter::CandidatesForLocationInFile(
   int column,
   const std::vector< UnsavedFile > &unsaved_files,
   const std::vector< std::string > &flags ) {
-  pybind11::gil_scoped_release unlock;
   shared_ptr< TranslationUnit > unit =
     translation_unit_store_.GetOrCreate( translation_unit,
                                          unsaved_files,
@@ -124,7 +120,6 @@ Location ClangCompleter::GetDeclarationLocation(
   const std::vector< UnsavedFile > &unsaved_files,
   const std::vector< std::string > &flags,
   bool reparse ) {
-  pybind11::gil_scoped_release unlock;
   shared_ptr< TranslationUnit > unit =
     translation_unit_store_.GetOrCreate( translation_unit,
                                          unsaved_files,
@@ -146,7 +141,6 @@ Location ClangCompleter::GetDefinitionLocation(
   const std::vector< UnsavedFile > &unsaved_files,
   const std::vector< std::string > &flags,
   bool reparse ) {
-  pybind11::gil_scoped_release unlock;
   shared_ptr< TranslationUnit > unit =
     translation_unit_store_.GetOrCreate( translation_unit,
                                          unsaved_files,
@@ -167,7 +161,6 @@ Location ClangCompleter::GetDefinitionOrDeclarationLocation(
   const std::vector< UnsavedFile > &unsaved_files,
   const std::vector< std::string > &flags,
   bool reparse ) {
-  pybind11::gil_scoped_release unlock;
   shared_ptr< TranslationUnit > unit =
     translation_unit_store_.GetOrCreate( translation_unit,
                                          unsaved_files,
@@ -189,7 +182,6 @@ std::string ClangCompleter::GetTypeAtLocation(
   const std::vector< std::string > &flags,
   bool reparse ) {
 
-  pybind11::gil_scoped_release unlock;
   shared_ptr< TranslationUnit > unit =
     translation_unit_store_.GetOrCreate( translation_unit,
                                          unsaved_files,
@@ -211,7 +203,6 @@ std::string ClangCompleter::GetEnclosingFunctionAtLocation(
   const std::vector< std::string > &flags,
   bool reparse ) {
 
-  pybind11::gil_scoped_release unlock;
   shared_ptr< TranslationUnit > unit =
     translation_unit_store_.GetOrCreate( translation_unit,
                                          unsaved_files,
@@ -234,7 +225,6 @@ ClangCompleter::GetFixItsForLocationInFile(
   const std::vector< std::string > &flags,
   bool reparse ) {
 
-  pybind11::gil_scoped_release unlock;
 
   shared_ptr< TranslationUnit > unit =
     translation_unit_store_.GetOrCreate( translation_unit,
@@ -258,7 +248,6 @@ DocumentationData ClangCompleter::GetDocsForLocationInFile(
   const std::vector< std::string > &flags,
   bool reparse ) {
 
-  pybind11::gil_scoped_release unlock;
 
   shared_ptr< TranslationUnit > unit =
     translation_unit_store_.GetOrCreate( translation_unit,
@@ -288,7 +277,6 @@ DocumentationData ClangCompleter::GetDocsForLocationInFile(
 }
 
 void ClangCompleter::DeleteCachesForFile( const std::string &filename ) {
-  pybind11::gil_scoped_release unlock;
   translation_unit_store_.Remove( filename );
 }
 

--- a/cpp/ycm/IdentifierCompleter.cpp
+++ b/cpp/ycm/IdentifierCompleter.cpp
@@ -22,8 +22,6 @@
 #include "Result.h"
 #include "Utils.h"
 
-#include <pybind11/pybind11.h>
-
 namespace YouCompleteMe {
 
 
@@ -45,7 +43,6 @@ void IdentifierCompleter::AddIdentifiersToDatabase(
   const std::vector< std::string > &new_candidates,
   const std::string &filetype,
   const std::string &filepath ) {
-  pybind11::gil_scoped_release unlock;
   identifier_database_.AddIdentifiers( new_candidates,
                                        filetype,
                                        filepath );
@@ -63,7 +60,6 @@ void IdentifierCompleter::ClearForFileAndAddIdentifiersToDatabase(
 
 void IdentifierCompleter::AddIdentifiersToDatabaseFromTagFiles(
   const std::vector< std::string > &absolute_paths_to_tag_files ) {
-  pybind11::gil_scoped_release unlock;
   for( const std::string & path : absolute_paths_to_tag_files ) {
     identifier_database_.AddIdentifiers(
       ExtractIdentifiersFromTagsFile( path ) );
@@ -82,7 +78,6 @@ std::vector< std::string > IdentifierCompleter::CandidatesForQueryAndType(
   const std::string &query,
   const std::string &filetype,
   const size_t max_candidates ) const {
-  pybind11::gil_scoped_release unlock;
 
   std::vector< Result > results;
   identifier_database_.ResultsForQueryAndType( query,

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -75,13 +75,17 @@ PYBIND11_MODULE( ycm_core, mod )
   py::class_< IdentifierCompleter >( mod, "IdentifierCompleter" )
     .def( py::init<>() )
     .def( "AddIdentifiersToDatabase",
-          &IdentifierCompleter::AddIdentifiersToDatabase )
+          &IdentifierCompleter::AddIdentifiersToDatabase,
+          py::call_guard< py::gil_scoped_release >() )
     .def( "ClearForFileAndAddIdentifiersToDatabase",
-          &IdentifierCompleter::ClearForFileAndAddIdentifiersToDatabase )
+          &IdentifierCompleter::ClearForFileAndAddIdentifiersToDatabase,
+          py::call_guard< py::gil_scoped_release >() )
     .def( "AddIdentifiersToDatabaseFromTagFiles",
-          &IdentifierCompleter::AddIdentifiersToDatabaseFromTagFiles )
+          &IdentifierCompleter::AddIdentifiersToDatabaseFromTagFiles,
+          py::call_guard< py::gil_scoped_release >() )
     .def( "CandidatesForQueryAndType",
           &IdentifierCompleter::CandidatesForQueryAndType,
+          py::call_guard< py::gil_scoped_release >(),
           py::arg( "query" ),
           py::arg( "filetype" ),
           py::arg( "max_candidates" ) = 0 );
@@ -107,22 +111,39 @@ PYBIND11_MODULE( ycm_core, mod )
 
   py::class_< ClangCompleter >( mod, "ClangCompleter" )
     .def( py::init<>() )
-    .def( "GetDeclarationLocation", &ClangCompleter::GetDeclarationLocation )
-    .def( "GetDefinitionLocation", &ClangCompleter::GetDefinitionLocation )
+    .def( "GetDeclarationLocation",
+          &ClangCompleter::GetDeclarationLocation,
+          py::call_guard< py::gil_scoped_release >() )
+    .def( "GetDefinitionLocation",
+          &ClangCompleter::GetDefinitionLocation,
+          py::call_guard< py::gil_scoped_release >() )
     .def( "GetDefinitionOrDeclarationLocation",
-          &ClangCompleter::GetDefinitionOrDeclarationLocation )
-    .def( "DeleteCachesForFile", &ClangCompleter::DeleteCachesForFile )
-    .def( "UpdatingTranslationUnit", &ClangCompleter::UpdatingTranslationUnit )
-    .def( "UpdateTranslationUnit", &ClangCompleter::UpdateTranslationUnit )
+          &ClangCompleter::GetDefinitionOrDeclarationLocation,
+          py::call_guard< py::gil_scoped_release >() )
+    .def( "DeleteCachesForFile",
+          &ClangCompleter::DeleteCachesForFile,
+          py::call_guard< py::gil_scoped_release >() )
+    .def( "UpdatingTranslationUnit",
+          &ClangCompleter::UpdatingTranslationUnit,
+          py::call_guard< py::gil_scoped_release >() )
+    .def( "UpdateTranslationUnit",
+          &ClangCompleter::UpdateTranslationUnit,
+          py::call_guard< py::gil_scoped_release >() )
     .def( "CandidatesForLocationInFile",
-          &ClangCompleter::CandidatesForLocationInFile )
-    .def( "GetTypeAtLocation", &ClangCompleter::GetTypeAtLocation )
+          &ClangCompleter::CandidatesForLocationInFile,
+          py::call_guard< py::gil_scoped_release >() )
+    .def( "GetTypeAtLocation",
+          &ClangCompleter::GetTypeAtLocation,
+          py::call_guard< py::gil_scoped_release >() )
     .def( "GetEnclosingFunctionAtLocation",
-          &ClangCompleter::GetEnclosingFunctionAtLocation )
+          &ClangCompleter::GetEnclosingFunctionAtLocation,
+          py::call_guard< py::gil_scoped_release >() )
     .def( "GetFixItsForLocationInFile",
-          &ClangCompleter::GetFixItsForLocationInFile )
+          &ClangCompleter::GetFixItsForLocationInFile,
+          py::call_guard< py::gil_scoped_release >() )
     .def( "GetDocsForLocationInFile",
-          &ClangCompleter::GetDocsForLocationInFile );
+          &ClangCompleter::GetDocsForLocationInFile,
+          py::call_guard< py::gil_scoped_release >() );
 
   py::enum_< CompletionKind >( mod, "CompletionKind" )
     .value( "STRUCT", CompletionKind::STRUCT )


### PR DESCRIPTION
- No #include <pybind11/pybind11.h> in `ClangCompleter.cpp` and `IdentifierCompleter.cpp`.
- Releases GIL just before function call, instead of just after.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1115)
<!-- Reviewable:end -->
