### PR TITLE
[READY] Fix LSP server startup when UnknownExtraConf is thrown

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -330,6 +330,10 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
       if self.ServerIsHealthy():
         return
 
+      # We have to get the settings before starting the server, as this call
+      # might throw UnknownExtraConf.
+      self._GetSettingsFromExtraConf( request_data )
+
       # Ensure we cleanup all states.
       self._Reset()
 

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -375,6 +375,10 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       if self._server_started:
         return
 
+      # We have to get the settings before starting the server, as this call
+      # might throw UnknownExtraConf.
+      self._GetSettingsFromExtraConf( request_data )
+
       self._server_started = True
 
       LOGGER.info( 'Starting jdt.ls Language Server...' )

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1378,10 +1378,8 @@ class LanguageServerCompleter( Completer ):
     with self._server_info_mutex:
       assert not self._initialize_response
 
-      request_id = self.GetConnection().NextRequestId()
-
-      self._GetSettingsFromExtraConf( request_data )
       self._project_directory = self._GetProjectDirectory( request_data )
+      request_id = self.GetConnection().NextRequestId()
       msg = lsp.Initialize( request_id,
                             self._project_directory,
                             self._settings )

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -30,10 +30,12 @@ from hamcrest import ( assert_that,
                        empty,
                        has_entries,
                        instance_of,
+                       is_not,
                        matches_regexp )
 from nose.tools import eq_
 from pprint import pformat
 import requests
+import json
 
 from ycmd.utils import ReadFile
 from ycmd.completers.java.java_completer import NO_DOCUMENTATION_MESSAGE
@@ -55,6 +57,7 @@ from ycmd.completers.language_server.language_server_completer import (
   ResponseTimeoutException,
   ResponseFailedException
 )
+from ycmd.responses import UnknownExtraConf
 
 
 
@@ -1695,6 +1698,57 @@ def Subcommands_ExtraConf_SettingsValid_test( app ):
         'fixits': contains( has_entries( {
           'chunks': empty(),
           'location': LocationMatcher( filepath, 1, 7 )
+        } ) )
+      } )
+    }
+  } )
+
+
+@IsolatedYcmd()
+def Subcommands_ExtraConf_SettingsValid_UnknownExtraConf_test( app ):
+  filepath = PathToTestFile( 'extra_confs',
+                             'simple_extra_conf_project',
+                             'src',
+                             'ExtraConf.java' )
+  contents = ReadFile( filepath )
+
+  response = app.post_json( '/event_notification',
+                            BuildRequest( **{
+                              'event_name': 'FileReadyToParse',
+                              'contents': contents,
+                              'filepath': filepath,
+                              'line_num': 1,
+                              'column_num': 7,
+                              'filetype': 'java',
+                            } ),
+                            expect_errors = True )
+
+  print( 'FileReadyToParse result: {}'.format( json.dumps( response.json,
+                                                           indent = 2 ) ) )
+
+  eq_( response.status_code, requests.codes.internal_server_error )
+  assert_that( response.json, ErrorMatcher( UnknownExtraConf ) )
+
+  app.post_json(
+    '/ignore_extra_conf_file',
+    { 'filepath': PathToTestFile( 'extra_confs', '.ycm_extra_conf.py' ) } )
+
+  RunTest( app, {
+    'description': 'RefactorRename is disabled in extra conf but ignored.',
+    'request': {
+      'command': 'RefactorRename',
+      'arguments': [ 'renamed_l' ],
+      'filepath': filepath,
+      'contents': contents,
+      'line_num': 1,
+      'column_num': 7,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          # Just prove that we actually got a reasonable result
+          'chunks': is_not( empty() ),
         } ) )
       } )
     }

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -109,16 +109,7 @@ def LanguageServerCompleter_ExtraConf_SettingsReturnsNone_test( app ):
   request_data = RequestWrap( BuildRequest( filepath = filepath,
                                             filetype = 'ycmtest',
                                             contents = '' ) )
-  completer.SendInitialize( request_data )
-  eq_( {}, completer._settings )
-
-  # Simulate receipt of response and initialization complete
-  initialize_response = {
-    'result': {
-      'capabilities': {}
-    }
-  }
-  completer._HandleInitializeInPollThread( initialize_response )
+  completer._GetSettingsFromExtraConf( request_data )
   eq_( {}, completer._settings )
 
 
@@ -133,16 +124,7 @@ def LanguageServerCompleter_ExtraConf_SettingValid_test( app ):
                                             contents = '' ) )
 
   eq_( {}, completer._settings )
-  completer.SendInitialize( request_data )
-  eq_( { 'java.rename.enabled' : False }, completer._settings )
-
-  # Simulate receipt of response and initialization complete
-  initialize_response = {
-    'result': {
-      'capabilities': {}
-    }
-  }
-  completer._HandleInitializeInPollThread( initialize_response )
+  completer._GetSettingsFromExtraConf( request_data )
   eq_( { 'java.rename.enabled' : False }, completer._settings )
 
 
@@ -156,7 +138,7 @@ def LanguageServerCompleter_ExtraConf_NoExtraConf_test( app ):
                                             contents = '' ) )
 
   eq_( {}, completer._settings )
-  completer.SendInitialize( request_data )
+  completer._GetSettingsFromExtraConf( request_data )
   eq_( {}, completer._settings )
 
   # Simulate receipt of response and initialization complete
@@ -443,6 +425,7 @@ def LanguageServerCompleter_DelayedInitialization_test( app ):
 
   with patch.object( completer, '_UpdateServerWithFileContents' ) as update:
     with patch.object( completer, '_PurgeFileFromServer' ) as purge:
+      completer._GetSettingsFromExtraConf( request_data )
       completer.SendInitialize( request_data )
       completer.OnFileReadyToParse( request_data )
       completer.OnBufferUnload( request_data )


### PR DESCRIPTION
The change to only load settings on initialize was flawed. In the case
where UnknownExtraConf was thrown, the server was started, but the
initialize request was not sent. This essentially left the completer
deadlocked, waiting for an initialize response that would never arrive.

The solution is to revert to requesting the settings prior to starting
the server instance, but instead of doing it on every
OnFileReadyToParse, have that concrete StartServer methods do this.

This isn't ideal, but it does solve the problem. In future, the
SimpleLSPServer will make this better, but ultimately we should probably
change it so that concrete completers don't call SendInitialize at all,
and the base class decides when to start the server and send the init.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1181)
<!-- Reviewable:end -->
