### PR TITLE
Ignore UnicodeDecodeError

### DIFF
--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -484,8 +484,11 @@ def BuildExtraData( completion_data ):
   fixit = completion_data.fixit_
   if fixit.chunks:
     extra_data.update( responses.BuildFixItResponse( [ fixit ] ) )
-  if completion_data.DocString():
-    extra_data[ 'doc_string' ] = completion_data.DocString()
+  try:
+    if completion_data.DocString():
+      extra_data[ 'doc_string' ] = completion_data.DocString()
+  except UnicodeDecodeError:
+    pass
   return extra_data
 
 


### PR DESCRIPTION
ERROR - Exception from semantic completer (using general): Traceback (most recent call last):
  File "/home/lonny/.vim/plugged/YouCompleteMe/third_party/ycmd/ycmd/handlers.py", line 103, in GetCompletions
    .ComputeCandidates( request_data ) )
  File "/home/lonny/.vim/plugged/YouCompleteMe/third_party/ycmd/ycmd/completers/completer.py", line 231, in ComputeCandidates
    candidates = self._GetCandidatesFromSubclass( request_data )
  File "/home/lonny/.vim/plugged/YouCompleteMe/third_party/ycmd/ycmd/completers/completer.py", line 242, in _GetCandidatesFromSubclass
    raw_completions = self.ComputeCandidatesInner( request_data )
  File "/home/lonny/.vim/plugged/YouCompleteMe/third_party/ycmd/ycmd/completers/cpp/clang_completer.py", line 171, in ComputeCandidatesInner
    return [ ConvertCompletionData( x ) for x in results ]
  File "/home/lonny/.vim/plugged/YouCompleteMe/third_party/ycmd/ycmd/completers/cpp/clang_completer.py", line 171, in <listcomp>
    return [ ConvertCompletionData( x ) for x in results ]
  File "/home/lonny/.vim/plugged/YouCompleteMe/third_party/ycmd/ycmd/completers/cpp/clang_completer.py", line 501, in ConvertCompletionData
    extra_data = BuildExtraData( completion_data ) )
  File "/home/lonny/.vim/plugged/YouCompleteMe/third_party/ycmd/ycmd/completers/cpp/clang_completer.py", line 489, in BuildExtraData
    if completion_data.DocString():
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xca in position 0: invalid continuation byte

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1173)
<!-- Reviewable:end -->
