### PR TITLE
Fix system header search paths on macOS for Objective-C++, too.

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -532,7 +532,7 @@ def _GetMacSysRoot():
 
 
 def _ExtractInfoForMacIncludePaths( flags ):
-  language_is_cpp = True
+  language = 'c++'
   use_libcpp = True
   sysroot = _GetMacSysRoot()
   isysroot = None
@@ -540,9 +540,9 @@ def _ExtractInfoForMacIncludePaths( flags ):
   previous_flag = None
   for current_flag in flags:
     if previous_flag == '-x':
-      language_is_cpp = current_flag == 'c++'
+      language = current_flag
     if current_flag.startswith( '-x' ):
-      language_is_cpp = current_flag[ 2: ] == 'c++'
+      language = current_flag[ 2: ]
     if current_flag.startswith( '-stdlib=' ):
       use_libcpp = current_flag[ 8: ] == 'libc++'
     if previous_flag == '--sysroot':
@@ -558,6 +558,8 @@ def _ExtractInfoForMacIncludePaths( flags ):
   # -isysroot takes precedence over --sysroot.
   if isysroot:
     sysroot = isysroot
+
+  language_is_cpp = language in { 'c++', 'objective-c++' }
 
   return language_is_cpp, use_libcpp, sysroot
 

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -377,6 +377,32 @@ def FlagsForFile_AddMacIncludePaths_Toolchain_CommandLine_test():
 
 @MacOnly
 @patch( 'os.path.exists', lambda path: False )
+def FlagsForFile_AddMacIncludePaths_ObjCppLanguage_test():
+  flags_object = flags.Flags()
+
+  def Settings( **kwargs ):
+    return {
+      'flags': [ '-Wall', '-x', 'c', '-xobjective-c++' ]
+    }
+
+  with MockExtraConfModule( Settings ):
+    flags_list, _ = flags_object.FlagsForFile( '/foo' )
+    assert_that( flags_list, contains(
+      '-Wall',
+      '-x', 'c',
+      '-xobjective-c++',
+      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-isystem',    '/usr/include/c++/v1',
+      '-isystem',    '/usr/local/include',
+      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    '/usr/include',
+      '-iframework', '/System/Library/Frameworks',
+      '-iframework', '/Library/Frameworks',
+      '-fspell-checking' ) )
+
+
+@MacOnly
+@patch( 'os.path.exists', lambda path: False )
 def FlagsForFile_AddMacIncludePaths_CppLanguage_test():
   flags_object = flags.Flags()
 


### PR DESCRIPTION
I've been running into https://github.com/Valloric/YouCompleteMe/issues/303, even though ycmd has a workaround for it. It looks like the issue is just that I'm writing ObjC++ and that change only affects C++.

So, this change makes `-x objective-c++` eligible, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1193)
<!-- Reviewable:end -->
