### PR TITLE
[READY] Don't find cmake and python if not needed

### DIFF
--- a/build.py
+++ b/build.py
@@ -870,16 +870,24 @@ def WritePythonUsedDuringBuild():
     f.write( sys.executable )
 
 
-def Main():
-  args = ParseArguments()
+def DoCmakeBuilds( args ):
   cmake = FindCmake()
   cmake_common_args = GetCmakeCommonArgs( args )
+
   if not args.skip_build:
     ExitIfYcmdLibInUseOnWindows()
     BuildYcmdLib( cmake, cmake_common_args, args )
     WritePythonUsedDuringBuild()
+
   if not args.no_regex:
     BuildRegexModule( cmake, cmake_common_args, args )
+
+
+def Main():
+  args = ParseArguments()
+
+  if not args.skip_build or not args.no_regex:
+    DoCmakeBuilds( args )
   if args.cs_completer or args.omnisharp_completer or args.all_completers:
     EnableCsCompleter( args )
   if args.go_completer or args.gocode_completer or args.all_completers:


### PR DESCRIPTION
This allows builds to just update, say jdt.ls or clangd with
'./build.py --skip-build --no-regex --java-completer' and the like.

On some systems finding python and cmake can be a pain, requiring
specifying lots of arguments, so this simplifies and speeds up that use
case.

Replaces: https://github.com/Valloric/ycmd/pull/1163

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1164)
<!-- Reviewable:end -->
