### PR TITLE
[READY] Add -B to INCLUDE_FLAGS

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -42,7 +42,7 @@ from ycmd.responses import NoExtraConfDetected
 # checks prefixes).
 INCLUDE_FLAGS = [ '-isystem', '-I', '-iquote', '-isysroot', '--sysroot',
                   '-gcc-toolchain', '-include-pch', '-include', '-iframework',
-                  '-F', '-imacros', '-idirafter' ]
+                  '-F', '-imacros', '-idirafter', '-B' ]
 INCLUDE_FLAGS_WIN_STYLE = [ '/I' ]
 PATH_FLAGS =  [ '--sysroot=' ] + INCLUDE_FLAGS
 

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -35,7 +35,7 @@ from nose.tools import eq_
 from types import ModuleType
 
 from ycmd.completers.cpp import flags
-from ycmd.completers.cpp.flags import _ShouldAllowWinStyleFlags
+from ycmd.completers.cpp.flags import _ShouldAllowWinStyleFlags, INCLUDE_FLAGS
 from ycmd.tests.test_utils import ( MacOnly, TemporaryTestDir, WindowsOnly,
                                     TemporaryClangProject )
 from ycmd.utils import CLANG_RESOURCE_DIR
@@ -1019,13 +1019,10 @@ def RemoveUnusedFlags_RemoveFilenameWithoutPrecedingInclude_test():
                                      expected + to_remove + expected[ 1: ]
                                    ) ) )
 
-  include_flags = [ '-isystem', '-I', '-iquote', '-isysroot', '--sysroot',
-                    '-gcc-toolchain', '-include', '-include-pch',
-                    '-iframework', '-F', '-imacros', '-idirafter' ]
   to_remove = [ '/moo/boo' ]
   filename = 'file'
 
-  for flag in include_flags:
+  for flag in INCLUDE_FLAGS:
     yield tester, flag
 
 


### PR DESCRIPTION
This flag tells the compiler frontend (`gcc`/`clang`) where to look for the subprograms (`cpp`, `cc`, `cc1plus`, `as`, `ld` etc.). This flag is needed when bootstrapping a toolchain, so it is unlikely to be found in a custom extra conf, but it can appear in users' compilation databases. While it is not really an include flag, it behaves just like one.

Fixes Valloric/YouCompleteMe#3333

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1197)
<!-- Reviewable:end -->
