### PR TITLE
[READY] Freeze flake8-comprehensions version to 1.4.1

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 flake8                >= 3.0.0
-flake8-comprehensions >= 1.4.1
+flake8-comprehensions == 1.4.1
 flake8-ycm            >= 0.1.0
 mock                  >= 1.3.0
 nose                  >= 1.3.7


### PR DESCRIPTION
`flake8-comprehensions` reports violation C408 for a dict construction that can't be rewritten with `{}` on the Python 3 build of CircleCI. See if this is caused by version 2.0.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1192)
<!-- Reviewable:end -->
