### PR TITLE
[READY] Report java server startup status correctly

### DIFF
--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -363,6 +363,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
 
     self._server_handle = None
     self._connection = None
+    self._started_message_sent = False
 
     self.ServerReset()
 
@@ -502,9 +503,10 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
 
       if message_type == 'Started':
         LOGGER.info( 'jdt.ls initialized successfully' )
+        self._server_init_status = notification[ 'params' ][ 'message' ]
         self._received_ready_message.set()
-
-      self._server_init_status = notification[ 'params' ][ 'message' ]
+      elif not self._received_ready_message.is_set():
+        self._server_init_status = notification[ 'params' ][ 'message' ]
 
     super( JavaCompleter, self ).HandleNotificationInPollThread( notification )
 
@@ -512,8 +514,14 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
   def ConvertNotificationToMessage( self, request_data, notification ):
     if notification[ 'method' ] == 'language/status':
       message = notification[ 'params' ][ 'message' ]
-      return responses.BuildDisplayMessageResponse(
-        'Initializing Java completer: {0}'.format( message ) )
+      if notification[ 'params' ][ 'type' ] == 'Started':
+        self._started_message_sent = True
+        return responses.BuildDisplayMessageResponse(
+          'Initializing Java completer: {0}'.format( message ) )
+
+      if not self._started_message_sent:
+        return responses.BuildDisplayMessageResponse(
+          'Initializing Java completer: {0}'.format( message ) )
 
     return super( JavaCompleter, self ).ConvertNotificationToMessage(
       request_data,

--- a/ycmd/tests/java/debug_info_test.py
+++ b/ycmd/tests/java/debug_info_test.py
@@ -48,7 +48,7 @@ def DebugInfo_test( app ):
                               instance_of( str ) ),
         'extras': contains(
           has_entries( { 'key': 'Startup Status',
-                         'value': instance_of( str ) } ),
+                         'value': 'Ready' } ),
           has_entries( { 'key': 'Java Path',
                          'value': instance_of( str ) } ),
           has_entries( { 'key': 'Launcher Config.',


### PR DESCRIPTION
Since some recent jdt.ls version, we always seem to receive a
'language/status' message type 'Starting' (100%) _after_ we receive the
'language/status' message with type 'Started'. This makes the server
look like it is still initializing although it is really ready to go.

We work around this dodgy message sequence by ignoring anything received
after 'Started'.