### PR TITLE
[READY] Simplify completer hook mechanism

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -25,7 +25,6 @@ from builtins import *  # noqa
 # Must not import ycm_core here! Vim imports completer, which imports this file.
 # We don't want ycm_core inside Vim.
 import logging
-import os
 from collections import defaultdict
 from future.utils import iteritems
 from ycmd.utils import ( ToCppStringCompatible, ToUnicode, re, ReadFile,
@@ -155,19 +154,6 @@ def _PrepareTrigger( trigger ):
   if trigger.startswith( TRIGGER_REGEX_PREFIX ):
     return re.compile( trigger[ len( TRIGGER_REGEX_PREFIX ) : ], re.UNICODE )
   return re.compile( re.escape( trigger ), re.UNICODE )
-
-
-def _PathToCompletersFolder():
-  dir_of_current_script = os.path.dirname( os.path.abspath( __file__ ) )
-  return os.path.join( dir_of_current_script )
-
-
-def PathToFiletypeCompleterPluginLoader( filetype ):
-  return os.path.join( _PathToCompletersFolder(), filetype, 'hook.py' )
-
-
-def FiletypeCompleterExistsForFiletype( filetype ):
-  return os.path.exists( PathToFiletypeCompleterPluginLoader( filetype ) )
 
 
 def FilterAndSortCandidatesWrap( candidates, sort_property, query,

--- a/ycmd/tests/javascript/__init__.py
+++ b/ycmd/tests/javascript/__init__.py
@@ -45,7 +45,7 @@ def setUpPackage():
   subserver, should be done here."""
   global shared_app
 
-  with patch( 'ycmd.completers.javascript.tern_completer.'
+  with patch( 'ycmd.completers.javascript.hook.'
               'ShouldEnableTernCompleter', return_value = False ):
     shared_app = SetUpApp()
     WaitUntilCompleterServerReady( shared_app, 'javascript' )

--- a/ycmd/tests/javascript/debug_info_test.py
+++ b/ycmd/tests/javascript/debug_info_test.py
@@ -54,9 +54,9 @@ def DebugInfo_TypeScriptCompleter_test( app ):
   )
 
 
-@patch( 'ycmd.completers.typescript.typescript_completer.'
+@patch( 'ycmd.completers.javascript.hook.'
         'ShouldEnableTypeScriptCompleter', return_value = False )
-@patch( 'ycmd.completers.javascript.tern_completer.'
+@patch( 'ycmd.completers.javascript.hook.'
         'ShouldEnableTernCompleter', return_value = False )
 @IsolatedYcmd
 def DebugInfo_NoCompleter_test( app, *args ):


### PR DESCRIPTION
Use `importlib.import_module` to import the `hook.py` file of a completer instead of loading its source. In addition to simplify the code, this is needed if we want to package only the `.pyc` files since source files don't exist in that case.

Changes are required in the tests because of how mocking works (see [Where to patch](https://docs.python.org/3/library/unittest.mock.html#where-to-patch) in the Python docs).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1138)
<!-- Reviewable:end -->
