### PR TITLE
[READY] Go back to testing on Python 2.7.2 on Travis-CI

### DIFF
--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -56,10 +56,7 @@ if [ "${YCMD_PYTHON_VERSION}" == "2.7" ]; then
   # Tests are failing on Python 2.7.0 with the exception "TypeError: argument
   # can't be <type 'unicode'>" and importing the coverage module fails on Python
   # 2.7.1.
-  # FIXME: pip 10 fails to upgrade packages on Python 2.7.3 or older. See
-  # https://github.com/pypa/pip/issues/5231 for the error. Revert to 2.7.2 once
-  # this is fixed in pip.
-  PYENV_VERSION="2.7.4"
+  PYENV_VERSION="2.7.2"
 else
   PYENV_VERSION="3.4.0"
 fi


### PR DESCRIPTION
Currently we test with python 2.7.4, because `pip` broke everything under the sun when version 10 came out. Back then what broke python 2.7.3 and earlier is [this bug](https://github.com/pypa/pip/issues/5231).

Since the bug is fixed, we can test 2.7.2 again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1176)
<!-- Reviewable:end -->
