### PR TITLE
[READY] Drop python 3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       - *save-cache
       - *upload-coverage
     environment:
-      YCMD_PYTHON_VERSION: 3.4
+      YCMD_PYTHON_VERSION: 3.5
   benchmark:
     <<: *common
     steps:
@@ -74,7 +74,7 @@ jobs:
           command: ./benchmark.py
       - *save-cache
     environment:
-      YCMD_PYTHON_VERSION: 3.4
+      YCMD_PYTHON_VERSION: 3.5
 workflows:
   version: 2
   build:

--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -57,7 +57,7 @@ if [ "${YCMD_PYTHON_VERSION}" == "2.7" ]; then
   # this is fixed in pip.
   PYENV_VERSION="2.7.4"
 else
-  PYENV_VERSION="3.4.0"
+  PYENV_VERSION="3.5.1"
 fi
 
 # In order to work with ycmd, python *must* be built as a shared library. The

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
   matrix:
     - YCMD_PYTHON_VERSION=2.7 USE_CLANG_COMPLETER=false
     - YCMD_PYTHON_VERSION=2.7
-    - YCMD_PYTHON_VERSION=3.4
-    - YCMD_PYTHON_VERSION=3.4 YCM_COMPILER=clang
-    - YCMD_PYTHON_VERSION=3.4 YCM_BENCHMARK=true COVERAGE=false
-    - YCMD_PYTHON_VERSION=3.4 YCM_CLANG_TIDY=true COVERAGE=false YCM_CORES=1
+    - YCMD_PYTHON_VERSION=3.5
+    - YCMD_PYTHON_VERSION=3.5 YCM_COMPILER=clang
+    - YCMD_PYTHON_VERSION=3.5 YCM_BENCHMARK=true COVERAGE=false
+    - YCMD_PYTHON_VERSION=3.5 YCM_CLANG_TIDY=true COVERAGE=false YCM_CORES=1
 addons:
   # If this doesn't make much sense to you, see the travis docs:
   #    https://docs.travis-ci.com/user/migrating-from-legacy/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Creating good pull requests
 Writing code that runs on Python 2 & 3
 ======================================
 
-We support Python 2.7 and 3.4+. Since we use
+We support Python 2.7 and 3.5+. Since we use
 [`python-future`][python-future], you should mostly write Python 3 as normal.
 Here's what you should watch out for:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ tests][test-setup].**
 
 This is all for Ubuntu Linux. Details on getting ycmd running on other OS's can
 be found in [YCM's instructions][ycm-install] (ignore the Vim-specific parts).
-Note that **ycmd runs on Python 2.7.1+ and 3.4+.**
+Note that **ycmd runs on Python 2.7.1+ and 3.5.1+.**
 
 First, install the minimal dependencies:
 ```

--- a/build.py
+++ b/build.py
@@ -26,11 +26,10 @@ import tarfile
 import tempfile
 
 IS_64BIT = sys.maxsize > 2**32
-PY_MAJOR, PY_MINOR, PY_PATCH = sys.version_info[ 0 : 3 ]
-if not ( ( PY_MAJOR == 2 and PY_MINOR == 7 and PY_PATCH >= 1 ) or
-         ( PY_MAJOR == 3 and PY_MINOR >= 4 ) or
-         PY_MAJOR > 3 ):
-  sys.exit( 'ycmd requires Python >= 2.7.1 or >= 3.4; '
+PY_MAJOR, PY_MINOR = sys.version_info[ 0 : 2 ]
+version = sys.version_info[ 0 : 3 ]
+if version < ( 2, 7, 1 ) or ( 3, 0, 0 ) <= version < ( 3, 5, 1 ):
+  sys.exit( 'ycmd requires Python >= 2.7.1 or >= 3.5.1; '
             'your version of Python is ' + sys.version )
 
 DIR_OF_THIS_SCRIPT = p.dirname( p.abspath( __file__ ) )
@@ -69,7 +68,7 @@ NO_PYTHON_HEADERS_ERROR = 'ERROR: Python headers are missing in {include_dir}.'
 # Regular expressions used to find static and dynamic Python libraries.
 # Notes:
 #  - Python 3 library name may have an 'm' suffix on Unix platforms, for
-#    instance libpython3.4m.so;
+#    instance libpython3.5m.so;
 #  - the linker name (the soname without the version) does not always
 #    exist so we look for the versioned names too;
 #  - on Windows, the .lib extension is used instead of the .dll one. See

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -58,7 +58,7 @@ if [ "${YCMD_PYTHON_VERSION}" == "2.7" ]; then
   # 2.7.1.
   PYENV_VERSION="2.7.2"
 else
-  PYENV_VERSION="3.4.0"
+  PYENV_VERSION="3.5.1"
 fi
 
 # In order to work with ycmd, python *must* be built as a shared library. This

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -253,8 +253,8 @@ if ( USE_PYTHON2 )
       "necessary python2 headers & libraries." )
   endif()
 else()
-  set( Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5 3.4 )
-  find_package( PythonLibs 3.4 REQUIRED )  # 3.4 is ONLY the mininum
+  set( Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5 )
+  find_package( PythonLibs 3.5 REQUIRED )  # 3.5 is ONLY the mininum
 endif()
 
 #############################################################################

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # ycmd example client
 
-The example client **requires** Python 3.4+ (unlike ycmd which also runs on
+The example client **requires** Python 3.5+ (unlike ycmd which also runs on
 Python 2).
 
 First make sure you have built ycmd; see the top-level README for details.

--- a/examples/example_client.py
+++ b/examples/example_client.py
@@ -17,7 +17,7 @@
 import sys
 import platform
 if sys.version_info[ 0 ] < 3:
-  sys.exit( 'example_client.py requires Python 3.4+; detected Python ' +
+  sys.exit( 'example_client.py requires Python 3.5+; detected Python ' +
             platform.python_version() )
 
 from base64 import b64encode, b64decode

--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -682,9 +682,7 @@ def ImportAndCheckCore_Missing_test():
 
 def ImportAndCheckCore_Python2_test():
   import_exception_messages = [
-    # Raised on Linux and OS X with Python 3.4.
-    'dynamic module does not define init function (PyInit_ycm_core).',
-    # Raised on Linux and OS X with Python 3.5.
+    # Raised on Linux and OS X.
     'dynamic module does not define module export function (PyInit_ycm_core).',
     # Raised on Windows.
     'Module use of python27.dll conflicts with this version of Python.'
@@ -704,7 +702,6 @@ def ImportAndCheckCore_Python3_test():
     # Raised on Linux and OS X.
     'dynamic module does not define init function (initycm_core).',
     # Raised on Windows.
-    'Module use of python34.dll conflicts with this version of Python.',
     'Module use of python35.dll conflicts with this version of Python.'
   ]
 


### PR DESCRIPTION
Python 3.4 reached end of life today (2019-03-16). Ubuntu 18.04 (what we officially support) has `python` pointing to Python 2.7 and `python3` pointing to Python 3.6.

Dropping Python 3.4 will allow us to use [abseil](https://github.com/abseil/abseil-cpp)'s flat hash maps and improve [benchmarks](https://gist.github.com/bstaletic/7d3e31db7fc8d40a12787fab09ff092f) by ~20% ~~except for `IdentifierCompleterFixture/CandidatesWithCommonPrefix/65536/10` (still an improvement, but a small one)~~. Turns out we can get ~20% in every benchmark.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1207)
<!-- Reviewable:end -->
