### PR TITLE
[READY] Fix UriToFilePath.

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1015,7 +1015,12 @@ class LanguageServerCompleter( Completer ):
       # diagnostics and return them in OnFileReadyToParse. We also need these
       # for correct FixIt handling, as they are part of the FixIt context.
       params = notification[ 'params' ]
-      uri = params[ 'uri' ]
+      # Since percent-encoded strings are not cannonical, they can choose to use
+      # upper case or lower case letters, also there are some characters that
+      # can be encoded or not. Therefore, we convert them back and forth
+      # according to our implementation to make sure they are in a cannonical
+      # form for access later on.
+      uri = lsp.FilePathToUri( lsp.UriToFilePath( params[ 'uri' ] ) )
       with self._server_info_mutex:
         self._latest_diagnostics[ uri ] = params[ 'diagnostics' ]
 

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -30,7 +30,9 @@ from ycmd.utils import ( ByteOffsetToCodepointOffset,
                          pathname2url,
                          ToBytes,
                          ToUnicode,
+                         unquote,
                          url2pathname,
+                         urlparse,
                          urljoin )
 
 
@@ -408,10 +410,18 @@ def FilePathToUri( file_name ):
 
 
 def UriToFilePath( uri ):
-  if uri[ : 5 ] != "file:":
+  parsed_uri = urlparse( uri )
+  if parsed_uri.scheme != 'file':
     raise InvalidUriException( uri )
 
-  return os.path.abspath( url2pathname( uri[ 5 : ] ) )
+  # url2pathname doesn't work as expected when uri.path is percent-encoded and
+  # is a windows path for ex:
+  # url2pathname('/C%3a/') == 'C:\\C:'
+  # whereas
+  # url2pathname('/C:/') == 'C:\\'
+  # Therefore first unquote pathname.
+  pathname = unquote( parsed_uri.path )
+  return os.path.abspath( url2pathname( pathname ) )
 
 
 def _BuildMessageData( message ):

--- a/ycmd/tests/java/diagnostics_test.py
+++ b/ycmd/tests/java/diagnostics_test.py
@@ -461,46 +461,6 @@ public class Test {
 
 
 @IsolatedYcmd
-@patch(
-  'ycmd.completers.language_server.language_server_protocol.UriToFilePath',
-  side_effect = lsp.InvalidUriException )
-def FileReadyToParse_Diagnostics_InvalidURI_test( app, uri_to_filepath, *args ):
-  StartJavaCompleterServerInDirectory( app,
-                                       PathToTestFile( DEFAULT_PROJECT_DIR ) )
-
-  filepath = TestFactory
-  contents = ReadFile( filepath )
-
-  # It can take a while for the diagnostics to be ready
-  expiration = time.time() + 10
-  while True:
-    try:
-      results = _WaitForDiagnosticsToBeReady( app, filepath, contents )
-      print( 'Completer response: {0}'.format(
-        json.dumps( results, indent=2 ) ) )
-
-      uri_to_filepath.assert_called()
-
-      assert_that( results, has_item(
-        has_entries( {
-          'kind': 'WARNING',
-          'text': 'The value of the field TestFactory.Bar.testString is not '
-                  'used',
-          'location': LocationMatcher( '', 15, 19 ),
-          'location_extent': RangeMatcher( '', ( 15, 19 ), ( 15, 29 ) ),
-          'ranges': contains( RangeMatcher( '', ( 15, 19 ), ( 15, 29 ) ) ),
-          'fixit_available': False
-        } ),
-      ) )
-
-      return
-    except AssertionError:
-      if time.time() > expiration:
-        raise
-      time.sleep( 0.25 )
-
-
-@IsolatedYcmd
 def FileReadyToParse_ServerNotReady_test( app ):
   filepath = TestFactory
   contents = ReadFile( filepath )

--- a/ycmd/tests/language_server/language_server_protocol_test.py
+++ b/ycmd/tests/language_server/language_server_protocol_test.py
@@ -168,7 +168,15 @@ def UriToFilePath_Windows_test():
 
   assert_that( lsp.UriToFilePath( 'file:c:/usr/local/test/test.test' ),
                equal_to( 'C:\\usr\\local\\test\\test.test' ) )
-  assert_that( lsp.UriToFilePath( 'file://c:/usr/local/test/test.test' ),
+  assert_that( lsp.UriToFilePath( 'file:c%3a/usr/local/test/test.test' ),
+               equal_to( 'C:\\usr\\local\\test\\test.test' ) )
+  assert_that( lsp.UriToFilePath( 'file:c%3A/usr/local/test/test.test' ),
+               equal_to( 'C:\\usr\\local\\test\\test.test' ) )
+  assert_that( lsp.UriToFilePath( 'file:///c:/usr/local/test/test.test' ),
+               equal_to( 'C:\\usr\\local\\test\\test.test' ) )
+  assert_that( lsp.UriToFilePath( 'file:///c%3a/usr/local/test/test.test' ),
+               equal_to( 'C:\\usr\\local\\test\\test.test' ) )
+  assert_that( lsp.UriToFilePath( 'file:///c%3A/usr/local/test/test.test' ),
                equal_to( 'C:\\usr\\local\\test\\test.test' ) )
 
 

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -44,10 +44,10 @@ import threading
 #   from ycmd.utils import pathname2url, url2pathname, urljoin, urlparse
 #
 if PY2:
-  from urlparse import urljoin, urlparse
-  from urllib import pathname2url, url2pathname
+  from urlparse import urljoin, urlparse, unquote
+  from urllib import pathname2url, url2pathname, quote
 else:
-  from urllib.parse import urljoin, urlparse  # noqa
+  from urllib.parse import urljoin, urlparse, unquote, quote  # noqa
   from urllib.request import pathname2url, url2pathname  # noqa
 
 


### PR DESCRIPTION
As specified in the [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
```
Of the ASCII character set, the characters : / ? # [ ] @ are reserved for use as delimiters of the generic URI components and must be percent-encoded
```

But turns out, implementation in url2pathname doesn't respect that. This patch fixes its behaviour in lsp. Which was the reason all tests related with a filepath(allmost every test) in windows for clangd was failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1119)
<!-- Reviewable:end -->
