### PR TITLE
[READY] Trigger semantic completion when instructed by server

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -240,6 +240,13 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
     return self.GetHoverResponse( request_data )[ 'value' ]
 
 
+  def GetTriggerCharacters( self, server_trigger_characters ):
+    # The trigger characters supplied by clangd are worse than ycmd's own
+    # semantic triggers (which are more sophisticated and regex-based. So we
+    # ignore them.
+    return []
+
+
   def GetSubcommandsMap( self ):
     return {
       # Handled by base class.

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -584,6 +584,12 @@ class LanguageServerCompleter( Completer ):
         - NOTE: The server's StartServer must not do anything if the server has
           already been started.
       - Language : a string used to identify the language in user's extra conf
+    - Optionally override methods to customise behavior:
+      - _GetProjectDirectory
+      - _GetTriggerCharacters
+      _ GetDefaultNotificationHandler
+      - HandleNotificationInPollThread
+      - ConvertNotificationToMessage
 
   Startup
 
@@ -1298,6 +1304,17 @@ class LanguageServerCompleter( Completer ):
         response_handler )
 
 
+  def _GetTriggerCharacters( self, server_trigger_characters ):
+    """Given the sever trigger characters supplied in the initialize response,
+    returns the trigger characters to merge with the ycmd-defined ones. By
+    default, all server trigger characters are merged in. Note this might not be
+    appropriate in all cases as ycmd's own triggering mechanism is more
+    sophisticated (regex based) than LSP's (single character). If the
+    server-supplied single-character triggers are not useful, override this
+    method to return an empty list or None."""
+    return server_trigger_characters
+
+
   def _HandleInitializeInPollThread( self, response ):
     """Called within the context of the LanguageServerConnection's message pump
     when the initialize request receives a response."""
@@ -1326,6 +1343,27 @@ class LanguageServerCompleter( Completer ):
         self._sync_type = SYNC_TYPE[ sync ]
         LOGGER.info( 'Language server requires sync type of %s',
                      self._sync_type )
+
+      # Update our semantic triggers if they are supplied by the server
+      if self.prepared_triggers is not None:
+        server_trigger_characters = (
+          ( self._server_capabilities.get( 'completionProvider' ) or {} )
+                                     .get( 'triggerCharacters' ) or []
+        )
+        LOGGER.debug( '%s: Server declares trigger characters: %s',
+                      self.Language(),
+                      server_trigger_characters )
+
+        trigger_characters = self._GetTriggerCharacters(
+          server_trigger_characters )
+
+        if trigger_characters:
+          LOGGER.info( '%s: Using trigger characters for semantic triggers: %s',
+                       self.Language(),
+                       ','.join( trigger_characters ) )
+
+          self.prepared_triggers.SetServerSemanticTriggers(
+            trigger_characters )
 
       # We must notify the server that we received the initialize response (for
       # no apparent reason, other than that's what the protocol says).

--- a/ycmd/tests/java/get_completions_test.py
+++ b/ycmd/tests/java/get_completions_test.py
@@ -692,3 +692,31 @@ def GetCompletions_ForceAtTopLevel_WithImport_test( app ):
       } )
     },
   } )
+
+
+@SharedYcmd
+def GetCompletions_UseServerTriggers_test( app ):
+  filepath = ProjectPath( 'TestWidgetImpl.java' )
+
+  RunTest( app, {
+    'description': 'We use the semantic triggers from the server (@ here)',
+    'request': {
+      'filetype'  : 'java',
+      'filepath'  : filepath,
+      'line_num'  : 24,
+      'column_num': 7,
+      'force_semantic': False,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completion_start_column': 4,
+        'completions': has_item(
+          CompletionEntryMatcher( 'Override', None, {
+            'kind': 'Class',
+            'menu_text': 'Override - java.lang',
+          } )
+        )
+      } )
+    }
+  } )


### PR DESCRIPTION
LSP initialization exchange includes the characters that should trigger
semantic completion. We now combine those characters with our own set of
regexes and any supplied by the user.

We do this by combining both user-supplied and server-supplied triggers (and of course the  "default" triggers) in the prepared triggers structure, which is already per-completer. the merge is a strict superset per filetype supported by the completer.

The main reason for this is to make adding new completers easier (one less thing to do). However, it's actually strictly worse in some cases (c++ being a specific case). The reason for this is that LSP only supports a single character for triggers, so clangd must send `>` as a trigger character. This is a false-positive in many cases, and triggering semantic completion after, say `template < typename T >` not only makes no sense, but returns no useful completions.

So for we allow the concrete completer to manipulate the server-supplied list. In the case of clangd, we ignore it.

For Java, the list makes sense and adds useful features, such as proper completion of `@Annotations`. Added a test for this.