### PR TITLE
[READY] Ease clangd_completer initialization

### DIFF
--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -31,7 +31,7 @@
   "racerd_binary_path": "",
   "python_binary_path": "",
   "java_jdtls_use_clean_workspace": 1,
-  "use_clangd": "Auto",
+  "use_clangd": 1,
   "clangd_binary_path": "",
   "clangd_args": [],
   "clangd_uses_ycmd_caching": 1

--- a/ycmd/tests/clang/__init__.py
+++ b/ycmd/tests/clang/__init__.py
@@ -44,7 +44,7 @@ def setUpPackage():
   subserver, should be done here."""
   global shared_app
 
-  shared_app = SetUpApp( { 'use_clangd': 'Never' } )
+  shared_app = SetUpApp( { 'use_clangd': 0 } )
 
 
 def SharedYcmd( test ):
@@ -82,7 +82,7 @@ def IsolatedYcmd( custom_options = {} ):
   def Decorator( test ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
-      custom_options.update( { 'use_clangd': 'Never' } )
+      custom_options.update( { 'use_clangd': 0 } )
       with IsolatedApp( custom_options ) as app:
         test( app, *args, **kwargs )
     return Wrapper

--- a/ycmd/tests/clangd/__init__.py
+++ b/ycmd/tests/clangd/__init__.py
@@ -55,8 +55,7 @@ def setUpPackage():
   subserver, should be done here."""
   global shared_app
 
-  user_options_with_clangd = { 'use_clangd': 'Always' }
-  shared_app = SetUpApp( user_options_with_clangd )
+  shared_app = SetUpApp()
 
 
 def tearDownPackage():
@@ -101,7 +100,6 @@ def IsolatedYcmd( custom_options = {} ):
   def Decorator( test ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
-      custom_options.update( { 'use_clangd': 'Always' } )
       with IgnoreExtraConfOutsideTestsFolder():
         with IsolatedApp( custom_options ) as app:
           clangd_completer.CLANGD_COMMAND = clangd_completer.NOT_CACHED

--- a/ycmd/tests/clangd/get_completions_test.py
+++ b/ycmd/tests/clangd/get_completions_test.py
@@ -31,8 +31,7 @@ from hamcrest import ( assert_that, contains, contains_inanyorder, empty,
                        has_item, has_items, has_entries )
 
 from ycmd.completers.cpp.clangd_completer import ( GetVersion,
-                                                   GetClangdCommand,
-                                                   GetThirdPartyClangd )
+                                                   GetClangdCommand )
 from ycmd.tests.clangd import ( IsolatedYcmd,
                                 PathToTestFile,
                                 RunAfterInitialized,
@@ -47,8 +46,7 @@ from ycmd.utils import ReadFile
 from ycmd.user_options_store import DefaultOptions
 
 Clangd8Only = skipIf(
-  GetVersion( GetClangdCommand( DefaultOptions(),
-                                GetThirdPartyClangd() )[ 0 ] ) == '7.0.0',
+  GetVersion( GetClangdCommand( DefaultOptions() )[ 0 ] ) == '7.0.0',
   'Include completion is not implemented in LLVM 7.0.0' )
 
 


### PR DESCRIPTION
- Makes `use_clangd` option binary.
  - It is no longer needed to set `use_clangd = 'Always'` after setting `clangd_binary_path` if user doesn't have clangd binary in third party folder.
- Gets rid of redundant `GetThirdPartyClangd` calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1191)
<!-- Reviewable:end -->
