### PR TITLE
[READY] Improve cache in LSP completer

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -411,7 +411,7 @@ class CompletionsCache( object ):
   """Cache of computed completions for a particular request."""
 
   def __init__( self ):
-    self._access_lock = threading.Lock()
+    self._access_lock = threading.RLock()
     self.Invalidate()
 
 

--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -303,19 +303,6 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
     return None
 
 
-  def GetCodepointForCompletionRequest( self, request_data ):
-    """Overriden to pass the actual cursor position to clangd."""
-
-    # There are two types of codepoint offsets on the current line in ycmd:
-    #   - start_codepoint: where the completion identifier starts.
-    #   - column_codepoint: where the current cursor is placed.
-    # ycmd uses the start_codepoint by default -- because it caches completion
-    # items and does filtering/ranking. Instead, we use the filtering/ranking
-    # results from clangd, thus we pass "column_codepoint" (which includes the
-    # whole query string e.g. "std::u_p") to clangd.
-    return request_data[ 'column_codepoint' ]
-
-
   # TODO: Turn on coverage detection when updating to LLVM8 release. It is
   # currently turned off because Clangd doesn't support it in LLVM7 release.
   def ShouldCompleteIncludeStatement( self, request_data ): # pragma: no cover
@@ -325,9 +312,10 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
 
 
   def ShouldUseNow( self, request_data ):
-    """Overriden to avoid ycmd's caching/filtering logic."""
+    """Overridden to use Clangd filtering and sorting when ycmd caching is
+    disabled."""
     # Clangd should be able to provide completions in any context.
-    # FIXME: Empty queries provide spammy results, fix this in clangd.
+    # FIXME: Empty queries provide spammy results, fix this in Clangd.
     # FIXME: Add triggers for include completion with release of LLVM8.
     if self._use_ycmd_caching:
       return super( ClangdCompleter, self ).ShouldUseNow( request_data )
@@ -336,11 +324,15 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
 
 
   def ComputeCandidates( self, request_data ):
-    """Orverriden to bypass ycmd's cache."""
-    # Caching results means reranking them, and ycmd has fewer signals.
+    """Overridden to bypass ycmd cache if disabled."""
+    # Caching results means resorting them, and ycmd has fewer signals.
     if self._use_ycmd_caching:
       return super( ClangdCompleter, self ).ComputeCandidates( request_data )
-    return super( ClangdCompleter, self ).ComputeCandidatesInner( request_data )
+    codepoint = request_data[ 'column_codepoint' ]
+    candidates, _ = super( ClangdCompleter,
+                           self ).ComputeCandidatesInner( request_data,
+                                                          codepoint )
+    return candidates
 
 
   def ServerIsHealthy( self ):

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -485,9 +485,10 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
     # a compromise, we allow the user to force us to send the "query" to the
     # semantic engine, and thus get good completion results at the top level,
     # even if this means the "filtering and sorting" is not 100% ycmd flavor.
-    return ( request_data[ 'column_codepoint' ]
-             if request_data[ 'force_semantic' ]
-             else request_data[ 'start_codepoint' ] )
+    if request_data[ 'force_semantic' ]:
+      return request_data[ 'column_codepoint' ]
+    return super( JavaCompleter, self ).GetCodepointForCompletionRequest(
+      request_data )
 
 
   def HandleNotificationInPollThread( self, notification ):

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -545,8 +545,13 @@ def LanguageServerCompleter_GetCompletions_List_test():
                        'GetResponse',
                        side_effect = [ completion_response ] +
                                      resolve_responses ):
-      assert_that( completer.ComputeCandidatesInner( request_data ),
-                   has_items( has_entries( { 'insertion_text': 'test' } ) ) )
+      assert_that(
+        completer.ComputeCandidatesInner( request_data, 1 ),
+        contains(
+          has_items( has_entries( { 'insertion_text': 'test' } ) ),
+          False
+        )
+      )
 
 
 def LanguageServerCompleter_GetCompletions_UnsupportedKinds_test():
@@ -565,9 +570,251 @@ def LanguageServerCompleter_GetCompletions_UnsupportedKinds_test():
                        'GetResponse',
                        side_effect = [ completion_response ] +
                                      resolve_responses ):
