### PR TITLE
[READY] Only detail filtered candidates in Python completer

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -121,7 +121,11 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
   ycmd.responses.BuildCompletionData to build the detailed response. See
   clang_completer.py to see how its used in practice.
 
-  Again, you probably want to override ComputeCandidatesInner().
+  Again, you probably want to override ComputeCandidatesInner(). If computing
+  the fields of the candidates is costly, you should consider building only the
+  "insertion_text" field in ComputeCandidatesInner() then fill the remaining
+  fields in DetailCandidates() which is called after the filtering is done. See
+  python_completer.py for an example.
 
   You also need to implement the SupportedFiletypes() function which should
   return a list of strings, where the strings are Vim filetypes your completer
@@ -229,7 +233,9 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
       return []
 
     candidates = self._GetCandidatesFromSubclass( request_data )
-    return self.FilterAndSortCandidates( candidates, request_data[ 'query' ] )
+    candidates = self.FilterAndSortCandidates( candidates,
+                                               request_data[ 'query' ] )
+    return self.DetailCandidates( candidates )
 
 
   def _GetCandidatesFromSubclass( self, request_data ):
@@ -242,6 +248,10 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
     raw_completions = self.ComputeCandidatesInner( request_data )
     self._completions_cache.Update( request_data, raw_completions )
     return raw_completions
+
+
+  def DetailCandidates( self, candidates ):
+    return candidates
 
 
   def ComputeCandidatesInner( self, request_data ):

--- a/ycmd/tests/python/get_completions_test.py
+++ b/ycmd/tests/python/get_completions_test.py
@@ -25,8 +25,16 @@ from __future__ import division
 from builtins import *  # noqa
 
 from nose.tools import eq_
-from hamcrest import ( assert_that, has_item, has_items, has_entry,
-                       has_entries, contains, empty, contains_string )
+from hamcrest import ( all_of,
+                       assert_that,
+                       contains,
+                       contains_string,
+                       empty,
+                       has_item,
+                       has_items,
+                       has_entry,
+                       has_entries,
+                       is_not )
 import requests
 
 from ycmd.utils import ReadFile
@@ -34,7 +42,6 @@ from ycmd.tests.python import IsolatedYcmd, PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import ( BuildRequest,
                                     CombineRequest,
                                     CompletionEntryMatcher,
-                                    CompletionLocationMatcher,
                                     ErrorMatcher )
 
 
@@ -71,8 +78,6 @@ def RunTest( app, test ):
   assert_that( response.json, test[ 'expect' ][ 'data' ] )
 
 
-
-
 @SharedYcmd
 def GetCompletions_Basic_test( app ):
   filepath = PathToTestFile( 'basic.py' )
@@ -84,15 +89,56 @@ def GetCompletions_Basic_test( app ):
 
   results = app.post_json( '/completions',
                            completion_data ).json[ 'completions' ]
-
   assert_that( results,
                has_items(
-                 CompletionEntryMatcher( 'a' ),
-                 CompletionEntryMatcher( 'b' ),
-                 CompletionLocationMatcher( 'line_num', 3 ),
-                 CompletionLocationMatcher( 'line_num', 4 ),
-                 CompletionLocationMatcher( 'column_num', 10 ),
-                 CompletionLocationMatcher( 'filepath', filepath ) ) )
+                 CompletionEntryMatcher( 'a',
+                                         'self.a = 1',
+                                         {
+                                           'extra_data': has_entry(
+                                             'location', has_entries( {
+                                               'line_num': 3,
+                                               'column_num': 10,
+                                               'filepath': filepath
+                                             } )
+                                           )
+                                         } ),
+                 CompletionEntryMatcher( 'b',
+                                         'self.b = 2',
+                                         {
+                                           'extra_data': has_entry(
+                                             'location', has_entries( {
+                                               'line_num': 4,
+                                               'column_num': 10,
+                                               'filepath': filepath
+                                             } )
+                                           )
+                                         } )
+               ) )
+
+  completion_data = BuildRequest( filepath = filepath,
+                                  filetype = 'python',
+                                  contents = ReadFile( filepath ),
+                                  line_num = 7,
+                                  column_num = 4 )
+
+  results = app.post_json( '/completions',
+                           completion_data ).json[ 'completions' ]
+  assert_that( results,
+               all_of(
+                 has_item(
+                   CompletionEntryMatcher( 'a',
+                                           'self.a = 1',
+                                           {
+                                             'extra_data': has_entry(
+                                               'location', has_entries( {
+                                                 'line_num': 3,
+                                                 'column_num': 10,
+                                                 'filepath': filepath
+                                               } )
+                                             )
+                                           } ) ),
+                 is_not( has_item( CompletionEntryMatcher( 'b' ) ) )
+               ) )
 
 
 @SharedYcmd

--- a/ycmd/tests/python/testdata/basic.py
+++ b/ycmd/tests/python/testdata/basic.py
@@ -4,4 +4,4 @@ class Foo(object):
     self.b = 2
 
 f = Foo()
-f.
+f.a

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -125,12 +125,6 @@ def CompletionEntryMatcher( insertion_text,
   return has_entries( match )
 
 
-def CompletionLocationMatcher( location_type, value ):
-  return has_entry( 'extra_data',
-                    has_entry( 'location',
-                               has_entry( location_type, value ) ) )
-
-
 def MessageMatcher( msg ):
   return has_entry( 'message', contains_string( msg ) )
 


### PR DESCRIPTION
Computing the fields of all candidates (`extra_menu_info`, `detailed_info`, etc.) becomes a performance issue when Jedi returns a lot of completions. Instead, we should only compute the fields on the filtered candidates (at most 50 by default). The same strategy could be applied to other completers like the TypeScript and LSP ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1153)
<!-- Reviewable:end -->
