### PR TITLE
[RFC] Only resolve filtered completion items

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -798,7 +798,7 @@ class LanguageServerCompleter( Completer ):
     # text to ensure that the returned text and start_codepoint are applicable
     # to our model of a single start column.
     return self._ResolveCompletionItems(
-      [ completion[ 'extra_data' ] for completion in completions ],
+      [ c[ 'extra_data' ][ 'item' ] for c in completions ],
       True, # Do a full resolve
       request_data )
 
@@ -811,7 +811,8 @@ class LanguageServerCompleter( Completer ):
         resolve_id,
         resolve,
         REQUEST_TIMEOUT_COMPLETION )
-      item = response[ 'result' ]
+      item.clear()
+      item.update( response[ 'result' ] )
     except ResponseFailedException:
       _logger.exception( 'A completion item could not be resolved. Using '
                          'basic data.' )
@@ -872,8 +873,9 @@ class LanguageServerCompleter( Completer ):
     # start_codepoints. Then, we fix-up the completion texts to use the
     # earliest start_codepoint by borrowing text from the original line.
     for item in items:
-      if resolve:
-        item = self._ResolveCompletionItem( item )
+      if resolve and not item.get( '_resolved', False ):
+        self._ResolveCompletionItem( item )
+        item[ '_resolved' ] = True
 
       extra_data = None
       start_codepoint = None
@@ -887,12 +889,14 @@ class LanguageServerCompleter( Completer ):
                            '{0}'.format( item ) )
         continue
 
-      min_start_codepoint = min( min_start_codepoint, start_codepoint )
 
       if not resolve and self._resolve_completion_items:
-        # We need to store the full item because we will get called again in a
-        # while to resolve the items
-        extra_data = item
+        # Store the actual item in the extra_data area of the completion item.
+        # We'll use this later to do the full resolve.
+        extra_data = {} if extra_data is None else extra_data
+        extra_data[ 'item' ] = item
+
+      min_start_codepoint = min( min_start_codepoint, start_codepoint )
 
       # Build a ycmd-compatible completion for the text as we received it. Later
       # we might modify insertion_text should we see a lower start codepoint.

--- a/ycmd/tests/java/get_completions_test.py
+++ b/ycmd/tests/java/get_completions_test.py
@@ -183,6 +183,35 @@ def GetCompletions_WithQuery_test( app ):
 
 
 @SharedYcmd
+def GetCompletions_DetailFromCache_test( app ):
+  for i in range( 0, 2 ):
+    RunTest( app, {
+      'description': 'completion works when the elements come from the cache',
+      'request': {
+        'filetype'  : 'java',
+        'filepath'  : ProjectPath( 'TestLauncher.java' ),
+        'line_num'  : 32,
+        'column_num': 12,
+      },
+      'expect': {
+        'response': requests.codes.ok,
+        'data': has_entries( {
+          'completion_start_column': 11,
+          'completions': has_item(
+            CompletionEntryMatcher( 'doSomethingVaguelyUseful',
+                                    'AbstractTestWidget', {
+                                      'kind': 'Function',
+                                      'menu_text':
+                                        'doSomethingVaguelyUseful() : void',
+                                    } )
+          ),
+          'errors': empty(),
+        } )
+      },
+    } )
+
+
+@SharedYcmd
 def GetCompletions_Package_test( app ):
   RunTest( app, {
     'description': 'completion works for package statements',

--- a/ycmd/tests/java/get_completions_test.py
+++ b/ycmd/tests/java/get_completions_test.py
@@ -511,9 +511,10 @@ def Subcommands_ServerNotReady_test( app ):
 
 
 @SharedYcmd
-def GetCompletions_MoreThan100NoResolve_test( app ):
+def GetCompletions_MoreThan100FilteredResolve_test( app ):
   RunTest( app, {
-    'description': 'We guess the right start codepoint without resolving',
+    'description': 'More that 100 match, but filtered set is fewer as this '
+                   'depends on max_num_candidates',
     'request': {
       'filetype'  : 'java',
       'filepath'  : ProjectPath( 'TestLauncher.java' ),
@@ -524,8 +525,9 @@ def GetCompletions_MoreThan100NoResolve_test( app ):
       'response': requests.codes.ok,
       'data': has_entries( {
         'completions': has_item(
-          CompletionEntryMatcher( 'com.youcompleteme', None, {
-            'kind': 'Module'
+          CompletionEntryMatcher( 'com.youcompleteme.*;', None, {
+            'kind': 'Module',
+            'detailed_info': 'com.youcompleteme\n\n',
           } ),
         ),
         'completion_start_column': 8,


### PR DESCRIPTION
This applies similar logic to the typescript and other completer to only call the 'resolve' completion request for the candidates that pass our initial filter on their simple `insertion_text`.

Notable wrinkles:

- some language servers don't require resolving, so we have to ensure we don't double up on work
- we need to identify candidates which have been resolved and ones which haven't as candidates may be passed to `DetailCandidates` from the cache.
- whether we are resolving or not, we still need to calculate the start code point and such the same way we did before.
- we now no longer need to prevent resolve when there are > 100 candidates, as by default ycmd restricts filtered results to 50