-      assert_that( completer.ComputeCandidatesInner( request_data ),
-                   has_items( all_of( has_entry( 'insertion_text', 'test' ),
-                                      is_not( has_key( 'kind' ) ) ) ) )
+      assert_that(
+        completer.ComputeCandidatesInner( request_data, 1 ),
+        contains(
+          has_items( all_of( has_entry( 'insertion_text', 'test' ),
+                             is_not( has_key( 'kind' ) ) ) ),
+          False
+        )
+      )
+
+
+def LanguageServerCompleter_GetCompletions_CompleteOnStartColumn_test():
+  completer = MockCompleter()
+  completer._resolve_completion_items = False
+  complete_response = {
+    'result': {
+      'items': [
+        { 'label': 'aa' },
+        { 'label': 'ac' },
+        { 'label': 'ab' }
+      ],
+      'isIncomplete': False
+    }
+  }
+
+  with patch.object( completer, 'ServerIsReady', return_value = True ):
+    request_data = RequestWrap( BuildRequest(
+      column_num = 2,
+      contents = 'a',
+      force_semantic = True
+    ) )
+
+    with patch.object( completer.GetConnection(),
+                       'GetResponse',
+                       return_value = complete_response ) as response:
+      assert_that(
+        completer.ComputeCandidates( request_data ),
+        contains(
+          has_entry( 'insertion_text', 'aa' ),
+          has_entry( 'insertion_text', 'ab' ),
+          has_entry( 'insertion_text', 'ac' )
+        )
+      )
+
+      # Nothing cached yet.
+      assert_that( response.call_count, equal_to( 1 ) )
+
+    request_data = RequestWrap( BuildRequest(
+      column_num = 3,
+      contents = 'ab',
+      force_semantic = True
+    ) )
+
+    with patch.object( completer.GetConnection(),
+                       'GetResponse',
+                       return_value = complete_response ) as response:
+      assert_that(
+        completer.ComputeCandidates( request_data ),
+        contains(
+          has_entry( 'insertion_text', 'ab' )
+        )
+      )
+
+      # Since the server returned a complete list of completions on the starting
+      # column, no request should be sent to the server and the cache should be
+      # used instead.
+      assert_that( response.call_count, equal_to( 0 ) )
+
+
+def LanguageServerCompleter_GetCompletions_CompleteOnCurrentColumn_test():
+  completer = MockCompleter()
+  completer._resolve_completion_items = False
+
+  a_response = {
+    'result': {
+      'items': [
+        { 'label': 'aba' },
+        { 'label': 'aab' },
+        { 'label': 'aaa' }
+      ],
+      'isIncomplete': True
+    }
+  }
+  aa_response = {
+    'result': {
+      'items': [
+        { 'label': 'aab' },
+        { 'label': 'aaa' }
+      ],
+      'isIncomplete': False
+    }
+  }
+  aaa_response = {
+    'result': {
+      'items': [
+        { 'label': 'aaa' }
+      ],
+      'isIncomplete': False
+    }
+  }
+  ab_response = {
+    'result': {
+      'items': [
+        { 'label': 'abb' },
+        { 'label': 'aba' }
+      ],
+      'isIncomplete': False
+    }
+  }
+
+  with patch.object( completer, 'ServerIsReady', return_value = True ):
+    # User starts by typing the character "a".
+    request_data = RequestWrap( BuildRequest(
+      column_num = 2,
+      contents = 'a',
+      force_semantic = True
+    ) )
+
+    with patch.object( completer.GetConnection(),
+                       'GetResponse',
+                       return_value = a_response ) as response:
+      assert_that(
+        completer.ComputeCandidates( request_data ),
+        contains(
+          has_entry( 'insertion_text', 'aaa' ),
+          has_entry( 'insertion_text', 'aab' ),
+          has_entry( 'insertion_text', 'aba' )
+        )
+      )
+
+      # Nothing cached yet.
+      assert_that( response.call_count, equal_to( 1 ) )
+
+    # User types again the character "a".
+    request_data = RequestWrap( BuildRequest(
+      column_num = 3,
+      contents = 'aa',
+      force_semantic = True
+    ) )
+
+    with patch.object( completer.GetConnection(),
+                       'GetResponse',
+                       return_value = aa_response ) as response:
+      assert_that(
+        completer.ComputeCandidates( request_data ),
+        contains(
+          has_entry( 'insertion_text', 'aaa' ),
+          has_entry( 'insertion_text', 'aab' )
+        )
+      )
+
+      # The server returned an incomplete list of completions the first time so
+      # a new completion request should have been sent.
+      assert_that( response.call_count, equal_to( 1 ) )
+
+    # User types the character "a" a third time.
+    request_data = RequestWrap( BuildRequest(
+      column_num = 4,
+      contents = 'aaa',
+      force_semantic = True
+    ) )
+
+    with patch.object( completer.GetConnection(),
+                       'GetResponse',
+                       return_value = aaa_response ) as response:
+
+      assert_that(
+        completer.ComputeCandidates( request_data ),
+        contains(
+          has_entry( 'insertion_text', 'aaa' )
+        )
+      )
+
+      # The server returned a complete list of completions the second time and
+      # the new query is a prefix of the cached one ("aa" is a prefix of "aaa")
+      # so the cache should be used.
+      assert_that( response.call_count, equal_to( 0 ) )
+
+    # User deletes the third character.
+    request_data = RequestWrap( BuildRequest(
+      column_num = 3,
+      contents = 'aa',
+      force_semantic = True
+    ) )
+
+    with patch.object( completer.GetConnection(),
+                       'GetResponse',
+                       return_value = aa_response ) as response:
+
+      assert_that(
+        completer.ComputeCandidates( request_data ),
+        contains(
+          has_entry( 'insertion_text', 'aaa' ),
+          has_entry( 'insertion_text', 'aab' )
+        )
+      )
+
+      # The new query is still a prefix of the cached one ("aa" is a prefix of
+      # "aa") so the cache should again be used.
+      assert_that( response.call_count, equal_to( 0 ) )
+
+    # User deletes the second character.
+    request_data = RequestWrap( BuildRequest(
+      column_num = 2,
+      contents = 'a',
+      force_semantic = True
+    ) )
+
+    with patch.object( completer.GetConnection(),
+                       'GetResponse',
+                       return_value = a_response ) as response:
+
+      assert_that(
+        completer.ComputeCandidates( request_data ),
+        contains(
+          has_entry( 'insertion_text', 'aaa' ),
+          has_entry( 'insertion_text', 'aab' ),
+          has_entry( 'insertion_text', 'aba' )
+        )
+      )
+
+      # The new query is not anymore a prefix of the cached one ("aa" is not a
+      # prefix of "a") so the cache is invalidated and a new request is sent.
+      assert_that( response.call_count, equal_to( 1 ) )
+
+    # Finally, user inserts the "b" character.
+    request_data = RequestWrap( BuildRequest(
+      column_num = 3,
+      contents = 'ab',
+      force_semantic = True
+    ) )
+
+    with patch.object( completer.GetConnection(),
+                       'GetResponse',
+                       return_value = ab_response ) as response:
+
+      assert_that(
+        completer.ComputeCandidates( request_data ),
+        contains(
+          has_entry( 'insertion_text', 'aba' ),
+          has_entry( 'insertion_text', 'abb' )
+        )
+      )
+
+      # Last response was incomplete so the cache should not be used.
+      assert_that( response.call_count, equal_to( 1 ) )
 
 
 def FindOverlapLength_test():


### PR DESCRIPTION
ycmd is caching completions that are already filtered by Clangd if we send the cursor column (`column_codepoint`) to Clangd when `clangd_uses_ycmd_caching` is set to `1`,  This leads to unexpected results when triggering semantic completion in a middle of a word. Here's a demo of the issue:

![missing-completions-before](https://user-images.githubusercontent.com/10026824/54240204-b3895200-451d-11e9-89d1-9ba496bd9507.gif)

No `foo` suggestion when deleting the `b` character. If we send the starting column (`start_codepoint`) instead:

![missing-completions-after](https://user-images.githubusercontent.com/10026824/54240249-d1ef4d80-451d-11e9-8960-cc0e03657e2d.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1205)
<!-- Reviewable:end -->
