### PR TITLE
[READY] Add the requests and Jedi modules to test PYTHONPATH

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -20,22 +20,30 @@ import sys
 DIR_OF_THIS_SCRIPT = p.dirname( p.abspath( __file__ ) )
 DIR_OF_THIRD_PARTY = p.join( DIR_OF_THIS_SCRIPT, 'third_party' )
 
-python_path = []
-for folder in os.listdir( DIR_OF_THIRD_PARTY ):
-  # We skip python-future because it needs to be inserted in sys.path AFTER
-  # the standard library imports but we can't do that with PYTHONPATH because
-  # the std lib paths are always appended to PYTHONPATH. We do it correctly in
-  # prod in ycmd/utils.py because we have access to the right sys.path.
-  # So for dev, we rely on python-future being installed correctly with
-  #   pip install -r test_requirements.txt
-  #
-  # Pip knows how to install this correctly so that it doesn't matter where in
-  # sys.path the path is.
-  if folder == 'python-future':
-    continue
-  if folder == 'cregex':
-    folder = p.join( folder, 'regex_{}'.format( sys.version_info[ 0 ] ) )
-  python_path.append( p.abspath( p.join( DIR_OF_THIRD_PARTY, folder ) ) )
+# We skip python-future because it needs to be inserted in sys.path AFTER the
+# standard library imports but we can't do that with PYTHONPATH because the std
+# lib paths are always appended to PYTHONPATH. We do it correctly in ycmd
+# because we have access to the right sys.path. So for dev, we rely on
+# python-future being installed correctly with
+#   pip install -r test_requirements.txt
+#
+# Pip knows how to install this correctly so that it doesn't matter where in
+# sys.path the path is.
+python_path = [
+  p.join( DIR_OF_THIRD_PARTY, 'bottle' ),
+  p.join( DIR_OF_THIRD_PARTY,
+          'cregex',
+          'regex_{}'.format( sys.version_info[ 0 ] ) ),
+  p.join( DIR_OF_THIRD_PARTY, 'frozendict' ),
+  p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'jedi' ),
+  p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'parso' ),
+  p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'certifi' ),
+  p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'chardet' ),
+  p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'idna' ),
+  p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'requests' ),
+  p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'urllib3', 'src' ),
+  p.join( DIR_OF_THIRD_PARTY, 'waitress' ),
+]
 if os.environ.get( 'PYTHONPATH' ) is not None:
   python_path.append( os.environ[ 'PYTHONPATH' ] )
 os.environ[ 'PYTHONPATH' ] = os.pathsep.join( python_path )


### PR DESCRIPTION
The test framework uses requests to communicate with ycmd. When it was
moved to its own directory, we didn't update run_tests.py to include it
in PYTHONPATH used by nosetests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1148)
<!-- Reviewable:end -->
