### PR TITLE
[READY] Do not rely on unordered_map ordering in tests

### DIFF
--- a/cpp/ycm/tests/IdentifierUtils_test.cpp
+++ b/cpp/ycm/tests/IdentifierUtils_test.cpp
@@ -29,6 +29,8 @@ namespace fs = boost::filesystem;
 using ::testing::ElementsAre;
 using ::testing::ContainerEq;
 using ::testing::WhenSorted;
+using ::testing::Pair;
+using ::testing::UnorderedElementsAre;
 
 
 TEST( IdentifierUtilsTest, ExtractIdentifiersFromTagsFileWorks ) {
@@ -36,30 +38,27 @@ TEST( IdentifierUtilsTest, ExtractIdentifiersFromTagsFileWorks ) {
   fs::path testfile = PathToTestFile( "basic.tags" );
   fs::path testfile_parent = testfile.parent_path();
 
-  FiletypeIdentifierMap expected;
-  expected[ "cpp" ][ ( testfile_parent / "foo" ).string() ]
-  .push_back( "i1" );
-  expected[ "cpp" ][ ( testfile_parent / "bar" ).string() ]
-  .push_back( "i1" );
-  expected[ "cpp" ][ ( testfile_parent / "foo" ).string() ]
-  .push_back( "foosy" );
-  expected[ "cpp" ][ ( testfile_parent / "bar" ).string() ]
-  .push_back( "fooaaa" );
-
-  expected[ "c" ][ ( root / "foo" / "zoo" ).string() ].push_back( "Floo::goo" );
-  expected[ "c" ][ ( root / "foo" / "goo maa" ).string() ].push_back( "!goo" );
-
-  expected[ "fakelang" ][ ( root / "foo" ).string() ].push_back( "zoro" );
-
-  expected[ "cs" ][ ( root / "m_oo" ).string() ].push_back( "#bleh" );
-
-  expected[ "foobar" ][ ( testfile_parent / "foo.bar" ).string() ]
-  .push_back( "API" );
-  expected[ "foobar" ][ ( testfile_parent / "foo.bar" ).string() ]
-  .push_back( "DELETE" );
-
   EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
-               ContainerEq( expected ) );
+      UnorderedElementsAre(
+        Pair( "cpp", UnorderedElementsAre(
+                         Pair( ( testfile_parent / "foo" ).string(),
+                               ElementsAre( "i1", "foosy" ) ),
+                         Pair( ( testfile_parent / "bar" ).string(),
+                               ElementsAre( "i1", "fooaaa" ) ) ) ),
+        Pair( "fakelang", UnorderedElementsAre(
+                              Pair( ( root / "foo" ).string(),
+                                    ElementsAre( "zoro" ) ) ) ),
+        Pair( "cs", UnorderedElementsAre(
+                        Pair( ( root / "m_oo" ).string(),
+                              ElementsAre( "#bleh" ) ) ) ),
+        Pair( "foobar", UnorderedElementsAre(
+                            Pair( ( testfile_parent / "foo.bar" ).string(),
+                                  ElementsAre( "API", "DELETE" ) ) ) ),
+        Pair( "c", UnorderedElementsAre(
+                       Pair( ( root / "foo" / "zoo" ).string(),
+                             ElementsAre( "Floo::goo" ) ),
+                       Pair( ( root / "foo" / "goo maa" ).string(),
+                             ElementsAre( "!goo" ) ) ) ) ) );
 }
 
 


### PR DESCRIPTION
Currently the `IdentifierUtilsTest.ExtractIdentifiersFromTagsFileWorks` relies on the fact that you can compare `std::unordered_map` and its preserved order of insertion. This is not true for much faster hash tables like `absl::flat_hash_map`. Using `absl::flat_hash_map` yield between 15 and 20 percent better performance, but also breaks `IdentifierUtilsTest.ExtractIdentifiersFromTagsFileWorks` on current master.

This PR rewrites `IdentifierUtilsTest.ExtractIdentifiersFromTagsFileWorks` to not depend on ordering. If you pay attention, you'll see that now `"c"` is last in the test, but second in the tag file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1142)
<!-- Reviewable:end -->
