### PR TITLE
[READY] Install fixed version of TypeScript in third-party folder

### DIFF
--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -112,12 +112,6 @@ cargo -V
 
 echo "export PATH=${CARGO_PATH}:\$PATH" >> $BASH_ENV
 
-##################
-# TypeScript setup
-##################
-
-npm install -g typescript
-
 #################
 # Java 8 setup
 #################

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ docs/package-lock.json
 
 # jdt.ls
 third_party/eclipse.jdt.ls
+
+# TSServer
+third_party/tsserver

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ sudo apt install build-essential cmake python3-dev
 
 Next, install the language specific dependencies you need:
 - `sudo apt install golang-go` for Go.
-- `sudo apt install npm` and `sudo npm -g install typescript` for JavaScript and
-  TypeScript.
+- `sudo apt install npm` for JavaScript and TypeScript.
 - `sudo apt install mono-devel` for C#.
 - install Cargo and rustc with [rustup][] for Rust.
 - `sudo apt install openjdk-8-jre` for Java.

--- a/build.py
+++ b/build.py
@@ -85,6 +85,8 @@ JDTLS_SHA256 = (
   '37c02deb37335668321643571e7316a231d94d07707325afdb83b16c953f2244'
 )
 
+TSSERVER_VERSION = '3.1.3'
+
 BUILD_ERROR_MESSAGE = (
   'ERROR: the build failed.\n\n'
   'NOTE: it is *highly* unlikely that this is a bug but rather\n'
@@ -326,6 +328,9 @@ def ParseArguments():
                        help = 'Enable Rust semantic completion engine.' )
   parser.add_argument( '--java-completer', action = 'store_true',
                        help = 'Enable Java semantic completion engine.' ),
+  parser.add_argument( '--ts-completer', action = 'store_true',
+                       help = 'Enable JavaScript and TypeScript semantic '
+                              'completion engine.' ),
   parser.add_argument( '--system-boost', action = 'store_true',
                        help = 'Use the system boost instead of bundled one. '
                        'NOT RECOMMENDED OR SUPPORTED!' )
@@ -642,7 +647,6 @@ def EnableRustCompleter( args ):
 
 
 def EnableJavaScriptCompleter( args ):
-  node = FindExecutableOrDie( 'node', 'node is required to set up Tern.' )
   npm = FindExecutableOrDie( 'npm', 'npm is required to set up Tern.' )
 
   # We install Tern into a runtime directory. This allows us to control
@@ -729,6 +733,16 @@ def EnableJavaCompleter( switches ):
     print( 'OK' )
 
 
+def EnableTypeScriptCompleter( args ):
+  npm = FindExecutableOrDie( 'npm', 'npm is required to install TSServer.' )
+  tsserver_folder = p.join( DIR_OF_THIRD_PARTY, 'tsserver' )
+  CheckCall( [ npm, 'install', '-g', '--prefix', tsserver_folder,
+               'typescript@{version}'.format( version = TSSERVER_VERSION ) ],
+             quiet = args.quiet,
+             status_message = 'Installing TSServer for JavaScript '
+                              'and TypeScript completion' )
+
+
 def WritePythonUsedDuringBuild():
   path = p.join( DIR_OF_THIS_SCRIPT, 'PYTHON_USED_DURING_BUILDING' )
   with open( path, 'w' ) as f:
@@ -755,6 +769,8 @@ def Main():
     EnableRustCompleter( args )
   if args.java_completer or args.all_completers:
     EnableJavaCompleter( args )
+  if args.ts_completer or args.all_completers:
+    EnableTypeScriptCompleter( args )
 
 
 if __name__ == '__main__':

--- a/ci/appveyor/appveyor_install.bat
+++ b/ci/appveyor/appveyor_install.bat
@@ -39,15 +39,6 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 python -c "with open('%python_path%\Lib\site-packages\sitecustomize.py', 'w') as f: f.write('import coverage\ncoverage.process_startup()')"
 
 ::
-:: Typescript configuration
-::
-
-:: Since npm executable is a batch file, we need to prefix it with a call
-:: statement. See https://github.com/npm/npm/issues/2938
-call npm install -g typescript
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-::
 :: Rust configuration
 ::
 

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -97,18 +97,12 @@ rustup update
 rustc -Vv
 cargo -V
 
