### PR TITLE
[build.py] Skip loooking for cmake/cmakeargs if skip_build and no_regex

### DIFF
--- a/build.py
+++ b/build.py
@@ -872,8 +872,9 @@ def WritePythonUsedDuringBuild():
 
 def Main():
   args = ParseArguments()
-  cmake = FindCmake()
-  cmake_common_args = GetCmakeCommonArgs( args )
+  if not args.skip_build or not args.no_regex:
+      cmake = FindCmake()
+      cmake_common_args = GetCmakeCommonArgs( args )
   if not args.skip_build:
     ExitIfYcmdLibInUseOnWindows()
     BuildYcmdLib( cmake, cmake_common_args, args )


### PR DESCRIPTION
Sometimes you just want to fetch jdt or something.
My particular use case is fetching jdt. And ycm_core/clangcompleter are built outside of build.py due to completely unstandard locations for python include/build dirs that build.py just can't detect. (so it'll fail looking for them even though I just want to fetch jdt)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1163)
<!-- Reviewable:end -->
