### PR TITLE
[READY] Remove unused regex in server_utils

### DIFF
--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -28,7 +28,6 @@ import sys
 
 ROOT_DIR = p.normpath( p.join( p.dirname( __file__ ), '..' ) )
 DIR_OF_THIRD_PARTY = p.join( ROOT_DIR, 'third_party' )
-DIR_PACKAGES_REGEX = re.compile( '(site|dist)-packages$' )
 PYTHON_STDLIB_ZIP_REGEX = re.compile( 'python[23][0-9]\\.zip' )
 
 


### PR DESCRIPTION
The `DIR_PACKAGES_REGEX` variable is not used since PR https://github.com/Valloric/ycmd/pull/578.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1170)
<!-- Reviewable:end -->
