### PR TITLE
[READY] Determine simple subcommands automatically

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -240,26 +240,11 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
     return self.GetHoverResponse( request_data )[ 'value' ]
 
 
-  def GetSubcommandsMap( self ):
+  def GetCustomSubcommands( self ):
     return {
-      # Handled by base class.
-      'GoToDefinition': (
-        lambda self, request_data, args: self.GoToDeclaration( request_data )
-      ),
       'FixIt': (
         lambda self, request_data, args: self.GetCodeActions( request_data,
                                                               args )
-      ),
-      'GoTo': (
-        lambda self, request_data, args: self.GoToDeclaration( request_data )
-      ),
-      # This is actually GoToDefinition, LSP does not support GoToDeclaration
-      # and clangd currently does not have extensions for that.
-      'GoToDeclaration': (
-        lambda self, request_data, args: self.GoToDeclaration( request_data )
-      ),
-      'GoToImprecise': (
-        lambda self, request_data, args: self.GoToDeclaration( request_data )
       ),
       'GetType': (
         # In addition to type information we show declaration.
@@ -291,6 +276,8 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
         request_data,
         command[ 'arguments' ][ 0 ],
         text = command[ 'title' ] )
+
+    return None
 
 
   def GetCodepointForCompletionRequest( self, request_data ):

--- a/ycmd/tests/clangd/__init__.py
+++ b/ycmd/tests/clangd/__init__.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 from builtins import *  # noqa
 
 import functools
+import json
 import os
 
 from hamcrest import assert_that
@@ -158,6 +159,8 @@ def RunAfterInitialized( app, test ):
                               expect_errors = expect_errors )
 
   if 'expect' in test:
+    print( "Completer response: {}".format( json.dumps( response.json,
+                                                        indent = 2 ) ) )
     eq_( response.status_code, test[ 'expect' ][ 'response' ] )
     assert_that( response.json, test[ 'expect' ][ 'data' ] )
   return response.json

--- a/ycmd/tests/clangd/testdata/basic.cpp
+++ b/ycmd/tests/clangd/testdata/basic.cpp
@@ -11,3 +11,14 @@ int main()
   foo.
 }
 
+
+static Foo test_function_that_has_no_errors()
+{
+  Foo foo = { 1,2,'c'};
+  if (foo.c ) {
+    foo.x = 1;
+    foo.y = 2;
+  }
+
+  return foo;
+}


### PR DESCRIPTION
# Determine simple subcommands automatically

LSP supports a 'capabilities' machanism where servers and clients can
identify support for certain requests. This implements a general
mechanism for discovery of supported subcommands, and standardises the
commands supported by LSP-based completers (other than Java).

Clangd completer is updated to use the general mechanism, as its
capabilities response is correct.  Java completer is a little more
complicated, so is not migrated in this change.

This will make adding basic completers much easier in future.


# RefactorRename in clangd

As a (happy?) co-incidence, this adds `RefactorRename` support to clangd.

Strangely though, the one test I wrote shows up a bug in clangd. cc @kadircet 

```
ycmd: DEBUG: RX: Received message: b'{"id":"2","jsonrpc":"2.0","result":{"changes":{"file:///Users/ben/.vim/bundle/YouCompleteMe/third_party/ycmd/ycmd/tests/clangd/testdata/basic.cpp":[{"newText":"Bar","range":{"end":{"character":10,"line":0},"start":{"character":7,"line":0}}},{"newText":"Bar","range":{"end":{"character":5,"line":8},"start":{"character":2,"line":8}}},{"newText":"Bar","range":{"end":{"character":10,"line":14},"start":{"character":7,"line":14}}},{"newText":"Bar","range":{"end":{"character":10,"line":14},"start":{"character":7,"line":14}}},{"newText":"Bar","range":{"end":{"character":5,"line":16},"start":{"character":2,"line":16}}}]}}}’
```

@kadircet the above is invalid because these overlap (and are clearly duplicated)

```
{"newText":"Bar","range":{"end":{"character":10,"line":14},"start":{"character":7,"line":14}}},
{"newText":"Bar","range":{"end":{"character":10,"line":14},"start":{"character":7,"line":14}}},
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1179)
<!-- Reviewable:end -->