### PR TITLE
[READY] Don't read LSP settings on every file parse

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -942,8 +942,6 @@ class LanguageServerCompleter( Completer ):
 
 
   def OnFileReadyToParse( self, request_data ):
-    self._GetSettingsFromExtraConf( request_data )
-
     self.StartServer( request_data )
 
     if not self.ServerIsHealthy():
@@ -1280,6 +1278,8 @@ class LanguageServerCompleter( Completer ):
       assert not self._initialize_response
 
       request_id = self.GetConnection().NextRequestId()
+
+      self._GetSettingsFromExtraConf( request_data )
       msg = lsp.Initialize( request_id,
                             self._GetProjectDirectory( request_data ),
                             self._settings )

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -104,15 +104,21 @@ def LanguageServerCompleter_ExtraConf_FileEmpty_test( app ):
                                  'settings_none_extra_conf.py' ) } )
 def LanguageServerCompleter_ExtraConf_SettingsReturnsNone_test( app ):
   filepath = PathToTestFile( 'extra_confs', 'foo' )
-  app.post_json( '/event_notification',
-                 BuildRequest( filepath = filepath,
-                               filetype = 'foo',
-                               contents = '',
-                               event_name = 'FileReadyToParse' ) )
 
   completer = MockCompleter()
-  request_data = RequestWrap( BuildRequest() )
-  completer.OnFileReadyToParse( request_data )
+  request_data = RequestWrap( BuildRequest( filepath = filepath,
+                                            filetype = 'ycmtest',
+                                            contents = '' ) )
+  completer.SendInitialize( request_data )
+  eq_( {}, completer._settings )
+
+  # Simulate receipt of response and initialization complete
+  initialize_response = {
+    'result': {
+      'capabilities': {}
+    }
+  }
+  completer._HandleInitializeInPollThread( initialize_response )
   eq_( {}, completer._settings )
 
 
@@ -120,30 +126,46 @@ def LanguageServerCompleter_ExtraConf_SettingsReturnsNone_test( app ):
                  PathToTestFile( 'extra_confs', 'settings_extra_conf.py' ) } )
 def LanguageServerCompleter_ExtraConf_SettingValid_test( app ):
   filepath = PathToTestFile( 'extra_confs', 'foo' )
-  app.post_json( '/event_notification',
-                 BuildRequest( filepath = filepath,
-                               filetype = 'foo',
-                               contents = '',
-                               event_name = 'FileReadyToParse' ) )
 
   completer = MockCompleter()
-  request_data = RequestWrap( BuildRequest() )
-  completer.OnFileReadyToParse( request_data )
+  request_data = RequestWrap( BuildRequest( filepath = filepath,
+                                            filetype = 'ycmtest',
+                                            contents = '' ) )
+
+  eq_( {}, completer._settings )
+  completer.SendInitialize( request_data )
+  eq_( { 'java.rename.enabled' : False }, completer._settings )
+
+  # Simulate receipt of response and initialization complete
+  initialize_response = {
+    'result': {
+      'capabilities': {}
+    }
+  }
+  completer._HandleInitializeInPollThread( initialize_response )
   eq_( { 'java.rename.enabled' : False }, completer._settings )
 
 
 @IsolatedYcmd( { 'extra_conf_globlist': [ '!*' ] } )
 def LanguageServerCompleter_ExtraConf_NoExtraConf_test( app ):
   filepath = PathToTestFile( 'extra_confs', 'foo' )
-  app.post_json( '/event_notification',
-                 BuildRequest( filepath = filepath,
-                               filetype = 'foo',
-                               contents = '',
-                               event_name = 'FileReadyToParse' ) )
 
   completer = MockCompleter()
-  request_data = RequestWrap( BuildRequest() )
-  completer.OnFileReadyToParse( request_data )
+  request_data = RequestWrap( BuildRequest( filepath = filepath,
+                                            filetype = 'ycmtest',
+                                            contents = '' ) )
+
+  eq_( {}, completer._settings )
+  completer.SendInitialize( request_data )
+  eq_( {}, completer._settings )
+
+  # Simulate receipt of response and initialization complete
+  initialize_response = {
+    'result': {
+      'capabilities': {}
+    }
+  }
+  completer._HandleInitializeInPollThread( initialize_response )
   eq_( {}, completer._settings )
 
 
@@ -427,7 +449,7 @@ def LanguageServerCompleter_DelayedInitialization_test( app ):
       update.assert_not_called()
       purge.assert_not_called()
 
-      # Simulate recept of response and initialization complete
+      # Simulate receipt of response and initialization complete
       initialize_response = {
         'result': {
           'capabilities': {}
@@ -589,7 +611,7 @@ def LanguageServerCompleter_Diagnostics_MaxDiagnosticsNumberExceeded_test():
 
   with patch.object( completer, 'ServerIsReady', return_value = True ):
     completer.SendInitialize( request_data )
-    # Simulate recept of response and initialization complete
+    # Simulate receipt of response and initialization complete
     initialize_response = {
       'result': {
         'capabilities': {}
@@ -663,7 +685,7 @@ def LanguageServerCompleter_Diagnostics_NoLimitToNumberOfDiagnostics_test():
 
   with patch.object( completer, 'ServerIsReady', return_value = True ):
     completer.SendInitialize( request_data )
-    # Simulate recept of response and initialization complete
+    # Simulate receipt of response and initialization complete
     initialize_response = {
       'result': {
         'capabilities': {}
@@ -751,7 +773,7 @@ def LanguageServerCompleter_Diagnostics_PercentEncodeCannonical_test():
 
   with patch.object( completer, 'ServerIsReady', return_value = True ):
     completer.SendInitialize( request_data )
-    # Simulate recept of response and initialization complete
+    # Simulate receipt of response and initialization complete
     initialize_response = {
       'result': {
         'capabilities': {}
@@ -810,7 +832,7 @@ def LanguageServerCompleter_OnFileReadyToParse_InvalidURI_test():
 
   with patch.object( completer, 'ServerIsReady', return_value = True ):
     completer.SendInitialize( request_data )
-    # Simulate recept of response and initialization complete
+    # Simulate receipt of response and initialization complete
     initialize_response = {
       'result': {
         'capabilities': {}


### PR DESCRIPTION
We only actually update the server settings when starting the server, so
only read them from the config when starting the server.

This incidentally fixes a bug in the clangd completer where settings
were always {} due to calling ServerReset (via _Reset()) immediately
prior to starting the server.

NOTE: LSP supports a didChangeConfiguration notification which we could
send should the settings change, but we don't currently so there is no
point repeatedly calling the user's Settings method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1167)
<!-- Reviewable:end -->
