### PR TITLE
[READY] Use struct of arrays for static code_points object

### DIFF
--- a/cpp/ycm/CodePoint.cpp
+++ b/cpp/ycm/CodePoint.cpp
@@ -52,15 +52,26 @@ const RawCodePoint FindCodePoint( const char *text ) {
   // Do a binary search on the array of code points to find the raw code point
   // corresponding to the text. If no code point is found, return the default
   // raw code point for that text.
-  auto first = code_points.begin();
-  size_t count = code_points.size();
+  const auto& original = code_points.original;
+  auto first = original.begin();
+  const auto start = first;
+  size_t count = original.size();
 
   while ( count > 0 ) {
     size_t step = count / 2;
     auto it = first + step;
-    int cmp = std::strcmp( it->original, text );
+    int cmp = std::strcmp( *it, text );
     if ( cmp == 0 ) {
-      return *it;
+      size_t index = std::distance( start, it );
+      return { *it,
+               code_points.normal[ index ],
+               code_points.folded_case[ index ],
+               code_points.swapped_case[ index ],
+               code_points.is_letter[ index ],
+               code_points.is_punctuation[ index ],
+               code_points.is_uppercase[ index ],
+               code_points.break_property[ index ],
+               code_points.combining_class[ index ] };
     }
     if ( cmp < 0 ) {
       first = ++it;

--- a/update_unicode.py
+++ b/update_unicode.py
@@ -42,9 +42,21 @@ DIR_OF_CPP_SOURCES = os.path.join( DIR_OF_THIS_SCRIPT, 'cpp', 'ycm' )
 UNICODE_TABLE_TEMPLATE = (
   """// This file was automatically generated with the update_unicode.py script
 // using version {unicode_version} of the Unicode Character Database.
-static const std::array< const RawCodePoint, {size} > code_points = {{ {{
+#include <array>
+struct RawCodePointArray {{
+std::array< char[{original_size}], {size} > original;
+std::array< char[{normal_size}], {size} > normal;
+std::array< char[{folded_case_size}], {size} > folded_case;
+std::array< char[{swapped_case_size}], {size} > swapped_case;
+std::array< bool, {size} > is_letter;
+std::array< bool, {size} > is_punctuation;
+std::array< bool, {size} > is_uppercase;
+std::array< uint8_t, {size} > break_property;
+std::array< uint8_t, {size} > combining_class;
+}};
+static const RawCodePointArray code_points = {{
 {code_points}
-}} }};""" )
+}};""" )
 UNICODE_VERSION_REGEX = re.compile( r'Version (?P<version>\d+(?:\.\d+){2})' )
 GRAPHEME_BREAK_PROPERTY_REGEX = re.compile(
   r'^(?P<value>[A-F0-9.]+)\s+; (?P<property>\w+) # .*$' )
@@ -486,23 +498,61 @@ def CppBool( statement ):
   return '0'
 
 
+# If a codepoint is written in hex (\x61) instead of a literal (a)
+# then the backslash needs to be escaped in order for the correct
+# string end up in the generated C++ file.
+# To calculate the actual length for these, we can't count bytes.
+# Instead, we split on '\\x', leaving only the an array of hex values.
+# \\x61 would end up as [ '', '61' ]
+def CppLength( utf8_code_point ):
+  nb_utf8_hex = len( utf8_code_point.split( '\\x' )[ 1: ] )
+  if nb_utf8_hex > 0:
+    # +1 for NULL terminator
+    return nb_utf8_hex + 1
+  return len( bytearray( utf8_code_point, encoding = 'utf8' ) ) + 1
+
+
 def GenerateUnicodeTable( header_path, code_points ):
   unicode_version = GetUnicodeVersion()
   size = len( code_points )
-  code_points = '\n'.join( [
-    ( '{' + CppChar( code_point[ 'original' ] ) + ',' +
-            CppChar( code_point[ 'normal' ] ) + ',' +
-            CppChar( code_point[ 'folded_case' ] ) + ',' +
-            CppChar( code_point[ 'swapped_case' ] ) + ',' +
-            CppBool( code_point[ 'is_letter' ] ) + ',' +
-            CppBool( code_point[ 'is_punctuation' ] ) + ',' +
-            CppBool( code_point[ 'is_uppercase' ] ) + ',' +
-            str( code_point[ 'break_property' ] ) + ',' +
-            str( code_point[ 'combining_class' ] ) + '},' )
-    for code_point in code_points ] )
-  contents = UNICODE_TABLE_TEMPLATE.format( unicode_version = unicode_version,
-                                            size = size,
-                                            code_points = code_points )
+  table = {
+    'original': { 'output': '{{', 'size': 0, 'converter': CppChar },
+    'normal': { 'output': '{{', 'size': 0, 'converter': CppChar },
+    'folded_case': { 'output': '{{', 'size': 0, 'converter': CppChar },
+    'swapped_case': { 'output': '{{', 'size': 0, 'converter': CppChar },
+    'is_letter': { 'output': '{{', 'converter': CppBool },
+    'is_punctuation': { 'output': '{{', 'converter': CppBool },
+    'is_uppercase': { 'output': '{{', 'converter': CppBool },
+    'break_property': { 'output': '{{', 'converter': str },
+    'combining_class': { 'output': '{{', 'converter': str },
+  }
+  for code_point in code_points:
+    for t, d in table.items():
+      cp = code_point[ t ]
+      d[ 'output' ] += d[ 'converter' ]( cp ) + ','
+      if d[ 'converter' ] == CppChar:
+        d[ 'size' ] = max( CppLength( cp ), d[ 'size' ] )
+  for t, d in table.items():
+    d[ 'output' ] = d[ 'output' ].rstrip( ',' ) + '}},'
+    if t == 'combining_class':
+      d[ 'output' ] = d[ 'output' ].rstrip( ',' )
+  code_points = '\n'.join( [ table[ 'original' ][ 'output' ],
+                             table[ 'normal' ][ 'output' ],
+                             table[ 'folded_case' ][ 'output' ],
+                             table[ 'swapped_case' ][ 'output' ],
+                             table[ 'is_letter' ][ 'output' ],
+                             table[ 'is_punctuation' ][ 'output' ],
+                             table[ 'is_uppercase' ][ 'output' ],
+                             table[ 'break_property' ][ 'output' ],
+                             table[ 'combining_class' ][ 'output' ] ] )
+  contents = UNICODE_TABLE_TEMPLATE.format(
+    unicode_version = unicode_version,
+    size = size,
+    original_size = table[ 'original' ][ 'size' ],
+    normal_size = table[ 'normal' ][ 'size' ],
+    folded_case_size = table[ 'folded_case' ][ 'size' ],
+    swapped_case_size = table[ 'swapped_case' ][ 'size' ],
+    code_points = code_points )
   with open( header_path, 'w', newline = '\n', encoding='utf8' ) as header_file:
     header_file.write( contents )
 


### PR DESCRIPTION
Introduce RawCodePointArray for FindCodePoint
to iterate of a continous array instead of
an array of structs.

This also allows the arrays in RawCodePointArray
to use char[] instead of const char* and thus
avoids 12MB of relocation data on linux.

This is another attempt of doing https://github.com/Valloric/ycmd/pull/1064.

Table summary from [Michel's comment](https://github.com/Valloric/ycmd/pull/1140#pullrequestreview-181520414)

<table>
  <tr>
    <th rowspan="2">Platform</th>
    <th colspan="2">Compilation time (s)</th>
    <th colspan="2">Library size (MB)</th>
  </tr>
  <tr>
    <td>Before</td>
    <td>After</td>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>    
    <td>Ubuntu 18.04 64-bit (GCC 7.3.0)</td>
    <td>26.56</td>
    <td>25.79</td>
    <td>19.59</td>
    <td>7.32</td>
  </tr>
  <tr>
    <td>macOS 10.14 (Apple Clang 10.0.0)</td>
    <td>29.16</td>
    <td>28.20</td>
    <td>7.09</td>
    <td>7.30</td>
  </tr>
  <tr> 
    <td>Windows 7 64-bit (MSVC 15)</td>
    <td>30.62</td>
    <td>30.39</td>
    <td>7.86</td>
    <td>6.99</td>
  </tr>  
</table>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1140)
<!-- Reviewable:end -->
