### PR TITLE
[READY] Search custom Clangd in PATH

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -33,6 +33,7 @@ from ycmd.completers.language_server import language_server_completer
 from ycmd.completers.language_server import language_server_protocol as lsp
 from ycmd.utils import ( GetExecutable,
                          ExpandVariablesInPath,
+                         FindExecutable,
                          LOGGER,
                          CLANG_RESOURCE_DIR )
 
@@ -119,7 +120,7 @@ def GetClangdExecutableAndResourceDir( user_options ):
   resource_dir = None
 
   if clangd:
-    clangd = GetExecutable( ExpandVariablesInPath( clangd ) )
+    clangd = FindExecutable( ExpandVariablesInPath( clangd ) )
 
     if not clangd:
       LOGGER.error( 'No Clangd executable found at %s',

--- a/ycmd/tests/clangd/utilities_test.py
+++ b/ycmd/tests/clangd/utilities_test.py
@@ -91,7 +91,7 @@ def ClangdCompleter_GetClangdCommand_NoCustomBinary_test():
   clangd_completer.CLANGD_COMMAND = clangd_completer.NOT_CACHED
 
 
-@patch( 'ycmd.completers.cpp.clangd_completer.GetExecutable', lambda exe: exe )
+@patch( 'ycmd.completers.cpp.clangd_completer.FindExecutable', lambda exe: exe )
 def ClangdCompleter_GetClangdCommand_CustomBinary_test():
   CLANGD_PATH = '/test/clangd'
   user_options = DefaultOptions()
@@ -104,7 +104,7 @@ def ClangdCompleter_GetClangdCommand_CustomBinary_test():
          CLANGD_PATH )
 
     # No Clangd binary in the given path.
-    with patch( 'ycmd.completers.cpp.clangd_completer.GetExecutable',
+    with patch( 'ycmd.completers.cpp.clangd_completer.FindExecutable',
                 return_value = None ):
       clangd_completer.CLANGD_COMMAND = clangd_completer.NOT_CACHED
       eq_( clangd_completer.GetClangdCommand( user_options ), None )


### PR DESCRIPTION
This change makes it possible to use a custom Clangd from the PATH by setting the `clangd_binary_path` option to `'clangd'` instead of having to specify an absolute path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1210)
<!-- Reviewable:end -->
