### PR TITLE
[NOT READY] Improve the project directory detection

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -218,12 +218,12 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
 
   def DebugInfo( self, request_data ):
     with self._server_state_mutex:
-      clangd = responses.DebugInfoServer(
-        name = 'clangd',
-        handle = self._server_handle,
-        executable = self._clangd_command,
-        logfiles = [ self._stderr_file ]
-      )
+      clangd = responses.DebugInfoServer( name = 'clangd',
+                                          handle = self._server_handle,
+                                          executable = self._clangd_command,
+                                          logfiles = [ self._stderr_file ],
+                                          extras = self.CommonDebugItems() )
+
       return responses.BuildDebugInfoResponse( name = 'clangd',
                                                servers = [ clangd ] )
 

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -266,13 +266,11 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       responses.DebugInfoItem( 'Launcher Config.', self._launcher_config ),
     ]
 
-    if self._project_dir:
-      items.append( responses.DebugInfoItem( 'Project Directory',
-                                             self._project_dir ) )
-
     if self._workspace_path:
       items.append( responses.DebugInfoItem( 'Workspace Path',
                                              self._workspace_path ) )
+
+    items.extend( self.CommonDebugItems() )
 
     return responses.BuildDebugInfoResponse(
       name = "Java",
@@ -306,7 +304,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
 
 
   def _GetProjectDirectory( self, request_data ):
-    return self._project_dir
+    return self._java_project_dir
 
 
   def _ServerIsRunning( self ):
@@ -356,7 +354,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
     self._launcher_path = _PathToLauncherJar()
     self._launcher_config = _LauncherConfiguration()
     self._workspace_path = None
-    self._project_dir = None
+    self._java_project_dir = None
     self._received_ready_message = threading.Event()
     self._server_init_status = 'Not started'
     self._server_started = False
@@ -382,13 +380,13 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       LOGGER.info( 'Starting jdt.ls Language Server...' )
 
       if project_directory:
-        self._project_dir = project_directory
+        self._java_project_dir = project_directory
       else:
-        self._project_dir = _FindProjectDir(
+        self._java_project_dir = _FindProjectDir(
           os.path.dirname( request_data[ 'filepath' ] ) )
 
       self._workspace_path = _WorkspaceDirForProject(
-        self._project_dir,
+        self._java_project_dir,
         self._use_clean_workspace )
 
       command = [

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -303,7 +303,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
              super( JavaCompleter, self ).ServerIsReady() )
 
 
-  def _GetProjectDirectory( self, request_data ):
+  def _GetProjectDirectory( self, *args, **kwargs ):
     return self._java_project_dir
 
 

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -672,6 +672,7 @@ class LanguageServerCompleter( Completer ):
       self._on_initialize_complete_handlers = []
       self._server_capabilities = None
       self._resolve_completion_items = False
+      self._project_directory = None
       self._settings = {}
 
 
@@ -1280,8 +1281,9 @@ class LanguageServerCompleter( Completer ):
       request_id = self.GetConnection().NextRequestId()
 
       self._GetSettingsFromExtraConf( request_data )
+      self._project_directory = self._GetProjectDirectory( request_data )
       msg = lsp.Initialize( request_id,
-                            self._GetProjectDirectory( request_data ),
+                            self._project_directory,
                             self._settings )
 
       def response_handler( response, message ):
@@ -1559,6 +1561,22 @@ class LanguageServerCompleter( Completer ):
                                                  message,
                                                  REQUEST_TIMEOUT_COMMAND )
     return response[ 'result' ]
+
+
+  def CommonDebugItems( self ):
+    def ServerStateDescription():
+      if not self.ServerIsHealthy():
+        return 'Dead'
+
+      if not self.ServerIsReady():
+        return 'Starting...'
+
+      return 'Initialized'
+
+    return [ responses.DebugInfoItem( 'Server State',
+                                      ServerStateDescription() ),
+             responses.DebugInfoItem( 'Project Directory',
+                                      self._project_directory ) ]
 
 
 def _CompletionItemToCompletionData( insertion_text, item, fixits ):

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -940,7 +940,12 @@ class LanguageServerCompleter( Completer ):
     if module:
       settings = self._GetSettings( module, request_data[ 'extra_conf_data' ] )
       self._settings = settings.get( 'ls', {} )
+      # Only return the dir if it was found in the paths; we don't want to use
+      # the path of the global extra conf as a project root dir.
+      if not extra_conf_store.IsGlobalExtraConfModule( module ):
+        return os.path.dirname( module.__file__ )
 
+    return None
 
   def OnFileReadyToParse( self, request_data ):
     self.StartServer( request_data )
@@ -1259,12 +1264,23 @@ class LanguageServerCompleter( Completer ):
     del self._server_file_state[ file_state.filename ]
 
 
-  def _GetProjectDirectory( self, request_data ):
+  def _GetProjectDirectory( self, request_data, extra_conf_dir ):
     """Return the directory in which the server should operate. Language server
-    protocol and most servers have a concept of a 'project directory'. By
-    default this is the filepath directory of the initial request, but
-    implementations may override this for example if there is a language- or
-    server-specific notion of a project that can be detected."""
+    protocol and most servers have a concept of a 'project directory'. Where a
+    concrete completer can detect this better, it should override this method,
+    but otherwise, we default as follows:
+      - if there's an extra_conf file, use that directory
+      - otherwise if we know the client's cwd, use that
+      - otherwise use the diretory of the file that we just opened
+    Note: None of these are ideal. Ycmd doesn't really have a notion of project
+    directory and therefore neither do any of our clients."""
+
+    if extra_conf_dir:
+      return extra_conf_dir
+
+    if 'working_dir' in request_data:
+      return request_data[ 'working_dir' ]
+
     return os.path.dirname( request_data[ 'filepath' ] )
 
 
@@ -1280,8 +1296,9 @@ class LanguageServerCompleter( Completer ):
 
       request_id = self.GetConnection().NextRequestId()
 
-      self._GetSettingsFromExtraConf( request_data )
-      self._project_directory = self._GetProjectDirectory( request_data )
+      extra_conf_dir = self._GetSettingsFromExtraConf( request_data )
+      self._project_directory = self._GetProjectDirectory( request_data,
+                                                           extra_conf_dir )
       msg = lsp.Initialize( request_id,
                             self._project_directory,
                             self._settings )

--- a/ycmd/extra_conf_store.py
+++ b/ycmd/extra_conf_store.py
@@ -232,3 +232,10 @@ def _RandomName():
 def _GlobalYcmExtraConfFileLocation():
   return ExpandVariablesInPath(
     user_options_store.Value( 'global_ycm_extra_conf' ) )
+
+
+def IsGlobalExtraConfModule( module ):
+  try:
+    return module.is_global_ycm_extra_conf
+  except AttributeError:
+    return False

--- a/ycmd/tests/clangd/debug_info_test.py
+++ b/ycmd/tests/clangd/debug_info_test.py
@@ -39,11 +39,21 @@ def DebugInfo_NotInitialized_test( app ):
     has_entry( 'completer', has_entries( {
       'name': 'clangd',
       'servers': contains( has_entries( {
-          'name': 'clangd',
-          'pid': None,
-          'is_running': False
+        'name': 'clangd',
+        'pid': None,
+        'is_running': False,
+        'extras': contains(
+          has_entries( {
+            'key': 'Server State',
+            'value': 'Dead',
+          } ),
+          has_entries( {
+            'key': 'Project Directory',
+            'value': None,
+          } ),
+        ),
       } ) ),
-      'items': empty()
+      'items': empty(),
     } ) )
   )
 
@@ -59,8 +69,18 @@ def DebugInfo_Initialized_test( app ):
     has_entry( 'completer', has_entries( {
       'name': 'clangd',
       'servers': contains( has_entries( {
-          'name': 'clangd',
-          'is_running': True
+        'name': 'clangd',
+        'is_running': True,
+        'extras': contains(
+          has_entries( {
+            'key': 'Server State',
+            'value': 'Initialized',
+          } ),
+          has_entries( {
+            'key': 'Project Directory',
+            'value': PathToTestFile(),
+          } ),
+        ),
       } ) ),
       'items': empty()
     } ) )

--- a/ycmd/tests/extra_conf_store_test.py
+++ b/ycmd/tests/extra_conf_store_test.py
@@ -29,7 +29,7 @@ from hamcrest import ( assert_that, calling, equal_to, has_length, has_property,
                        none, raises, same_instance )
 from ycmd import extra_conf_store
 from ycmd.responses import UnknownExtraConf
-from ycmd.tests import IsolatedYcmd, PathToTestFile
+from ycmd.tests import IsolatedYcmd, PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import TemporarySymlink, UnixOnly, WindowsOnly
 
 
@@ -57,6 +57,8 @@ def ExtraConfStore_ModuleForSourceFile_NoConfirmation_test( app ):
   assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
   assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
   assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
+  assert_that( extra_conf_store.IsGlobalExtraConfModule( module ),
+               equal_to( False ) )
 
 
 @IsolatedYcmd( { 'extra_conf_globlist': [ PROJECT_EXTRA_CONF ] } )
@@ -67,6 +69,8 @@ def ExtraConfStore_ModuleForSourceFile_Whitelisted_test( app ):
   assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
   assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
   assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
+  assert_that( extra_conf_store.IsGlobalExtraConfModule( module ),
+               equal_to( False ) )
 
 
 @IsolatedYcmd( { 'extra_conf_globlist': [ '!' + PROJECT_EXTRA_CONF ] } )
@@ -84,6 +88,8 @@ def ExtraConfStore_ModuleForSourceFile_UnixVarEnv_test( app ):
   assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
   assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
   assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
+  assert_that( extra_conf_store.IsGlobalExtraConfModule( module ),
+               equal_to( False ) )
 
 
 @WindowsOnly
@@ -96,6 +102,8 @@ def ExtraConfStore_ModuleForSourceFile_WinVarEnv_test( app ):
   assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
   assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
   assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
+  assert_that( extra_conf_store.IsGlobalExtraConfModule( module ),
+               equal_to( False ) )
 
 
 @UnixOnly
@@ -110,6 +118,8 @@ def ExtraConfStore_ModuleForSourceFile_SupportSymlink_test( app ):
     assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
     assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
     assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
+  assert_that( extra_conf_store.IsGlobalExtraConfModule( module ),
+               equal_to( False ) )
 
 
 @IsolatedYcmd( { 'global_ycm_extra_conf': GLOBAL_EXTRA_CONF } )
@@ -120,6 +130,8 @@ def ExtraConfStore_ModuleForSourceFile_GlobalExtraConf_test( app ):
   assert_that( inspect.getfile( module ), equal_to( GLOBAL_EXTRA_CONF ) )
   assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
   assert_that( module.is_global_ycm_extra_conf, equal_to( True ) )
+  assert_that( extra_conf_store.IsGlobalExtraConfModule( module ),
+               equal_to( True ) )
 
 
 @patch.dict( 'os.environ', { 'YCMD_TEST': GLOBAL_EXTRA_CONF } )
@@ -131,6 +143,8 @@ def ExtraConfStore_ModuleForSourceFile_GlobalExtraConf_UnixEnvVar_test( app ):
   assert_that( inspect.getfile( module ), equal_to( GLOBAL_EXTRA_CONF ) )
   assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
   assert_that( module.is_global_ycm_extra_conf, equal_to( True ) )
+  assert_that( extra_conf_store.IsGlobalExtraConfModule( module ),
+               equal_to( True ) )
 
 
 @WindowsOnly
@@ -143,6 +157,8 @@ def ExtraConfStore_ModuleForSourceFile_GlobalExtraConf_WinEnvVar_test( app ):
   assert_that( inspect.getfile( module ), equal_to( GLOBAL_EXTRA_CONF ) )
   assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
   assert_that( module.is_global_ycm_extra_conf, equal_to( True ) )
+  assert_that( extra_conf_store.IsGlobalExtraConfModule( module ),
+               equal_to( True ) )
 
 
 @IsolatedYcmd( { 'global_ycm_extra_conf': NO_EXTRA_CONF } )
@@ -210,6 +226,8 @@ def Load_DoNotReloadExtraConf_NoForce_test( app ):
     assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
     assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
     assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
+    assert_that( extra_conf_store.IsGlobalExtraConfModule( module ),
+                 equal_to( False ) )
     assert_that(
       extra_conf_store.Load( PROJECT_EXTRA_CONF ),
       same_instance( module )
@@ -224,7 +242,15 @@ def Load_DoNotReloadExtraConf_ForceEqualsTrue_test( app ):
     assert_that( inspect.getfile( module ), equal_to( PROJECT_EXTRA_CONF ) )
     assert_that( module, has_property( 'is_global_ycm_extra_conf' ) )
     assert_that( module.is_global_ycm_extra_conf, equal_to( False ) )
+    assert_that( extra_conf_store.IsGlobalExtraConfModule( module ),
+                 equal_to( False ) )
     assert_that(
       extra_conf_store.Load( PROJECT_EXTRA_CONF, force = True ),
       same_instance( module )
     )
+
+
+@SharedYcmd
+def ExtraConfStore_IsGlobalExtraConfStore_NotAExtraConf_test( app ):
+  assert_that( extra_conf_store.IsGlobalExtraConfModule( extra_conf_store ),
+               equal_to( False ) )

--- a/ycmd/tests/java/debug_info_test.py
+++ b/ycmd/tests/java/debug_info_test.py
@@ -28,7 +28,7 @@ from hamcrest import ( assert_that,
                        has_entries,
                        instance_of )
 
-from ycmd.tests.java import SharedYcmd
+from ycmd.tests.java import SharedYcmd, PathToTestFile, DEFAULT_PROJECT_DIR
 from ycmd.tests.test_utils import BuildRequest
 
 
@@ -53,10 +53,12 @@ def DebugInfo_test( app ):
                          'value': instance_of( str ) } ),
           has_entries( { 'key': 'Launcher Config.',
                          'value': instance_of( str ) } ),
-          has_entries( { 'key': 'Project Directory',
-                         'value': instance_of( str ) } ),
           has_entries( { 'key': 'Workspace Path',
-                         'value': instance_of( str ) } )
+                         'value': instance_of( str ) } ),
+          has_entries( { 'key': 'Server State',
+                         'value': 'Initialized' } ),
+          has_entries( { 'key': 'Project Directory',
+                         'value': PathToTestFile( DEFAULT_PROJECT_DIR ) } )
         )
       } ) )
     } ) )

--- a/ycmd/tests/language_server/__init__.py
+++ b/ycmd/tests/language_server/__init__.py
@@ -26,7 +26,9 @@ import functools
 import os
 
 from ycmd.completers.language_server import language_server_completer as lsc
-from ycmd.tests.test_utils import IsolatedApp, StopCompleterServer
+from ycmd.tests.test_utils import ( IgnoreExtraConfOutsideTestsFolder,
+                                    IsolatedApp,
+                                    StopCompleterServer )
 
 
 def PathToTestFile( *args ):
@@ -63,10 +65,11 @@ def IsolatedYcmd( custom_options = {} ):
   def Decorator( test ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
-      with IsolatedApp( custom_options ) as app:
-        try:
-          test( app, *args, **kwargs )
-        finally:
-          StopCompleterServer( app, 'foo' )
+      with IgnoreExtraConfOutsideTestsFolder():
+        with IsolatedApp( custom_options ) as app:
+          try:
+            test( app, *args, **kwargs )
+          finally:
+            StopCompleterServer( app, 'foo' )
     return Wrapper
   return Decorator


### PR DESCRIPTION
NOTE: Do not merge yet: depends on #1177 

In LSP's view of the world, everything has a project root directory.
Currently we dumbly use the path of the first file opened as the root
unless the completer implementation does something smarter. For example,
the java completer tries to find a project config file.

We now try and guess a project directory using the following hierarchy:
 - extra conf dir if it is not the global extra conf
 - client working dir
 - dir of first opened file

Other LSP servers legitimately expect a reasonable project directory to
be supplied on initialisation. Clangd presumably doesn't because it uses
the path of the compile_commands.json that _it finds itself_. Therefore,
this change should have no effect on real use cases of existing uses.

This is change 2 in the batch of changes to simplify LSP completer 
additions.