-##################
-# JavaScript setup
-##################
+#################################
+# JavaScript and TypeScript setup
+#################################
 
 # Pre-installed Node.js is too old. Install latest Node.js v4 LTS.
 nvm install 4
-
-##################
-# TypeScript setup
-##################
-
-npm install -g typescript
 
 ###############
 # Java 8 setup

--- a/run_tests.py
+++ b/run_tests.py
@@ -60,8 +60,7 @@ COMPLETERS = {
   },
   'javascript': {
     'build': [ '--js-completer' ],
-    'test': [ '--exclude-dir=ycmd/tests/javascript',
-              '--exclude-dir=ycmd/tests/tern' ],
+    'test': [ '--exclude-dir=ycmd/tests/tern' ],
     'aliases': [ 'js', 'tern' ]
   },
   'go': {
@@ -75,9 +74,10 @@ COMPLETERS = {
     'aliases': [ 'racer', 'racerd', ]
   },
   'typescript': {
-    'build': [],
-    'test': [ '--exclude-dir=ycmd/tests/typescript' ],
-    'aliases': []
+    'build': [ '--ts-completer' ],
+    'test': [ '--exclude-dir=ycmd/tests/javascript',
+              '--exclude-dir=ycmd/tests/typescript' ],
+    'aliases': [ 'ts' ]
   },
   'python': {
     'build': [],

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -44,7 +44,9 @@ NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 
 RESPONSE_TIMEOUT_SECONDS = 10
 
-PATH_TO_TSSERVER = utils.FindExecutable( 'tsserver' )
+TSSERVER_DIR = os.path.abspath(
+  os.path.join( os.path.dirname( __file__ ), '..', '..', '..', 'third_party',
+                'tsserver' ) )
 
 LOGFILE_FORMAT = 'tsserver_'
 
@@ -78,13 +80,25 @@ class DeferredResponse( object ):
       return self._message[ 'body' ]
 
 
-def ShouldEnableTypeScriptCompleter():
-  if not PATH_TO_TSSERVER:
-    _logger.error( 'Not using TypeScript completer: unable to find TSServer.'
-                   'TypeScript 1.5 or higher is required.' )
-    return False
-  _logger.info( 'Using TSServer from {0}'.format( PATH_TO_TSSERVER ) )
+def FindTSServer():
+  # The TSServer executable is installed at the root directory on Windows while
+  # it's installed in the bin folder on other platforms.
+  for executable in [ os.path.join( TSSERVER_DIR, 'bin', 'tsserver' ),
+                      os.path.join( TSSERVER_DIR, 'tsserver' ),
+                      'tsserver' ]:
+    tsserver = utils.FindExecutable( executable )
+    if tsserver:
+      return tsserver
+  return None
 
+
+def ShouldEnableTypeScriptCompleter():
+  tsserver = FindTSServer()
+  if not tsserver:
+    _logger.error( 'Not using TypeScript completer: TSServer not installed '
+                   'in %s', TSSERVER_DIR )
+    return False
+  _logger.info( 'Using TypeScript completer' )
   return True
 
 
@@ -133,6 +147,7 @@ class TypeScriptCompleter( Completer ):
     self._tsserver_lock = threading.RLock()
     self._tsserver_handle = None
     self._tsserver_version = None
+    self._tsserver_executable = FindTSServer()
     # Used to read response only if TSServer is running.
     self._tsserver_is_running = threading.Event()
 
@@ -190,7 +205,7 @@ class TypeScriptCompleter( Completer ):
       _logger.info( 'TSServer log file: {0}'.format( self._logfile ) )
 
       # We need to redirect the error stream to the output one on Windows.
-      self._tsserver_handle = utils.SafePopen( PATH_TO_TSSERVER,
+      self._tsserver_handle = utils.SafePopen( self._tsserver_executable,
                                                stdin = subprocess.PIPE,
                                                stdout = subprocess.PIPE,
                                                stderr = subprocess.STDOUT,
@@ -826,7 +841,7 @@ class TypeScriptCompleter( Completer ):
       tsserver = responses.DebugInfoServer(
           name = 'TSServer',
           handle = self._tsserver_handle,
-          executable = PATH_TO_TSSERVER,
+          executable = self._tsserver_executable,
           logfiles = [ self._logfile ],
           extras = [ item_version ] )
 

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -98,7 +98,7 @@ def ShouldEnableTypeScriptCompleter():
     _logger.error( 'Not using TypeScript completer: TSServer not installed '
                    'in %s', TSSERVER_DIR )
     return False
-  _logger.info( 'Using TypeScript completer' )
+  _logger.info( 'Using TypeScript completer with %s', tsserver )
   return True
 
 

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -27,7 +27,6 @@ from builtins import *  # noqa
 from hamcrest import ( assert_that,
                        contains,
                        contains_inanyorder,
-                       contains_string,
                        has_entries,
                        matches_regexp )
 from nose.tools import eq_
@@ -39,7 +38,6 @@ from ycmd.tests.test_utils import ( BuildRequest,
                                     ChunkMatcher,
                                     CombineRequest,
                                     ErrorMatcher,
-                                    ExpectedFailure,
                                     LocationMatcher,
                                     MessageMatcher )
 from ycmd.utils import ReadFile
@@ -573,9 +571,6 @@ def Subcommands_RefactorRename_Missing_test( app ):
   } )
 
 
-@ExpectedFailure( 'TSServer 3.1.1 regression',
-                  contains_string( "Cannot read property "
-                                   "'start' of undefined" ) )
 @SharedYcmd
 def Subcommands_RefactorRename_NotPossible_test( app ):
   RunTest( app, {

--- a/ycmd/tests/server_utils_test.py
+++ b/ycmd/tests/server_utils_test.py
@@ -47,6 +47,7 @@ THIRD_PARTY_FOLDERS = [
   os.path.join( DIR_OF_THIRD_PARTY, 'racerd' ),
   os.path.join( DIR_OF_THIRD_PARTY, 'requests' ),
   os.path.join( DIR_OF_THIRD_PARTY, 'tern_runtime' ),
+  os.path.join( DIR_OF_THIRD_PARTY, 'tsserver' ),
   os.path.join( DIR_OF_THIRD_PARTY, 'waitress' ),
   os.path.join( DIR_OF_THIRD_PARTY, 'eclipse.jdt.ls' ),
 ]

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -27,7 +27,6 @@ from builtins import *  # noqa
 from hamcrest import ( assert_that,
                        contains,
                        contains_inanyorder,
-                       contains_string,
                        has_entries,
                        has_entry,
                        matches_regexp )
@@ -41,7 +40,6 @@ from ycmd.tests.test_utils import ( BuildRequest,
                                     ChunkMatcher,
                                     CombineRequest,
                                     ErrorMatcher,
-                                    ExpectedFailure,
                                     LocationMatcher,
                                     MessageMatcher,
                                     MockProcessTerminationTimingOut,
@@ -754,9 +752,6 @@ def Subcommands_RefactorRename_Missing_test( app ):
   } )
 
 
-@ExpectedFailure( 'TSServer 3.1.1 regression',
-                  contains_string( "Cannot read property "
-                                   "'start' of undefined" ) )
 @SharedYcmd
 def Subcommands_RefactorRename_NotPossible_test( app ):
   RunTest( app, {

--- a/ycmd/tests/typescript/typescript_completer_test.py
+++ b/ycmd/tests/typescript/typescript_completer_test.py
@@ -33,7 +33,6 @@ def ShouldEnableTypeScriptCompleter_NodeAndTsserverFound_test():
   ok_( ShouldEnableTypeScriptCompleter() )
 
 
-@patch( 'ycmd.completers.typescript.typescript_completer.PATH_TO_TSSERVER',
-        None )
+@patch( 'ycmd.utils.FindExecutable', return_value = None )
 def ShouldEnableTypeScriptCompleter_TsserverNotFound_test( *args ):
   ok_( not ShouldEnableTypeScriptCompleter() )


### PR DESCRIPTION
Add the `--ts-completer` parameter to the `install.py` script to configure the TypeScript completer. This parameter installs a specific version of TypeScript in the third-party folder which is used by the completer. If not installed this way, the completer still looks for `tsserver` in the `PATH` to ensure backward compatibility. This change has several benefits:
 - tests on the build bots can't be broken by a new version of TypeScript:
 - users are on a known version of TSServer that is tested;
 - users are not instructed to install TypeScript globally. See issue https://github.com/Valloric/YouCompleteMe/issues/3149.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1123)
<!-- Reviewable:end -->
