### PR TITLE
[READY] Simplify LSP completer API for starting server

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -327,13 +327,6 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
 
   def StartServer( self, request_data ):
     with self._server_state_mutex:
-      if self.ServerIsHealthy():
-        return
-
-      # We have to get the settings before starting the server, as this call
-      # might throw UnknownExtraConf.
-      extra_conf_dir = self._GetSettingsFromExtraConf( request_data )
-
       # Ensure we cleanup all states.
       self._Reset()
 
@@ -360,11 +353,11 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
         LOGGER.error( 'clangd failed to start, or did not connect '
                       'successfully' )
         self.Shutdown()
-        return
+        return False
 
     LOGGER.info( 'clangd started' )
 
-    self.SendInitialize( request_data, extra_conf_dir = extra_conf_dir )
+    return True
 
 
   def Shutdown( self ):

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -630,14 +630,13 @@ class LanguageServerCompleter( Completer ):
       - DebugInfo
       - Shutdown
       - ServerIsHealthy : Return True if the server is _running_
-      - StartServer
-        - NOTE: The server's StartServer must not do anything if the server has
-          already been started.
+      - StartServer : Return True if the server was started.
       - Language : a string used to identify the language in user's extra conf
 
   Startup
 
-  - After starting and connecting to the server, call SendInitialize
+  - Startup is initiated for you in OnFileReadyToParse
+  - The StartServer method is only called once (reset with ServerReset)
   - See also LanguageServerConnection requirements
 
   Shutdown
@@ -722,7 +721,7 @@ class LanguageServerCompleter( Completer ):
       self._resolve_completion_items = False
       self._project_directory = None
       self._settings = {}
-
+      self._server_started = False
 
   @abc.abstractmethod
   def Language( self ):
@@ -1043,12 +1042,34 @@ class LanguageServerCompleter( Completer ):
       # Only return the dir if it was found in the paths; we don't want to use
       # the path of the global extra conf as a project root dir.
       if not extra_conf_store.IsGlobalExtraConfModule( module ):
+        LOGGER.debug( 'Using path %s for extra_conf_dir',
+                      os.path.dirname( module.__file__ ) )
         return os.path.dirname( module.__file__ )
 
     return None
 
+
+  def _StartAndInitializeServer( self, request_data, *args, **kwargs ):
+    """Starts the server and sends the initialize request, assuming the start is
+    successful. |args| and |kwargs| are passed through to the underlying call to
+    StartServer. In general, completers don't need to call this as it is called
+    automatically in OnFileReadyToParse, but this may be used in completer
+    subcommands that require restarting the underlying server."""
+    extra_conf_dir = self._GetSettingsFromExtraConf( request_data )
+
+    # Only attempt to start the server once. Set this after above call as it may
+    # throw an exception
+    self._server_started = True
+
+    if self.StartServer( request_data, *args, **kwargs ):
+      self._SendInitialize( request_data, extra_conf_dir )
+
+
   def OnFileReadyToParse( self, request_data ):
-    self.StartServer( request_data )
+    if not self.ServerIsHealthy() and not self._server_started:
+      # We have to get the settings before starting the server, as this call
+      # might throw UnknownExtraConf.
+      self._StartAndInitializeServer( request_data )
 
     if not self.ServerIsHealthy():
       return
@@ -1083,7 +1104,6 @@ class LanguageServerCompleter( Completer ):
                         for diag in self._latest_diagnostics[ uri ] ]
         return responses.BuildDiagnosticResponse(
           diagnostics, filepath, self.max_diagnostics_to_display )
-
 
 
   def PollForMessagesInner( self, request_data, timeout ):
@@ -1384,16 +1404,15 @@ class LanguageServerCompleter( Completer ):
     return os.path.dirname( request_data[ 'filepath' ] )
 
 
-  def SendInitialize( self, request_data, extra_conf_dir ):
+  def _SendInitialize( self, request_data, extra_conf_dir ):
     """Sends the initialize request asynchronously.
     This must be called immediately after establishing the connection with the
     language server. Implementations must not issue further requests to the
     server until the initialize exchange has completed. This can be detected by
     calling this class's implementation of ServerIsReady.
     The extra_conf_dir parameter is the value returned from
-    _GetSettingsFromExtraConf, which must be called by concrete completers
-    manually before calling this method. It should normally be called before
-    starting the server."""
+    _GetSettingsFromExtraConf, which must be called before calling this method.
+    It is called before starting the server in OnFileReadyToParse."""
 
     with self._server_info_mutex:
       assert not self._initialize_response


### PR DESCRIPTION
We always need to get the settings, start the server, then send the
initialize request. This change hoists that code into the base class,
reducing boilerplate required by concrete classes and overall
simplifying usage. By doing so, this also prevents a loop when starting
the clangd completer fails, implementing the approach taken by java
completer.

This is the next step in simplifying LSP completer creation.

This is a follow up to #1178.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1184)
<!-- Reviewable:end -->
