### PR TITLE
[READY] Make LSP debug info consistent

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -218,12 +218,12 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
 
   def DebugInfo( self, request_data ):
     with self._server_state_mutex:
-      clangd = responses.DebugInfoServer(
-        name = 'clangd',
-        handle = self._server_handle,
-        executable = self._clangd_command,
-        logfiles = [ self._stderr_file ]
-      )
+      clangd = responses.DebugInfoServer( name = 'clangd',
+                                          handle = self._server_handle,
+                                          executable = self._clangd_command,
+                                          logfiles = [ self._stderr_file ],
+                                          extras = self.CommonDebugItems() )
+
       return responses.BuildDebugInfoResponse( name = 'clangd',
                                                servers = [ clangd ] )
 

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -266,13 +266,11 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       responses.DebugInfoItem( 'Launcher Config.', self._launcher_config ),
     ]
 
-    if self._project_dir:
-      items.append( responses.DebugInfoItem( 'Project Directory',
-                                             self._project_dir ) )
-
     if self._workspace_path:
       items.append( responses.DebugInfoItem( 'Workspace Path',
                                              self._workspace_path ) )
+
+    items.extend( self.CommonDebugItems() )
 
     return responses.BuildDebugInfoResponse(
       name = "Java",
@@ -306,7 +304,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
 
 
   def _GetProjectDirectory( self, request_data ):
-    return self._project_dir
+    return self._java_project_dir
 
 
   def _ServerIsRunning( self ):
@@ -356,7 +354,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
     self._launcher_path = _PathToLauncherJar()
     self._launcher_config = _LauncherConfiguration()
     self._workspace_path = None
-    self._project_dir = None
+    self._java_project_dir = None
     self._received_ready_message = threading.Event()
     self._server_init_status = 'Not started'
     self._server_started = False
@@ -382,13 +380,13 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       LOGGER.info( 'Starting jdt.ls Language Server...' )
 
       if project_directory:
-        self._project_dir = project_directory
+        self._java_project_dir = project_directory
       else:
-        self._project_dir = _FindProjectDir(
+        self._java_project_dir = _FindProjectDir(
           os.path.dirname( request_data[ 'filepath' ] ) )
 
       self._workspace_path = _WorkspaceDirForProject(
-        self._project_dir,
+        self._java_project_dir,
         self._use_clean_workspace )
 
       command = [

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -672,6 +672,7 @@ class LanguageServerCompleter( Completer ):
       self._on_initialize_complete_handlers = []
       self._server_capabilities = None
       self._resolve_completion_items = False
+      self._project_directory = None
       self._settings = {}
 
 
@@ -1280,8 +1281,9 @@ class LanguageServerCompleter( Completer ):
       request_id = self.GetConnection().NextRequestId()
 
       self._GetSettingsFromExtraConf( request_data )
+      self._project_directory = self._GetProjectDirectory( request_data )
       msg = lsp.Initialize( request_id,
-                            self._GetProjectDirectory( request_data ),
+                            self._project_directory,
                             self._settings )
 
       def response_handler( response, message ):
@@ -1559,6 +1561,22 @@ class LanguageServerCompleter( Completer ):
                                                  message,
                                                  REQUEST_TIMEOUT_COMMAND )
     return response[ 'result' ]
+
+
+  def CommonDebugItems( self ):
+    def ServerStateDescription():
+      if not self.ServerIsHealthy():
+        return 'Dead'
+
+      if not self.ServerIsReady():
+        return 'Starting...'
+
+      return 'Initialized'
+
+    return [ responses.DebugInfoItem( 'Server State',
+                                      ServerStateDescription() ),
+             responses.DebugInfoItem( 'Project Directory',
+                                      self._project_directory ) ]
 
 
 def _CompletionItemToCompletionData( insertion_text, item, fixits ):

--- a/ycmd/tests/clangd/debug_info_test.py
+++ b/ycmd/tests/clangd/debug_info_test.py
@@ -39,11 +39,21 @@ def DebugInfo_NotInitialized_test( app ):
     has_entry( 'completer', has_entries( {
       'name': 'clangd',
       'servers': contains( has_entries( {
-          'name': 'clangd',
-          'pid': None,
-          'is_running': False
+        'name': 'clangd',
+        'pid': None,
+        'is_running': False,
+        'extras': contains(
+          has_entries( {
+            'key': 'Server State',
+            'value': 'Dead',
+          } ),
+          has_entries( {
+            'key': 'Project Directory',
+            'value': None,
+          } ),
+        ),
       } ) ),
-      'items': empty()
+      'items': empty(),
     } ) )
   )
 
@@ -59,8 +69,18 @@ def DebugInfo_Initialized_test( app ):
     has_entry( 'completer', has_entries( {
       'name': 'clangd',
       'servers': contains( has_entries( {
-          'name': 'clangd',
-          'is_running': True
+        'name': 'clangd',
+        'is_running': True,
+        'extras': contains(
+          has_entries( {
+            'key': 'Server State',
+            'value': 'Initialized',
+          } ),
+          has_entries( {
+            'key': 'Project Directory',
+            'value': PathToTestFile(),
+          } ),
+        ),
       } ) ),
       'items': empty()
     } ) )

--- a/ycmd/tests/java/debug_info_test.py
+++ b/ycmd/tests/java/debug_info_test.py
@@ -28,7 +28,7 @@ from hamcrest import ( assert_that,
                        has_entries,
                        instance_of )
 
-from ycmd.tests.java import SharedYcmd
+from ycmd.tests.java import SharedYcmd, PathToTestFile, DEFAULT_PROJECT_DIR
 from ycmd.tests.test_utils import BuildRequest
 
 
@@ -53,10 +53,12 @@ def DebugInfo_test( app ):
                          'value': instance_of( str ) } ),
           has_entries( { 'key': 'Launcher Config.',
                          'value': instance_of( str ) } ),
-          has_entries( { 'key': 'Project Directory',
-                         'value': instance_of( str ) } ),
           has_entries( { 'key': 'Workspace Path',
-                         'value': instance_of( str ) } )
+                         'value': instance_of( str ) } ),
+          has_entries( { 'key': 'Server State',
+                         'value': 'Initialized' } ),
+          has_entries( { 'key': 'Project Directory',
+                         'value': PathToTestFile( DEFAULT_PROJECT_DIR ) } )
         )
       } ) )
     } ) )


### PR DESCRIPTION
Include server startup state and working directory in all LSP
completers. Migrate java completer to use this rather than
including its own.

This is step 1 in refactoring the LSP completer to make it easy to add new ones.