### PR TITLE
[READY] Fix exit codes in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ of the following return codes if unsuccessful:
 
 - 3: unexpected error while loading the library;
 - 4: the `ycm_core` library is missing;
-- 5: the `ycm_core` library is compiled for Python 3 but loaded in Python 2;
-- 6: the `ycm_core` library is compiled for Python 2 but loaded in Python 3;
+- 5: the `ycm_core` library is compiled for Python 2 but loaded in Python 3;
+- 6: the `ycm_core` library is compiled for Python 3 but loaded in Python 2;
 - 7: the version of the `ycm_core` library is outdated.
 
 User-level customization


### PR DESCRIPTION
[The exit codes 5 and 6 are inverted in the docs](https://github.com/Valloric/ycmd/blob/ed8d17c2e392458e197d90d6a9cba3dc94a7e0e9/ycmd/server_utils.py#L56-L59).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1160)
<!-- Reviewable:end -->
