### PR TITLE
[clangd] Don't include clangd in --all

### DIFF
--- a/build.py
+++ b/build.py
@@ -892,7 +892,7 @@ def Main():
     EnableJavaCompleter( args )
   if args.ts_completer or args.all_completers:
     EnableTypeScriptCompleter( args )
-  if args.clangd_completer or args.all_completers:
+  if args.clangd_completer:
     EnableClangdCompleter( args )
 
 


### PR DESCRIPTION
Clangd is enabled by default when it is installed/configured. Currently,
clangd is a feature regression and breaking change for most users, By
including in --all, we are breaking users by default.

For now, remove it from --all and require that --clangd-complerter is
explicitly requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1149)
<!-- Reviewable:end -->
