### PR TITLE
[READY] Parallel sorting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -48,3 +48,6 @@
 [submodule "third_party/idna"]
 	path = third_party/requests_deps/idna
 	url = https://github.com/kjd/idna
+[submodule "cpp/tbb"]
+	path = cpp/tbb
+	url = https://github.com/bstaletic/tbb

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -60,6 +60,8 @@ flags = [
 '-x',
 'c++',
 '-isystem',
+'cpp/pstl/include',
+'-isystem',
 'cpp/pybind11',
 '-isystem',
 'cpp/whereami',

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,6 +23,7 @@ coverage:
   - .*/benchmarks/.*
   - .*/BoostParts/.*
   - .*/pybind11/.*
+  - .*/pstl/.*
   - .*/whereami/.*
 
 comment:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -265,4 +265,11 @@ if (NOT USE_SYSTEM_BOOST)
   add_subdirectory( BoostParts )
 endif()
 
+# This adds -fPIC to everything
+set( CMAKE_POSITION_INDEPENDENT_CODE TRUE )
+
+option( USE_SYSTEM_TBB "Unsupported: link against system tbb" OFF )
+if ( NOT USE_SYSTEM_TBB )
+  add_subdirectory( tbb )
+endif()
 add_subdirectory( ycm )

--- a/cpp/pstl/LICENSE.txt
+++ b/cpp/pstl/LICENSE.txt
@@ -1,0 +1,218 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.

--- a/cpp/pstl/include/pstl/algorithm
+++ b/cpp/pstl/include/pstl/algorithm
@@ -1,0 +1,30 @@
+// -*- C++ -*-
+//===-- algorithm ---------------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_algorithm
+#define __PSTL_algorithm
+
+#include "internal/pstl_config.h"
+
+#if __PSTL_EXECUTION_POLICIES_DEFINED
+// If <execution> has already been included, pull in implementations
+#include "internal/glue_algorithm_impl.h"
+#else
+// Otherwise just pull in forward declarations
+#include "internal/glue_algorithm_defs.h"
+#define __PSTL_ALGORITHM_FORWARD_DECLARED 1
+#endif
+
+#endif /* __PSTL_algorithm */

--- a/cpp/pstl/include/pstl/execution
+++ b/cpp/pstl/include/pstl/execution
@@ -1,0 +1,54 @@
+// -*- C++ -*-
+//===-- execution ---------------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_execution
+#define __PSTL_execution
+
+#include "internal/pstl_config.h"
+#include "internal/execution_defs.h"
+
+#define __PSTL_EXECUTION_POLICIES_DEFINED 1
+
+#if __PSTL_ALGORITHM_FORWARD_DECLARED
+#include "internal/glue_algorithm_impl.h"
+#endif
+
+#if __PSTL_MEMORY_FORWARD_DECLARED
+#include "internal/glue_memory_impl.h"
+#endif
+
+#if __PSTL_NUMERIC_FORWARD_DECLARED
+#include "internal/glue_numeric_impl.h"
+#endif
+
+#if __PSTL_CPP17_EXECUTION_POLICIES_PRESENT
+__PSTL_PRAGMA_MESSAGE_POLICIES("The <Parallel STL> execution policies are defined in the namespace __pstl::execution")
+#else
+#include "internal/glue_execution_defs.h"
+__PSTL_PRAGMA_MESSAGE_POLICIES(
+    "The <Parallel STL> execution policies are injected into the standard namespace std::execution")
+#endif
+
+//TODO: __pstl::execution namespace is injected into the pstl::execution namespace when the implementation is not a part of
+// standard C++ library
+namespace pstl
+{
+namespace execution
+{
+using namespace __pstl::execution;
+}
+}
+
+#endif /* __PSTL_execution */

--- a/cpp/pstl/include/pstl/internal/algorithm_impl.h
+++ b/cpp/pstl/include/pstl/internal/algorithm_impl.h
@@ -1,0 +1,3672 @@
+// -*- C++ -*-
+//===-- algorithm_impl.h --------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_algorithm_impl_H
+#define __PSTL_algorithm_impl_H
+
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <functional>
+#include <algorithm>
+
+#include "execution_impl.h"
+#include "memory_impl.h"
+#include "unseq_backend_simd.h"
+
+#if __PSTL_USE_PAR_POLICIES
+#include "parallel_backend.h"
+#include "parallel_impl.h"
+#endif
+
+namespace __pstl
+{
+namespace internal
+{
+
+//------------------------------------------------------------------------
+// any_of
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class _Pred>
+bool
+brick_any_of(const _ForwardIterator __first, const _ForwardIterator __last, _Pred __pred,
+             /*__is_vector=*/std::false_type) noexcept
+{
+    return std::any_of(__first, __last, __pred);
+};
+
+template <class _ForwardIterator, class _Pred>
+bool
+brick_any_of(const _ForwardIterator __first, const _ForwardIterator __last, _Pred __pred,
+             /*__is_vector=*/std::true_type) noexcept
+{
+    return unseq_backend::simd_or(__first, __last - __first, __pred);
+};
+
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Pred, class _IsVector>
+bool
+pattern_any_of(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Pred __pred,
+               _IsVector __is_vector, /*parallel=*/std::false_type) noexcept
+{
+    return internal::brick_any_of(__first, __last, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _Pred, class _IsVector>
+bool
+pattern_any_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Pred __pred,
+               _IsVector __is_vector, /*parallel=*/std::true_type)
+{
+    return internal::except_handler([&]() {
+        return internal::parallel_or(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                     [__pred, __is_vector](_ForwardIterator __i, _ForwardIterator __j) {
+                                         return internal::brick_any_of(__i, __j, __pred, __is_vector);
+                                     });
+    });
+}
+#endif
+
+
+// [alg.foreach]
+// for_each_n with no policy
+
+template <class _ForwardIterator, class _Size, class _Function>
+_ForwardIterator
+for_each_n_it_serial(_ForwardIterator __first, _Size __n, _Function __f)
+{
+    for (; __n > 0; ++__first, --__n)
+        __f(__first);
+    return __first;
+}
+
+//------------------------------------------------------------------------
+// walk1 (pseudo)
+//
+// walk1 evaluates f(x) for each dereferenced value x drawn from [first,last)
+//------------------------------------------------------------------------
+template <class _ForwardIterator, class _Function>
+void
+brick_walk1(_ForwardIterator __first, _ForwardIterator __last, _Function __f, /*vector=*/std::false_type) noexcept
+{
+    std::for_each(__first, __last, __f);
+}
+
+template <class _RandomAccessIterator, class _Function>
+void
+brick_walk1(_RandomAccessIterator __first, _RandomAccessIterator __last, _Function __f,
+            /*vector=*/std::true_type) noexcept
+{
+    unseq_backend::simd_walk_1(__first, __last - __first, __f);
+}
+
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
+void
+pattern_walk1(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
+              _IsVector __is_vector,
+              /*parallel=*/std::false_type) noexcept
+{
+    internal::brick_walk1(__first, __last, __f, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
+void
+pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
+              _IsVector __is_vector,
+              /*parallel=*/std::true_type)
+{
+    internal::except_handler([&]() {
+        par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                  [__f, __is_vector](_ForwardIterator __i, _ForwardIterator __j) {
+                                      internal::brick_walk1(__i, __j, __f, __is_vector);
+                                  });
+    });
+}
+#endif
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Brick>
+void
+pattern_walk_brick(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Brick __brick,
+                   /*parallel=*/std::false_type) noexcept
+{
+    __brick(__first, __last);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _Brick>
+void
+pattern_walk_brick(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Brick __brick,
+                   /*parallel=*/std::true_type)
+{
+    internal::except_handler([&]() {
+        par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                  [__brick](_ForwardIterator __i, _ForwardIterator __j) { __brick(__i, __j); });
+    });
+}
+#endif
+
+
+//------------------------------------------------------------------------
+// walk1_n
+//------------------------------------------------------------------------
+template <class _ForwardIterator, class _Size, class _Function>
+_ForwardIterator
+brick_walk1_n(_ForwardIterator __first, _Size __n, _Function __f, /*_IsVectorTag=*/std::false_type)
+{
+    return for_each_n_it_serial(__first, __n, [&__f](_ForwardIterator __it) { __f(*__it); }); // calling serial version
+}
+
+template <class _RandomAccessIterator, class _DifferenceType, class _Function>
+_RandomAccessIterator
+brick_walk1_n(_RandomAccessIterator __first, _DifferenceType __n, _Function __f,
+              /*vectorTag=*/std::true_type) noexcept
+{
+    return unseq_backend::simd_walk_1(__first, __n, __f);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Function, class _IsVector>
+_ForwardIterator
+pattern_walk1_n(_ExecutionPolicy&&, _ForwardIterator __first, _Size __n, _Function __f, _IsVector __is_vector,
+                /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_walk1_n(__first, __n, __f, __is_vector);
+}
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Function, class _IsVector>
+_RandomAccessIterator
+pattern_walk1_n(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Size __n, _Function __f,
+                _IsVector __is_vector,
+                /*is_parallel=*/std::true_type)
+{
+    internal::pattern_walk1(std::forward<_ExecutionPolicy>(__exec), __first, __first + __n, __f, __is_vector,
+                            std::true_type());
+    return __first + __n;
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Brick>
+_ForwardIterator
+pattern_walk_brick_n(_ExecutionPolicy&&, _ForwardIterator __first, _Size __n, _Brick __brick,
+                     /*is_parallel=*/std::false_type) noexcept
+{
+    return __brick(__first, __n);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Brick>
+_RandomAccessIterator
+pattern_walk_brick_n(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Size __n, _Brick __brick,
+                     /*is_parallel=*/std::true_type)
+{
+    return internal::except_handler([&]() {
+        par_backend::parallel_for(
+            std::forward<_ExecutionPolicy>(__exec), __first, __first + __n,
+            [__brick](_RandomAccessIterator __i, _RandomAccessIterator __j) { __brick(__i, __j - __i); });
+        return __first + __n;
+    });
+}
+#endif
+
+
+//------------------------------------------------------------------------
+// walk2 (pseudo)
+//
+// walk2 evaluates f(x,y) for deferenced values (x,y) drawn from [first1,last1) and [first2,...)
+//------------------------------------------------------------------------
+template <class _ForwardIterator1, class _ForwardIterator2, class _Function>
+_ForwardIterator2
+brick_walk2(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f,
+            /*vector=*/std::false_type) noexcept
+{
+    for (; __first1 != __last1; ++__first1, ++__first2)
+        __f(*__first1, *__first2);
+    return __first2;
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _Function>
+_ForwardIterator2
+brick_walk2(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f,
+            /*vector=*/std::true_type) noexcept
+{
+    return unseq_backend::simd_walk_2(__first1, __last1 - __first1, __first2, __f);
+}
+
+template <class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Function>
+_ForwardIterator2
+brick_walk2_n(_ForwardIterator1 __first1, _Size __n, _ForwardIterator2 __first2, _Function __f,
+              /*vector=*/std::false_type) noexcept
+{
+    for (; __n > 0; --__n, ++__first1, ++__first2)
+        __f(*__first1, *__first2);
+    return __first2;
+}
+
+template <class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Function>
+_ForwardIterator2
+brick_walk2_n(_ForwardIterator1 __first1, _Size __n, _ForwardIterator2 __first2, _Function __f,
+              /*vector=*/std::true_type) noexcept
+{
+    return unseq_backend::simd_walk_2(__first1, __n, __first2, __f);
+}
+
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Function, class _IsVector>
+_ForwardIterator2
+pattern_walk2(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+              _Function __f, _IsVector __is_vector, /*parallel=*/std::false_type) noexcept
+{
+    return internal::brick_walk2(__first1, __last1, __first2, __f, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Function, class _IsVector>
+_ForwardIterator2
+pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+              _ForwardIterator2 __first2, _Function __f, _IsVector __is_vector, /*parallel=*/std::true_type)
+{
+    return internal::except_handler([&]() {
+        par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+                                  [__f, __first1, __first2, __is_vector](_ForwardIterator1 __i, _ForwardIterator1 __j) {
+                                      internal::brick_walk2(__i, __j, __first2 + (__i - __first1), __f, __is_vector);
+                                  });
+        return __first2 + (__last1 - __first1);
+    });
+}
+#endif
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Function,
+          class _IsVector>
+_ForwardIterator2
+pattern_walk2_n(_ExecutionPolicy&&, _ForwardIterator1 __first1, _Size n, _ForwardIterator2 __first2, _Function f,
+                _IsVector is_vector, /*parallel=*/std::false_type) noexcept
+{
+    return internal::brick_walk2_n(__first1, n, __first2, f, is_vector);
+}
+
+template <class _ExecutionPolicy, class _RandomAccessIterator1, class _Size, class _RandomAccessIterator2,
+          class _Function, class _IsVector>
+_RandomAccessIterator2
+pattern_walk2_n(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _Size n, _RandomAccessIterator2 __first2,
+                _Function f, _IsVector is_vector, /*parallel=*/std::true_type)
+{
+    return internal::pattern_walk2(std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + n, __first2, f,
+                                   is_vector, std::true_type());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Brick>
+_ForwardIterator2
+pattern_walk2_brick(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                    _ForwardIterator2 __first2, _Brick __brick, /*parallel=*/std::false_type) noexcept
+{
+    return __brick(__first1, __last1, __first2);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2, class _Brick>
+_RandomAccessIterator2
+pattern_walk2_brick(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
+                    _RandomAccessIterator2 __first2, _Brick __brick, /*parallel=*/std::true_type)
+{
+    return except_handler([&]() {
+        par_backend::parallel_for(
+            std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+            [__first1, __first2, __brick](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
+                __brick(__i, __j, __first2 + (__i - __first1));
+            });
+        return __first2 + (__last1 - __first1);
+    });
+}
+#endif
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator1, class _Size, class _RandomAccessIterator2, class _Brick>
+_RandomAccessIterator2
+pattern_walk2_brick_n(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _Size __n,
+                      _RandomAccessIterator2 __first2, _Brick __brick, /*parallel=*/std::true_type)
+{
+    return except_handler([&]() {
+        par_backend::parallel_for(
+            std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
+            [__first1, __first2, __brick](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
+                __brick(__i, __j - __i, __first2 + (__i - __first1));
+            });
+        return __first2 + __n;
+    });
+}
+#endif
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Brick>
+_ForwardIterator2
+pattern_walk2_brick_n(_ExecutionPolicy&&, _ForwardIterator1 __first1, _Size __n, _ForwardIterator2 __first2,
+                      _Brick __brick, /*parallel=*/std::false_type) noexcept
+{
+    return __brick(__first1, __n, __first2);
+}
+
+
+//------------------------------------------------------------------------
+// walk3 (pseudo)
+//
+// walk3 evaluates f(x,y,z) for (x,y,z) drawn from [first1,last1), [first2,...), [first3,...)
+//------------------------------------------------------------------------
+template <class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3, class _Function>
+_ForwardIterator3
+brick_walk3(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+            _ForwardIterator3 __first3, _Function __f, /*vector=*/std::false_type) noexcept
+{
+    for (; __first1 != __last1; ++__first1, ++__first2, ++__first3)
+        __f(*__first1, *__first2, *__first3);
+    return __first3;
+}
+
+template <class _RandomAccessIterator1, class _RandomAccessIterator2, class _RandomAccessIterator3, class _Function>
+_RandomAccessIterator3
+brick_walk3(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
+            _RandomAccessIterator3 __first3, _Function __f, /*vector=*/std::true_type) noexcept
+{
+    return unseq_backend::simd_walk_3(__first1, __last1 - __first1, __first2, __first3, __f);
+}
+
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3,
+          class _Function, class _IsVector>
+_ForwardIterator3
+pattern_walk3(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+              _ForwardIterator3 __first3, _Function __f, _IsVector __is_vector, /*parallel=*/std::false_type) noexcept
+{
+    return internal::brick_walk3(__first1, __last1, __first2, __first3, __f, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
+          class _RandomAccessIterator3, class _Function, class _IsVector>
+_RandomAccessIterator3
+pattern_walk3(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
+              _RandomAccessIterator2 __first2, _RandomAccessIterator3 __first3, _Function __f, _IsVector __is_vector,
+              /*parallel=*/std::true_type)
+{
+    return internal::except_handler([&]() {
+        par_backend::parallel_for(
+            std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+            [__f, __first1, __first2, __first3, __is_vector](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
+                internal::brick_walk3(__i, __j, __first2 + (__i - __first1), __first3 + (__i - __first1), __f,
+                                      __is_vector);
+            });
+        return __first3 + (__last1 - __first1);
+    });
+}
+#endif
+
+
+//------------------------------------------------------------------------
+// equal
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+bool
+brick_equal(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __p,
+            /* IsVector = */ std::false_type) noexcept
+{
+    return std::equal(__first1, __last1, __first2, __p);
+}
+
+template <class _RandomAccessIterator1, class _RandomAccessIterator2, class _BinaryPredicate>
+bool
+brick_equal(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
+            _BinaryPredicate __p, /* is_vector = */ std::true_type) noexcept
+{
+    return unseq_backend::simd_first(__first1, __last1 - __first1, __first2, not_pred<_BinaryPredicate>(__p)).first ==
+           __last1;
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate,
+          class _IsVector>
+bool
+pattern_equal(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+              _BinaryPredicate __p, _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept
+{
+    return internal::brick_equal(__first1, __last1, __first2, __p, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2, class _BinaryPredicate,
+          class _IsVector>
+bool
+pattern_equal(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
+              _RandomAccessIterator2 __first2, _BinaryPredicate __p, _IsVector __is_vector,
+              /*is_parallel=*/std::true_type)
+{
+    return internal::except_handler([&]() {
+        return !internal::parallel_or(
+            std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+            [__first1, __first2, __p, __is_vector](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
+                return !brick_equal(__i, __j, __first2 + (__i - __first1), __p, __is_vector);
+            });
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// find_if
+//------------------------------------------------------------------------
+template <class _ForwardIterator, class _Predicate>
+_ForwardIterator
+brick_find_if(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred,
+              /*is_vector=*/std::false_type) noexcept
+{
+    return std::find_if(__first, __last, __pred);
+}
+
+template <class _RandomAccessIterator, class _Predicate>
+_RandomAccessIterator
+brick_find_if(_RandomAccessIterator __first, _RandomAccessIterator __last, _Predicate __pred,
+              /*is_vector=*/std::true_type) noexcept
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _SizeType;
+    return unseq_backend::simd_first(
+        __first, _SizeType(0), __last - __first,
+        [&__pred](_RandomAccessIterator __it, _SizeType __i) { return __pred(__it[__i]); });
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate, class _IsVector>
+_ForwardIterator
+pattern_find_if(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred,
+                _IsVector __is_vector,
+                /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_find_if(__first, __last, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate, class _IsVector>
+_ForwardIterator
+pattern_find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred,
+                _IsVector __is_vector,
+                /*is_parallel=*/std::true_type)
+{
+    return internal::except_handler([&]() {
+        return internal::parallel_find(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                       [__pred, __is_vector](_ForwardIterator __i, _ForwardIterator __j) {
+                                           return internal::brick_find_if(__i, __j, __pred, __is_vector);
+                                       },
+                                       std::less<typename std::iterator_traits<_ForwardIterator>::difference_type>(),
+                                       /*is_first=*/true);
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// find_end
+//------------------------------------------------------------------------
+
+// find the first occurrence of the subsequence [s_first, s_last)
+//   or the  last occurrence of the subsequence in the range [first, last)
+// b_first determines what occurrence we want to find (first or last)
+template <class _RandomAccessIterator1, class _RandomAccessIterator2, class _BinaryPredicate, class _IsVector>
+_RandomAccessIterator1
+find_subrange(_RandomAccessIterator1 __first, _RandomAccessIterator1 __last, _RandomAccessIterator1 __global_last,
+              _RandomAccessIterator2 __s_first, _RandomAccessIterator2 __s_last, _BinaryPredicate __pred,
+              bool __b_first, _IsVector __is_vector) noexcept
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator2>::value_type _ValueType;
+    auto __n2 = __s_last - __s_first;
+    if (__n2 < 1)
+    {
+        return __b_first ? __first : __last;
+    }
+
+    auto __n1 = __global_last - __first;
+    if (__n1 < __n2)
+    {
+        return __last;
+    }
+
+    auto __cur = __last;
+    while (__first != __last && (__global_last - __first >= __n2))
+    {
+        // find position of *s_first in [first, last) (it can be start of subsequence)
+        __first = internal::brick_find_if(
+            __first, __last, internal::equal_value_by_pred<_ValueType, _BinaryPredicate>(*__s_first, __pred),
+            __is_vector);
+
+        // if position that was found previously is the start of subsequence
+        // then we can exit the loop (b_first == true) or keep the position
+        // (b_first == false)
+        if (__first != __last && (__global_last - __first >= __n2) &&
+            internal::brick_equal(__s_first + 1, __s_last, __first + 1, __pred, __is_vector))
+        {
+            if (__b_first)
+            {
+                return __first;
+            }
+            else
+            {
+                __cur = __first;
+            }
+        }
+        else if (__first == __last)
+        {
+            break;
+        }
+        else
+        {
+        }
+
+        // in case of b_first == false we try to find new start position
+        // for the next subsequence
+        ++__first;
+    }
+    return __cur;
+}
+
+template <class _RandomAccessIterator, class _Size, class _Tp, class _BinaryPredicate, class _IsVector>
+_RandomAccessIterator
+find_subrange(_RandomAccessIterator __first, _RandomAccessIterator __last, _RandomAccessIterator __global_last,
+              _Size __count, const _Tp& __value, _BinaryPredicate __pred, _IsVector __is_vector) noexcept
+{
+    if (__global_last - __first < __count || __count < 1)
+    {
+        return __last; // According to the standard last shall be returned when count < 1
+    }
+
+    auto __n = __global_last - __first;
+    auto __unary_pred = internal::equal_value_by_pred<_Tp, _BinaryPredicate>(__value, __pred);
+    while (__first != __last && (__global_last - __first >= __count))
+    {
+        __first = brick_find_if(__first, __last, __unary_pred, __is_vector);
+
+        // check that all of elements in [first+1, first+count) equal to value
+        if (__first != __last && (__global_last - __first >= __count) &&
+            !internal::brick_any_of(__first + 1, __first + __count,
+                                    internal::not_pred<decltype(__unary_pred)>(__unary_pred), __is_vector))
+        {
+            return __first;
+        }
+        else if (__first == __last)
+        {
+            break;
+        }
+        else
+        {
+            ++__first;
+        }
+    }
+    return __last;
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1
+brick_find_end(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+               _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*__is_vector=*/std::false_type) noexcept
+{
+    return std::find_end(__first, __last, __s_first, __s_last, __pred);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1
+brick_find_end(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+               _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*__is_vector=*/std::true_type) noexcept
+{
+    return internal::find_subrange(__first, __last, __last, __s_first, __s_last, __pred, false, std::true_type());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate,
+          class _IsVector>
+_ForwardIterator1
+pattern_find_end(_ExecutionPolicy&&, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+                 _ForwardIterator2 __s_last, _BinaryPredicate __pred, _IsVector __is_vector,
+                 /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_find_end(__first, __last, __s_first, __s_last, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate,
+          class _IsVector>
+_ForwardIterator1
+pattern_find_end(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                 _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred,
+                 _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept
+{
+    if (__last - __first == __s_last - __s_first)
+    {
+        const bool __res = internal::pattern_equal(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first,
+                                                   __pred, __is_vector, std::true_type());
+        return __res ? __first : __last;
+    }
+    else
+    {
+        return except_handler([&]() {
+            return internal::parallel_find(
+                std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                [__first, __last, __s_first, __s_last, __pred, __is_vector](_ForwardIterator1 __i,
+                                                                            _ForwardIterator1 __j) {
+                    return internal::find_subrange(__i, __j, __last, __s_first, __s_last, __pred, false, __is_vector);
+                },
+                std::greater<typename std::iterator_traits<_ForwardIterator1>::difference_type>(), /*is_first=*/false);
+        });
+    }
+}
+#endif
+
+//------------------------------------------------------------------------
+// find_first_of
+//------------------------------------------------------------------------
+template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1
+brick_find_first_of(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+                    _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*__is_vector=*/std::false_type) noexcept
+{
+    return std::find_first_of(__first, __last, __s_first, __s_last, __pred);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1
+brick_find_first_of(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+                    _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*__is_vector=*/std::true_type) noexcept
+{
+    return unseq_backend::simd_find_first_of(__first, __last, __s_first, __s_last, __pred);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate,
+          class _IsVector>
+_ForwardIterator1
+pattern_find_first_of(_ExecutionPolicy&&, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                      _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred,
+                      _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_find_first_of(__first, __last, __s_first, __s_last, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate,
+          class _IsVector>
+_ForwardIterator1
+pattern_find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                      _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred,
+                      _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept
+{
+    return except_handler([&]() {
+        return internal::parallel_find(
+            std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            [__s_first, __s_last, __pred, __is_vector](_ForwardIterator1 __i, _ForwardIterator1 __j) {
+                return internal::brick_find_first_of(__i, __j, __s_first, __s_last, __pred, __is_vector);
+            },
+            std::less<typename std::iterator_traits<_ForwardIterator1>::difference_type>(), /*is_first=*/true);
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// search
+//------------------------------------------------------------------------
+template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1
+brick_search(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+             _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*vector=*/std::false_type) noexcept
+{
+    return std::search(__first, __last, __s_first, __s_last, __pred);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1
+brick_search(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+             _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*vector=*/std::true_type) noexcept
+{
+    return internal::find_subrange(__first, __last, __last, __s_first, __s_last, __pred, true, std::true_type());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate,
+          class _IsVector>
+_ForwardIterator1
+pattern_search(_ExecutionPolicy&&, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+               _ForwardIterator2 __s_last, _BinaryPredicate __pred, _IsVector __is_vector,
+               /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_search(__first, __last, __s_first, __s_last, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate,
+          class _IsVector>
+_ForwardIterator1
+pattern_search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, _IsVector __is_vector,
+               /*is_parallel=*/std::true_type) noexcept
+{
+    if (__last - __first == __s_last - __s_first)
+    {
+        const bool __res = internal::pattern_equal(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first,
+                                                   __pred, __is_vector, std::true_type());
+        return __res ? __first : __last;
+    }
+    else
+    {
+        return except_handler([&]() {
+            return internal::parallel_find(
+                std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                [__last, __s_first, __s_last, __pred, __is_vector](_ForwardIterator1 __i, _ForwardIterator1 __j) {
+                    return internal::find_subrange(__i, __j, __last, __s_first, __s_last, __pred, true, __is_vector);
+                },
+                std::less<typename std::iterator_traits<_ForwardIterator1>::difference_type>(), /*is_first=*/true);
+        });
+    }
+}
+#endif
+
+//------------------------------------------------------------------------
+// search_n
+//------------------------------------------------------------------------
+template <class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
+_ForwardIterator
+brick_search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value,
+               _BinaryPredicate __pred, /*vector=*/std::false_type) noexcept
+{
+    return std::search_n(__first, __last, __count, __value, __pred);
+}
+
+template <class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
+_ForwardIterator
+brick_search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value,
+               _BinaryPredicate __pred, /*vector=*/std::true_type) noexcept
+{
+    return internal::find_subrange(__first, __last, __last, __count, __value, __pred, std::true_type());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate,
+          class _IsVector>
+_ForwardIterator
+pattern_search_n(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Size __count,
+                 const _Tp& __value, _BinaryPredicate __pred, _IsVector __is_vector,
+                 /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_search_n(__first, __last, __count, __value, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Size, class _Tp, class _BinaryPredicate,
+          class _IsVector>
+_RandomAccessIterator
+pattern_search_n(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Size __count,
+                 const _Tp& __value, _BinaryPredicate __pred, _IsVector __is_vector,
+                 /*is_parallel=*/std::true_type) noexcept
+{
+    if (__last - __first == __count)
+    {
+        const bool __result =
+            !internal::pattern_any_of(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                      [&__value, &__pred](const _Tp& __val) { return !__pred(__val, __value); },
+                                      __is_vector, /*is_parallel*/ std::true_type());
+        return __result ? __first : __last;
+    }
+    else
+    {
+        return except_handler([&__exec, __first, __last, __count, &__value, __pred, __is_vector]() {
+            return internal::parallel_find(
+                std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                [__last, __count, &__value, __pred, __is_vector](_RandomAccessIterator __i, _RandomAccessIterator __j) {
+                    return internal::find_subrange(__i, __j, __last, __count, __value, __pred, __is_vector);
+                },
+                std::less<typename std::iterator_traits<_RandomAccessIterator>::difference_type>(), /*is_first=*/true);
+        });
+    }
+}
+#endif
+
+//------------------------------------------------------------------------
+// copy_n
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class _Size, class _OutputIterator>
+_OutputIterator
+brick_copy_n(_ForwardIterator __first, _Size __n, _OutputIterator __result, /*vector=*/std::false_type) noexcept
+{
+    return std::copy_n(__first, __n, __result);
+}
+
+template <class _ForwardIterator, class _Size, class _OutputIterator>
+_OutputIterator
+brick_copy_n(_ForwardIterator __first, _Size __n, _OutputIterator __result, /*vector=*/std::true_type) noexcept
+{
+    return unseq_backend::simd_assign(__first, __n, __result,
+                                      [](_ForwardIterator __first, _OutputIterator __result) { *__result = *__first; });
+}
+
+//------------------------------------------------------------------------
+// copy
+//------------------------------------------------------------------------
+template <class _ForwardIterator, class _OutputIterator>
+_OutputIterator
+brick_copy(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+           /*vector=*/std::false_type) noexcept
+{
+    return std::copy(__first, __last, __result);
+}
+
+template <class _RandomAccessIterator, class _OutputIterator>
+_OutputIterator
+brick_copy(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
+           /*vector=*/std::true_type) noexcept
+{
+    return unseq_backend::simd_assign(
+        __first, __last - __first, __result,
+        [](_RandomAccessIterator __first, _OutputIterator __result) { *__result = *__first; });
+}
+
+//------------------------------------------------------------------------
+// move
+//------------------------------------------------------------------------
+template <class _ForwardIterator, class _OutputIterator>
+_OutputIterator
+brick_move(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+           /*vector=*/std::false_type) noexcept
+{
+    return std::move(__first, __last, __result);
+}
+
+template <class _RandomAccessIterator, class _OutputIterator>
+_OutputIterator
+brick_move(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
+           /*vector=*/std::true_type) noexcept
+{
+    return unseq_backend::simd_assign(
+        __first, __last - __first, __result,
+        [](_RandomAccessIterator __first, _OutputIterator __result) { *__result = std::move(*__first); });
+}
+
+//------------------------------------------------------------------------
+// swap_ranges
+//------------------------------------------------------------------------
+template <class _ForwardIterator, class _OutputIterator>
+_OutputIterator
+brick_swap_ranges(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                  /*vector=*/std::false_type) noexcept
+{
+    return std::swap_ranges(__first, __last, __result);
+}
+
+template <class _ForwardIterator, class _OutputIterator>
+_OutputIterator
+brick_swap_ranges(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                  /*vector=*/std::true_type) noexcept
+{
+    using std::iter_swap;
+    return unseq_backend::simd_assign(__first, __last - __first, __result,
+                                      iter_swap<_ForwardIterator, _OutputIterator>);
+}
+
+//------------------------------------------------------------------------
+// copy_if
+//------------------------------------------------------------------------
+template <class _ForwardIterator, class _OutputIterator, class _UnaryPredicate>
+_OutputIterator
+brick_copy_if(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result, _UnaryPredicate __pred,
+              /*vector=*/std::false_type) noexcept
+{
+    return std::copy_if(__first, __last, __result, __pred);
+}
+
+template <class _ForwardIterator, class _OutputIterator, class _UnaryPredicate>
+_OutputIterator
+brick_copy_if(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result, _UnaryPredicate __pred,
+              /*vector=*/std::true_type) noexcept
+{
+#if (__PSTL_MONOTONIC_PRESENT)
+    return unseq_backend::simd_copy_if(__first, __last - __first, __result, __pred);
+#else
+    return std::copy_if(__first, __last, __result, __pred);
+#endif
+}
+
+// TODO: Try to use transform_reduce for combining brick_copy_if_phase1 on IsVector.
+template <class _DifferenceType, class _ForwardIterator, class _UnaryPredicate>
+std::pair<_DifferenceType, _DifferenceType>
+brick_calc_mask_1(_ForwardIterator __first, _ForwardIterator __last, bool* __restrict __mask, _UnaryPredicate __pred,
+                  /*vector=*/std::false_type) noexcept
+{
+    auto __count_true = _DifferenceType(0);
+    auto __size = __last - __first;
+
+    static_assert(internal::is_random_access_iterator<_ForwardIterator>::value,
+                  "Pattern-brick error. Should be a random access iterator.");
+
+    for (; __first != __last; ++__first, ++__mask)
+    {
+        *__mask = __pred(*__first);
+        if (*__mask)
+        {
+            ++__count_true;
+        }
+    }
+    return std::make_pair(__count_true, __size - __count_true);
+}
+
+template <class _DifferenceType, class _RandomAccessIterator, class _UnaryPredicate>
+std::pair<_DifferenceType, _DifferenceType>
+brick_calc_mask_1(_RandomAccessIterator __first, _RandomAccessIterator __last, bool* __mask, _UnaryPredicate __pred,
+                  /*vector=*/std::true_type) noexcept
+{
+    auto __result = unseq_backend::simd_calc_mask_1(__first, __last - __first, __mask, __pred);
+    return std::make_pair(__result, (__last - __first) - __result);
+}
+
+template <class _ForwardIterator, class _OutputIterator, class _Assigner>
+void
+brick_copy_by_mask(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result, bool* __mask,
+                   _Assigner __assigner, /*vector=*/std::false_type) noexcept
+{
+    for (; __first != __last; ++__first, ++__mask)
+    {
+        if (*__mask)
+        {
+            __assigner(__first, __result);
+            ++__result;
+        }
+    }
+}
+
+template <class _ForwardIterator, class _OutputIterator, class _Assigner>
+void
+brick_copy_by_mask(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result, bool* __restrict __mask,
+                   _Assigner __assigner, /*vector=*/std::true_type) noexcept
+{
+#if (__PSTL_MONOTONIC_PRESENT)
+    unseq_backend::simd_copy_by_mask(__first, __last - __first, __result, __mask, __assigner);
+#else
+    internal::brick_copy_by_mask(__first, __last, __result, __mask, __assigner, std::false_type());
+#endif
+}
+
+template <class _ForwardIterator, class _OutputIterator1, class _OutputIterator2>
+void
+brick_partition_by_mask(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator1 __out_true,
+                        _OutputIterator2 __out_false, bool* __mask, /*vector=*/std::false_type) noexcept
+{
+    for (; __first != __last; ++__first, ++__mask)
+    {
+        if (*__mask)
+        {
+            *__out_true = *__first;
+            ++__out_true;
+        }
+        else
+        {
+            *__out_false = *__first;
+            ++__out_false;
+        }
+    }
+}
+
+template <class _RandomAccessIterator, class _OutputIterator1, class _OutputIterator2>
+void
+brick_partition_by_mask(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator1 __out_true,
+                        _OutputIterator2 __out_false, bool* __mask, /*vector=*/std::true_type) noexcept
+{
+#if (__PSTL_MONOTONIC_PRESENT)
+    unseq_backend::simd_partition_by_mask(__first, __last - __first, __out_true, __out_false, __mask);
+#else
+    internal::brick_partition_by_mask(__first, __last, __out_true, __out_false, __mask, std::false_type());
+#endif
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _UnaryPredicate, class _IsVector>
+_OutputIterator
+pattern_copy_if(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                _UnaryPredicate __pred, _IsVector __is_vector, /*parallel=*/std::false_type) noexcept
+{
+    return internal::brick_copy_if(__first, __last, __result, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator, class _UnaryPredicate,
+          class _IsVector>
+_OutputIterator
+pattern_copy_if(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                _OutputIterator __result, _UnaryPredicate __pred, _IsVector __is_vector, /*parallel=*/std::true_type)
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
+    const _DifferenceType __n = __last - __first;
+    if (_DifferenceType(1) < __n)
+    {
+        par_backend::buffer<bool> __mask_buf(std::forward<_ExecutionPolicy>(__exec), __n);
+        return except_handler([&__exec, __n, __first, __last, __result, __is_vector, __pred, &__mask_buf]() {
+            bool* __mask = __mask_buf.get();
+            _DifferenceType __m{};
+            par_backend::parallel_strict_scan(
+                std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
+                [=](_DifferenceType __i, _DifferenceType __len) { // Reduce
+                    return brick_calc_mask_1<_DifferenceType>(__first + __i, __first + (__i + __len), __mask + __i,
+                                                              __pred, __is_vector)
+                        .first;
+                },
+                std::plus<_DifferenceType>(),                                                // Combine
+                [=](_DifferenceType __i, _DifferenceType __len, _DifferenceType __initial) { // Scan
+                    brick_copy_by_mask(__first + __i, __first + (__i + __len), __result + __initial, __mask + __i,
+                                       [](_RandomAccessIterator __x, _OutputIterator __z) { *__z = *__x; },
+                                       __is_vector);
+                },
+                [&__m](_DifferenceType __total) { __m = __total; });
+            return __result + __m;
+        });
+    }
+    // trivial sequence - use serial algorithm
+    return brick_copy_if(__first, __last, __result, __pred, __is_vector);
+}
+#endif
+
+//------------------------------------------------------------------------
+// count
+//------------------------------------------------------------------------
+template <class _ForwardIterator, class _Predicate>
+typename std::iterator_traits<_ForwardIterator>::difference_type
+brick_count(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred,
+            /* is_vector = */ std::true_type) noexcept
+{
+    return unseq_backend::simd_count(__first, __last - __first, __pred);
+}
+
+template <class _ForwardIterator, class _Predicate>
+typename std::iterator_traits<_ForwardIterator>::difference_type
+brick_count(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred,
+            /* is_vector = */ std::false_type) noexcept
+{
+    return std::count_if(__first, __last, __pred);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate, class _IsVector>
+typename std::iterator_traits<_ForwardIterator>::difference_type
+pattern_count(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred,
+              /* is_parallel */ std::false_type, _IsVector __is_vector) noexcept
+{
+    return brick_count(__first, __last, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate, class _IsVector>
+typename std::iterator_traits<_ForwardIterator>::difference_type
+pattern_count(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred,
+              /* is_parallel */ std::true_type, _IsVector __is_vector)
+{
+    typedef typename std::iterator_traits<_ForwardIterator>::difference_type _SizeType;
+    return except_handler([&]() {
+        return par_backend::parallel_reduce(
+            std::forward<_ExecutionPolicy>(__exec), __first, __last, _SizeType(0),
+            [__pred, __is_vector](_ForwardIterator __begin, _ForwardIterator __end, _SizeType __value) -> _SizeType {
+                return __value + brick_count(__begin, __end, __pred, __is_vector);
+            },
+            std::plus<_SizeType>());
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// unique
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class _BinaryPredicate>
+_ForwardIterator
+brick_unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred,
+             /*is_vector=*/std::false_type) noexcept
+{
+    return std::unique(__first, __last, __pred);
+}
+
+template <class _ForwardIterator, class _BinaryPredicate>
+_ForwardIterator
+brick_unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred,
+             /*is_vector=*/std::true_type) noexcept
+{
+    __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
+    return std::unique(__first, __last, __pred);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate, class _IsVector>
+_ForwardIterator
+pattern_unique(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred,
+               _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_unique(__first, __last, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+// That function is shared between two algorithms - remove_if (pattern_remove_if) and unique (pattern unique). But a mask calculation is different.
+// So, a caller passes _CalcMask brick into remove_elements.
+template <class _ExecutionPolicy, class _ForwardIterator, class _CalcMask, class _IsVector>
+_ForwardIterator
+remove_elements(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _CalcMask __calc_mask,
+                _IsVector __is_vector)
+{
+    typedef typename std::iterator_traits<_ForwardIterator>::difference_type _DifferenceType;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _Tp;
+    _DifferenceType __n = __last - __first;
+    par_backend::buffer<bool> __mask_buf(std::forward<_ExecutionPolicy>(__exec), __n);
+    // 1. find a first iterator that should be removed
+    return except_handler([&]() {
+        bool* __mask = __mask_buf.get();
+        _DifferenceType __min = par_backend::parallel_reduce(
+            std::forward<_ExecutionPolicy>(__exec), _DifferenceType(0), __n, __n,
+            [__first, __mask, &__calc_mask, __is_vector](_DifferenceType __i, _DifferenceType __j,
+                                                         _DifferenceType __local_min) -> _DifferenceType {
+                // Create mask
+                __calc_mask(__mask + __i, __mask + __j, __first + __i);
+
+                // if minimum was found in a previous range we shouldn't do anymore
+                if (__local_min < __i)
+                {
+                    return __local_min;
+                }
+                // find first iterator that should be removed
+                bool* __result =
+                    brick_find_if(__mask + __i, __mask + __j, [](bool __val) { return !__val; }, __is_vector);
+                if (__result - __mask == __j)
+                {
+                    return __local_min;
+                }
+                return std::min(__local_min, _DifferenceType(__result - __mask));
+            },
+            [](_DifferenceType __local_min1, _DifferenceType __local_min2) -> _DifferenceType {
+                return std::min(__local_min1, __local_min2);
+            });
+
+        // No elements to remove - exit
+        if (__min == __n)
+        {
+            return __last;
+        }
+        __n -= __min;
+        __first += __min;
+
+        par_backend::buffer<_Tp> __buf(std::forward<_ExecutionPolicy>(__exec), __n);
+        _Tp* __result = __buf.get();
+        __mask += __min;
+        _DifferenceType __m{};
+        // 2. Elements that doesn't satisfy pred are moved to result
+        par_backend::parallel_strict_scan(
+            std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
+            [__mask, __is_vector](_DifferenceType __i, _DifferenceType __len) {
+                return brick_count(__mask + __i, __mask + __i + __len, [](bool __val) { return __val; }, __is_vector);
+            },
+            std::plus<_DifferenceType>(),
+            [=](_DifferenceType __i, _DifferenceType __len, _DifferenceType __initial) {
+                brick_copy_by_mask(__first + __i, __first + __i + __len, __result + __initial, __mask + __i,
+                                   [](_ForwardIterator __x, _Tp* __z) {
+                                       invoke_if_else(std::is_trivial<_Tp>(), [&]() { *__z = std::move(*__x); },
+                                                      [&]() { ::new (std::addressof(*__z)) _Tp(std::move(*__x)); });
+                                   },
+                                   __is_vector);
+            },
+            [&__m](_DifferenceType __total) { __m = __total; });
+
+        // 3. Elements from result are moved to [first, last)
+        par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __result, __result + __m,
+                                  [__result, __first, __is_vector](_Tp* __i, _Tp* __j) {
+                                      brick_move(__i, __j, __first + (__i - __result), __is_vector);
+                                  });
+        return __first + __m;
+    });
+}
+#endif
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate, class _IsVector>
+_ForwardIterator
+pattern_unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred,
+               _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept
+{
+    typedef typename std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
+
+    if (__first == __last)
+    {
+        return __last;
+    }
+    if (__first + 1 == __last || __first + 2 == __last)
+    {
+        // Trivial sequence - use serial algorithm
+        return brick_unique(__first, __last, __pred, __is_vector);
+    }
+    return remove_elements(
+        std::forward<_ExecutionPolicy>(__exec), ++__first, __last,
+        [&__pred, __is_vector](bool* __b, bool* __e, _ForwardIterator __it) {
+            brick_walk3(__b, __e, __it - 1, __it,
+                        [&__pred](bool& __x, _ReferenceType __y, _ReferenceType __z) { __x = !__pred(__y, __z); },
+                        __is_vector);
+        },
+        __is_vector);
+}
+#endif
+
+//------------------------------------------------------------------------
+// unique_copy
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class OutputIterator, class _BinaryPredicate>
+OutputIterator
+brick_unique_copy(_ForwardIterator __first, _ForwardIterator __last, OutputIterator __result, _BinaryPredicate __pred,
+                  /*vector=*/std::false_type) noexcept
+{
+    return std::unique_copy(__first, __last, __result, __pred);
+}
+
+template <class _RandomAccessIterator, class OutputIterator, class _BinaryPredicate>
+OutputIterator
+brick_unique_copy(_RandomAccessIterator __first, _RandomAccessIterator __last, OutputIterator __result,
+                  _BinaryPredicate __pred, /*vector=*/std::true_type) noexcept
+{
+#if (__PSTL_MONOTONIC_PRESENT)
+    return unseq_backend::simd_unique_copy(__first, __last - __first, __result, __pred);
+#else
+    return std::unique_copy(__first, __last, __result, __pred);
+#endif
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _BinaryPredicate,
+          class _IsVector>
+_OutputIterator
+pattern_unique_copy(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                    _BinaryPredicate __pred, _IsVector __is_vector, /*parallel=*/std::false_type) noexcept
+{
+    return internal::brick_unique_copy(__first, __last, __result, __pred, __is_vector);
+}
+
+template <class _DifferenceType, class _RandomAccessIterator, class _BinaryPredicate>
+_DifferenceType
+brick_calc_mask_2(_RandomAccessIterator __first, _RandomAccessIterator __last, bool* __restrict __mask,
+                  _BinaryPredicate __pred, /*vector=*/std::false_type) noexcept
+{
+    _DifferenceType __count = 0;
+    for (; __first != __last; ++__first, ++__mask)
+    {
+        *__mask = !__pred(*__first, *(__first - 1));
+        __count += *__mask;
+    }
+    return __count;
+}
+
+template <class _DifferenceType, class _RandomAccessIterator, class _BinaryPredicate>
+_DifferenceType
+brick_calc_mask_2(_RandomAccessIterator __first, _RandomAccessIterator __last, bool* __restrict __mask,
+                  _BinaryPredicate __pred, /*vector=*/std::true_type) noexcept
+{
+    return unseq_backend::simd_calc_mask_2(__first, __last - __first, __mask, __pred);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator, class _BinaryPredicate,
+          class _IsVector>
+_OutputIterator
+pattern_unique_copy(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                    _OutputIterator __result, _BinaryPredicate __pred, _IsVector __is_vector,
+                    /*parallel=*/std::true_type)
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
+    const _DifferenceType __n = __last - __first;
+    if (_DifferenceType(2) < __n)
+    {
+        par_backend::buffer<bool> __mask_buf(std::forward<_ExecutionPolicy>(__exec), __n);
+        if (_DifferenceType(2) < __n)
+        {
+            return internal::except_handler([&__exec, __n, __first, __result, __pred, __is_vector, &__mask_buf]() {
+                bool* __mask = __mask_buf.get();
+                _DifferenceType __m{};
+                par_backend::parallel_strict_scan(
+                    std::forward<_ExecutionPolicy>(__exec), __n, _DifferenceType(0),
+                    [=](_DifferenceType __i, _DifferenceType __len) -> _DifferenceType { // Reduce
+                        _DifferenceType __extra = 0;
+                        if (__i == 0)
+                        {
+                            // Special boundary case
+                            __mask[__i] = true;
+                            if (--__len == 0)
+                                return 1;
+                            ++__i;
+                            ++__extra;
+                        }
+                        return brick_calc_mask_2<_DifferenceType>(__first + __i, __first + (__i + __len), __mask + __i,
+                                                                  __pred, __is_vector) +
+                               __extra;
+                    },
+                    std::plus<_DifferenceType>(),                                                // Combine
+                    [=](_DifferenceType __i, _DifferenceType __len, _DifferenceType __initial) { // Scan
+                        // Phase 2 is same as for pattern_copy_if
+                        internal::brick_copy_by_mask(
+                            __first + __i, __first + (__i + __len), __result + __initial, __mask + __i,
+                            [](_RandomAccessIterator __x, _OutputIterator __z) { *__z = *__x; }, __is_vector);
+                    },
+                    [&__m](_DifferenceType __total) { __m = __total; });
+                return __result + __m;
+            });
+        }
+    }
+    // trivial sequence - use serial algorithm
+    return brick_unique_copy(__first, __last, __result, __pred, __is_vector);
+}
+#endif
+
+//------------------------------------------------------------------------
+// reverse
+//------------------------------------------------------------------------
+template <class _BidirectionalIterator>
+void
+brick_reverse(_BidirectionalIterator __first, _BidirectionalIterator __last, /*__is_vector=*/std::false_type) noexcept
+{
+    std::reverse(__first, __last);
+}
+
+template <class _BidirectionalIterator>
+void
+brick_reverse(_BidirectionalIterator __first, _BidirectionalIterator __last, /*__is_vector=*/std::true_type) noexcept
+{
+    typedef typename std::iterator_traits<_BidirectionalIterator>::reference _ReferenceType;
+
+    const auto __n = (__last - __first) / 2;
+    unseq_backend::simd_walk_2(__first, __n, std::reverse_iterator<_BidirectionalIterator>(__last),
+                               [](_ReferenceType __x, _ReferenceType __y) {
+                                   using std::swap;
+                                   swap(__x, __y);
+                               });
+}
+
+// this brick is called in parallel version, so we can use iterator arithmetic
+template <class _BidirectionalIterator>
+void
+brick_reverse(_BidirectionalIterator __first, _BidirectionalIterator __last, _BidirectionalIterator __d_last,
+              /*is_vector=*/std::false_type) noexcept
+{
+    for (--__d_last; __first != __last; ++__first, --__d_last)
+    {
+        using std::iter_swap;
+        iter_swap(__first, __d_last);
+    }
+}
+
+// this brick is called in parallel version, so we can use iterator arithmetic
+template <class _BidirectionalIterator>
+void
+brick_reverse(_BidirectionalIterator __first, _BidirectionalIterator __last, _BidirectionalIterator __d_last,
+              /*is_vector=*/std::true_type) noexcept
+{
+    typedef typename std::iterator_traits<_BidirectionalIterator>::reference _ReferenceType;
+
+    unseq_backend::simd_walk_2(__first, __last - __first, std::reverse_iterator<_BidirectionalIterator>(__d_last),
+                               [](_ReferenceType __x, _ReferenceType __y) {
+                                   using std::swap;
+                                   swap(__x, __y);
+                               });
+}
+
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _IsVector>
+void
+pattern_reverse(_ExecutionPolicy&&, _BidirectionalIterator __first, _BidirectionalIterator __last, _IsVector _is_vector,
+                /*is_parallel=*/std::false_type) noexcept
+{
+    brick_reverse(__first, __last, _is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _IsVector>
+void
+pattern_reverse(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last,
+                _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+    par_backend::parallel_for(
+        std::forward<_ExecutionPolicy>(__exec), __first, __first + (__last - __first) / 2,
+        [__is_vector, __first, __last](_BidirectionalIterator __inner_first, _BidirectionalIterator __inner_last) {
+            brick_reverse(__inner_first, __inner_last, __last - (__inner_first - __first), __is_vector);
+        });
+}
+#endif
+
+//------------------------------------------------------------------------
+// reverse_copy
+//------------------------------------------------------------------------
+
+template <class _BidirectionalIterator, class _OutputIterator>
+_OutputIterator
+brick_reverse_copy(_BidirectionalIterator __first, _BidirectionalIterator __last, _OutputIterator __d_first,
+                   /*is_vector=*/std::false_type) noexcept
+{
+    return std::reverse_copy(__first, __last, __d_first);
+}
+
+template <class _BidirectionalIterator, class _OutputIterator>
+_OutputIterator
+brick_reverse_copy(_BidirectionalIterator __first, _BidirectionalIterator __last, _OutputIterator __d_first,
+                   /*is_vector=*/std::true_type) noexcept
+{
+    typedef typename std::iterator_traits<_BidirectionalIterator>::reference _ReferenceType1;
+    typedef typename std::iterator_traits<_OutputIterator>::reference _ReferenceType2;
+
+    return unseq_backend::simd_walk_2(std::reverse_iterator<_BidirectionalIterator>(__last), __last - __first,
+                                      __d_first, [](_ReferenceType1 __x, _ReferenceType2 __y) { __y = __x; });
+}
+
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _OutputIterator, class _IsVector>
+_OutputIterator
+pattern_reverse_copy(_ExecutionPolicy&&, _BidirectionalIterator __first, _BidirectionalIterator __last,
+                     _OutputIterator __d_first, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_reverse_copy(__first, __last, __d_first, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _OutputIterator, class _IsVector>
+_OutputIterator
+pattern_reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last,
+                     _OutputIterator __d_first, _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+    auto __len = __last - __first;
+    par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                              [__is_vector, __first, __len, __d_first](_BidirectionalIterator __inner_first,
+                                                                       _BidirectionalIterator __inner_last) {
+                                  brick_reverse_copy(__inner_first, __inner_last,
+                                                     __d_first + (__len - (__inner_last - __first)), __is_vector);
+                              });
+    return __d_first + __len;
+}
+#endif
+
+//------------------------------------------------------------------------
+// rotate
+//------------------------------------------------------------------------
+template <class _ForwardIterator>
+_ForwardIterator
+brick_rotate(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last,
+             /*is_vector=*/std::false_type) noexcept
+{
+#if __PSTL_CPP11_STD_ROTATE_BROKEN
+    std::rotate(__first, __middle, __last);
+    return std::next(__first, std::distance(__middle, __last));
+#else
+    return std::rotate(__first, __middle, __last);
+#endif
+}
+
+template <class _ForwardIterator>
+_ForwardIterator
+brick_rotate(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last,
+             /*is_vector=*/std::true_type) noexcept
+{
+    auto __n = __last - __first;
+    auto __m = __middle - __first;
+    const _ForwardIterator __ret = __first + (__last - __middle);
+
+    bool __is_left = (__m <= __n / 2);
+    if (!__is_left)
+        __m = __n - __m;
+
+    while (__n > 1 && __m > 0)
+    {
+        using std::iter_swap;
+        const auto __m_2 = __m * 2;
+        if (__is_left)
+        {
+            for (; __last - __first >= __m_2; __first += __m)
+            {
+                unseq_backend::simd_assign(__first, __m, __first + __m, iter_swap<_ForwardIterator, _ForwardIterator>);
+            }
+        }
+        else
+        {
+            for (; __last - __first >= __m_2; __last -= __m)
+            {
+                unseq_backend::simd_assign(__last - __m, __m, __last - __m_2,
+                                           iter_swap<_ForwardIterator, _ForwardIterator>);
+            }
+        }
+        __is_left = !__is_left;
+        __m = __n % __m;
+        __n = __last - __first;
+    }
+
+    return __ret;
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _IsVector>
+_ForwardIterator
+pattern_rotate(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last,
+               _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_rotate(__first, __middle, __last, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _IsVector>
+_ForwardIterator
+pattern_rotate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last,
+               _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _Tp;
+    auto __n = __last - __first;
+    auto __m = __middle - __first;
+    if (__m <= __n / 2)
+    {
+        par_backend::buffer<_Tp> __buf(std::forward<_ExecutionPolicy>(__exec), __n - __m);
+        return except_handler([&__exec, __n, __m, __first, __middle, __last, __is_vector, &__buf]() {
+            _Tp* __result = __buf.get();
+            par_backend::parallel_for(
+                std::forward<_ExecutionPolicy>(__exec), __middle, __last,
+                [__first, __last, __middle, __result, __is_vector](_ForwardIterator __b, _ForwardIterator __e) {
+                    brick_uninitialized_move(__b, __e, __result + (__b - __middle), __is_vector);
+                });
+
+            par_backend::parallel_for(
+                std::forward<_ExecutionPolicy>(__exec), __first, __middle,
+                [__first, __last, __middle, __result, __is_vector](_ForwardIterator __b, _ForwardIterator __e) {
+                    brick_move(__b, __e, __b + (__last - __middle), __is_vector);
+                });
+
+            par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __result, __result + (__n - __m),
+                                      [__first, __result, __is_vector](_Tp* __b, _Tp* __e) {
+                                          brick_move(__b, __e, __first + (__b - __result), __is_vector);
+                                      });
+
+            return __first + (__last - __middle);
+        });
+    }
+    else
+    {
+        par_backend::buffer<_Tp> __buf(std::forward<_ExecutionPolicy>(__exec), __m);
+        return except_handler([&__exec, __n, __m, __first, __middle, __last, __is_vector, &__buf]() {
+            _Tp* __result = __buf.get();
+            par_backend::parallel_for(
+                std::forward<_ExecutionPolicy>(__exec), __first, __middle,
+                [__m, __first, __last, __middle, __result, __is_vector](_ForwardIterator __b, _ForwardIterator __e) {
+                    brick_uninitialized_move(__b, __e, __result + (__b - __first), __is_vector);
+                });
+
+            par_backend::parallel_for(
+                std::forward<_ExecutionPolicy>(__exec), __middle, __last,
+                [__first, __last, __middle, __result, __is_vector](_ForwardIterator __b, _ForwardIterator __e) {
+                    brick_move(__b, __e, __first + (__b - __middle), __is_vector);
+                });
+
+            par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __result, __result + __m,
+                                      [__n, __m, __first, __result, __is_vector](_Tp* __b, _Tp* __e) {
+                                          brick_move(__b, __e, __first + ((__n - __m) + (__b - __result)), __is_vector);
+                                      });
+
+            return __first + (__last - __middle);
+        });
+    }
+}
+#endif
+
+//------------------------------------------------------------------------
+// rotate_copy
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class _OutputIterator>
+_OutputIterator
+brick_rotate_copy(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last,
+                  _OutputIterator __result, /*__is_vector=*/std::false_type) noexcept
+{
+    return std::rotate_copy(__first, __middle, __last, __result);
+}
+
+template <class _ForwardIterator, class _OutputIterator>
+_OutputIterator
+brick_rotate_copy(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last,
+                  _OutputIterator __result, /*__is_vector=*/std::true_type) noexcept
+{
+    _OutputIterator __res = brick_copy(__middle, __last, __result, std::true_type());
+    return brick_copy(__first, __middle, __res, std::true_type());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _IsVector>
+_OutputIterator
+pattern_rotate_copy(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last,
+                    _OutputIterator __result, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_rotate_copy(__first, __middle, __last, __result, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _IsVector>
+_OutputIterator
+pattern_rotate_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __middle,
+                    _ForwardIterator __last, _OutputIterator __result, _IsVector __is_vector,
+                    /*is_parallel=*/std::true_type)
+{
+    par_backend::parallel_for(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        [__first, __last, __middle, __result, __is_vector](_ForwardIterator __b, _ForwardIterator __e) {
+            if (__b > __middle)
+            {
+                brick_copy(__b, __e, __result + (__b - __middle), __is_vector);
+            }
+            else
+            {
+                _OutputIterator __new_result = __result + ((__last - __middle) + (__b - __first));
+                if (__e < __middle)
+                {
+                    brick_copy(__b, __e, __new_result, __is_vector);
+                }
+                else
+                {
+                    brick_copy(__b, __middle, __new_result, __is_vector);
+                    brick_copy(__middle, __e, __result, __is_vector);
+                }
+            }
+        });
+    return __result + (__last - __first);
+}
+#endif
+
+//------------------------------------------------------------------------
+// is_partitioned
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class _UnaryPredicate>
+bool
+brick_is_partitioned(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+                     /*is_vector=*/std::false_type) noexcept
+{
+    return std::is_partitioned(__first, __last, __pred);
+}
+
+template <class _ForwardIterator, class _UnaryPredicate>
+bool
+brick_is_partitioned(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+                     /*is_vector=*/std::true_type) noexcept
+{
+    typedef typename std::iterator_traits<_ForwardIterator>::difference_type _SizeType;
+    if (__first == __last)
+    {
+        return true;
+    }
+    else
+    {
+        _ForwardIterator __result =
+            unseq_backend::simd_first(__first, _SizeType(0), __last - __first,
+                                      [&__pred](_ForwardIterator __it, _SizeType __i) { return !__pred(__it[__i]); });
+        if (__result == __last)
+        {
+            return true;
+        }
+        else
+        {
+            ++__result;
+            return !unseq_backend::simd_or(__result, __last - __result, __pred);
+        }
+    }
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+bool
+pattern_is_partitioned(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+                       _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_is_partitioned(__first, __last, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+bool
+pattern_is_partitioned(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+                       _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+    if (__first == __last)
+    {
+        return true;
+    }
+    else
+    {
+        return except_handler([&]() {
+            typedef typename std::iterator_traits<_ForwardIterator>::difference_type _SizeType;
+
+            // State of current range:
+            // broken     - current range is not partitioned by pred
+            // all_true   - all elements in current range satisfy pred
+            // all_false  - all elements in current range don't satisfy pred
+            // true_false - elements satisfy pred are placed before elements that don't satisfy pred
+            enum _ReduceType
+            {
+                __not_init = -1,
+                __broken,
+                __all_true,
+                __all_false,
+                __true_false
+            };
+            _ReduceType __init = __not_init;
+
+            // Array with states that we'll have when state from the left branch is merged with state from the right branch.
+            // State is calculated by formula: new_state = table[left_state * 4 + right_state]
+            _ReduceType __table[] = {__broken,     __broken,     __broken,     __broken, __broken,    __all_true,
+                                     __true_false, __true_false, __broken,     __broken, __all_false, __broken,
+                                     __broken,     __broken,     __true_false, __broken};
+
+            __init = par_backend::parallel_reduce(
+                std::forward<_ExecutionPolicy>(__exec), __first, __last, __init,
+                [__first, &__pred, &__table, __is_vector](_ForwardIterator __i, _ForwardIterator __j,
+                                                          _ReduceType __value) -> _ReduceType {
+                    if (__value == __broken)
+                    {
+                        return __broken;
+                    }
+                    _ReduceType __res = __not_init;
+                    // if first element satisfy pred
+                    if (__pred(*__i))
+                    {
+                        // find first element that don't satisfy pred
+                        _ForwardIterator __x =
+                            brick_find_if(__i + 1, __j, not_pred<_UnaryPredicate>(__pred), __is_vector);
+                        if (__x != __j)
+                        {
+                            // find first element after "x" that satisfy pred
+                            _ForwardIterator __y = brick_find_if(__x + 1, __j, __pred, __is_vector);
+                            // if it was found then range isn't partitioned by pred
+                            if (__y != __j)
+                            {
+                                return __broken;
+                            }
+                            else
+                            {
+                                __res = __true_false;
+                            }
+                        }
+                        else
+                        {
+                            __res = __all_true;
+                        }
+                    }
+                    else
+                    { // if first element doesn't satisfy pred
+                        // then we should find the first element that satisfy pred.
+                        // If we found it then range isn't partitioned by pred
+                        if (brick_find_if(__i + 1, __j, __pred, __is_vector) != __j)
+                        {
+                            return __broken;
+                        }
+                        else
+                        {
+                            __res = __all_false;
+                        }
+                    }
+                    // if we have value from left range then we should calculate the result
+                    return (__value == -1) ? __res : __table[__value * 4 + __res];
+                },
+
+                [&__table](_ReduceType __val1, _ReduceType __val2) -> _ReduceType {
+                    if (__val1 == __broken || __val2 == __broken)
+                    {
+                        return __broken;
+                    }
+                    // calculate the result for new big range
+                    return __table[__val1 * 4 + __val2];
+                });
+            return __init != __broken;
+        });
+    }
+}
+#endif
+
+//------------------------------------------------------------------------
+// partition
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class _UnaryPredicate>
+_ForwardIterator
+brick_partition(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+                /*is_vector=*/std::false_type) noexcept
+{
+    return std::partition(__first, __last, __pred);
+}
+
+template <class _ForwardIterator, class _UnaryPredicate>
+_ForwardIterator
+brick_partition(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+                /*is_vector=*/std::true_type) noexcept
+{
+    __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
+    return std::partition(__first, __last, __pred);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+_ForwardIterator
+pattern_partition(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+                  _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_partition(__first, __last, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+_ForwardIterator
+pattern_partition(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+                  _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+
+    // partitioned range: elements before pivot satisfy pred (true part),
+    //                    elements after pivot don't satisfy pred (false part)
+    struct _PartitionRange
+    {
+        _ForwardIterator __begin;
+        _ForwardIterator __pivot;
+        _ForwardIterator __end;
+    };
+
+    return except_handler([&]() {
+        _PartitionRange __init{__last, __last, __last};
+
+        // lambda for merging two partitioned ranges to one partitioned range
+        auto __reductor = [&__exec, __first, __is_vector](_PartitionRange __val1,
+                                                          _PartitionRange __val2) -> _PartitionRange {
+            auto __size1 = __val1.__end - __val1.__pivot;
+            auto __size2 = __val2.__pivot - __val2.__begin;
+            auto __new_begin = __val2.__begin - (__val1.__end - __val1.__begin);
+
+            // if all elements in left range satisfy pred then we can move new pivot to pivot of right range
+            if (__val1.__end == __val1.__pivot)
+            {
+                return {__new_begin, __val2.__pivot, __val2.__end};
+            }
+            // if true part of right range greater than false part of left range
+            // then we should swap the false part of left range and last part of true part of right range
+            else if (__size2 > __size1)
+            {
+                par_backend::parallel_for(
+                    std::forward<_ExecutionPolicy>(__exec), __val1.__pivot, __val1.__pivot + __size1,
+                    [__val1, __val2, __size1, __is_vector](_ForwardIterator __i, _ForwardIterator __j) {
+                        brick_swap_ranges(__i, __j, (__val2.__pivot - __size1) + (__i - __val1.__pivot), __is_vector);
+                    });
+                return {__new_begin, __val2.__pivot - __size1, __val2.__end};
+            }
+            // else we should swap the first part of false part of left range and true part of right range
+            else
+            {
+                par_backend::parallel_for(
+                    std::forward<_ExecutionPolicy>(__exec), __val1.__pivot, __val1.__pivot + __size2,
+                    [__val1, __val2, __is_vector](_ForwardIterator __i, _ForwardIterator __j) {
+                        brick_swap_ranges(__i, __j, __val2.__begin + (__i - __val1.__pivot), __is_vector);
+                    });
+                return {__new_begin, __val1.__pivot + __size2, __val2.__end};
+            }
+        };
+
+        _PartitionRange __result = par_backend::parallel_reduce(
+            std::forward<_ExecutionPolicy>(__exec), __first, __last, __init,
+            [__first, __pred, __is_vector, __reductor](_ForwardIterator __i, _ForwardIterator __j,
+                                                       _PartitionRange __value) -> _PartitionRange {
+                //1. serial partition
+                _ForwardIterator __pivot = brick_partition(__i, __j, __pred, __is_vector);
+
+                // 2. merging of two ranges (left and right respectively)
+                return __reductor(__value, {__i, __pivot, __j});
+            },
+            __reductor);
+        return __result.__pivot;
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// stable_partition
+//------------------------------------------------------------------------
+
+template <class _BidirectionalIterator, class _UnaryPredicate>
+_BidirectionalIterator
+brick_stable_partition(_BidirectionalIterator __first, _BidirectionalIterator __last, _UnaryPredicate __pred,
+                       /*__is_vector=*/std::false_type) noexcept
+{
+    return std::stable_partition(__first, __last, __pred);
+}
+
+template <class _BidirectionalIterator, class _UnaryPredicate>
+_BidirectionalIterator
+brick_stable_partition(_BidirectionalIterator __first, _BidirectionalIterator __last, _UnaryPredicate __pred,
+                       /*__is_vector=*/std::true_type) noexcept
+{
+    __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
+    return std::stable_partition(__first, __last, __pred);
+}
+
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _UnaryPredicate, class _IsVector>
+_BidirectionalIterator
+pattern_stable_partition(_ExecutionPolicy&&, _BidirectionalIterator __first, _BidirectionalIterator __last,
+                         _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallelization=*/std::false_type) noexcept
+{
+    return internal::brick_stable_partition(__first, __last, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _UnaryPredicate, class _IsVector>
+_BidirectionalIterator
+pattern_stable_partition(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last,
+                         _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallelization=*/std::true_type) noexcept
+{
+    // partitioned range: elements before pivot satisfy pred (true part),
+    //                    elements after pivot don't satisfy pred (false part)
+    struct _PartitionRange
+    {
+        _BidirectionalIterator __begin;
+        _BidirectionalIterator __pivot;
+        _BidirectionalIterator __end;
+    };
+    typedef typename std::iterator_traits<_BidirectionalIterator>::value_type T;
+
+    return except_handler([&]() {
+        _PartitionRange __init{__last, __last, __last};
+
+        // lambda for merging two partitioned ranges to one partitioned range
+        auto __reductor = [__first, __is_vector, __pred](_PartitionRange __val1,
+                                                         _PartitionRange __val2) -> _PartitionRange {
+            auto __size1 = __val1.__end - __val1.__pivot;
+            auto __new_begin = __val2.__begin - (__val1.__end - __val1.__begin);
+
+            // if all elements in left range satisfy pred then we can move new pivot to pivot of right range
+            if (__val1.__end == __val1.__pivot)
+            {
+                return {__new_begin, __val2.__pivot, __val2.__end};
+            }
+            // if true part of right range greater than false part of left range
+            // then we should swap the false part of left range and last part of true part of right range
+            else
+            {
+                brick_rotate(__val1.__pivot, __val2.__begin, __val2.__pivot, __is_vector);
+                return {__new_begin, __val2.__pivot - __size1, __val2.__end};
+            }
+        };
+
+        _PartitionRange __result = par_backend::parallel_reduce(
+            std::forward<_ExecutionPolicy>(__exec), __first, __last, __init,
+            [__first, &__pred, __is_vector, __reductor](_BidirectionalIterator __i, _BidirectionalIterator __j,
+                                                        _PartitionRange __value) -> _PartitionRange {
+                //1. serial stable_partition
+                _BidirectionalIterator __pivot = brick_stable_partition(__i, __j, __pred, __is_vector);
+
+                // 2. merging of two ranges (left and right respectively)
+                return __reductor(__value, {__i, __pivot, __j});
+            },
+            __reductor);
+        return __result.__pivot;
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// partition_copy
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class _OutputIterator1, class _OutputIterator2, class _UnaryPredicate>
+std::pair<_OutputIterator1, _OutputIterator2>
+brick_partition_copy(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator1 __out_true,
+                     _OutputIterator2 __out_false, _UnaryPredicate __pred, /*is_vector=*/std::false_type) noexcept
+{
+    return std::partition_copy(__first, __last, __out_true, __out_false, __pred);
+}
+
+template <class _ForwardIterator, class _OutputIterator1, class _OutputIterator2, class _UnaryPredicate>
+std::pair<_OutputIterator1, _OutputIterator2>
+brick_partition_copy(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator1 __out_true,
+                     _OutputIterator2 __out_false, _UnaryPredicate __pred, /*is_vector=*/std::true_type) noexcept
+{
+#if (__PSTL_MONOTONIC_PRESENT)
+    return unseq_backend::simd_partition_copy(__first, __last - __first, __out_true, __out_false, __pred);
+#else
+    return std::partition_copy(__first, __last, __out_true, __out_false, __pred);
+#endif
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator1, class _OutputIterator2,
+          class _UnaryPredicate, class _IsVector>
+std::pair<_OutputIterator1, _OutputIterator2>
+pattern_partition_copy(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+                       _OutputIterator1 __out_true, _OutputIterator2 __out_false, _UnaryPredicate __pred,
+                       _IsVector __is_vector, /*is_parallelization=*/std::false_type) noexcept
+{
+    return internal::brick_partition_copy(__first, __last, __out_true, __out_false, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator1, class _OutputIterator2,
+          class _UnaryPredicate, class _IsVector>
+std::pair<_OutputIterator1, _OutputIterator2>
+pattern_partition_copy(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                       _OutputIterator1 __out_true, _OutputIterator2 __out_false, _UnaryPredicate __pred,
+                       _IsVector __is_vector, /*is_parallelization=*/std::true_type)
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
+    typedef std::pair<_DifferenceType, _DifferenceType> _ReturnType;
+    const _DifferenceType __n = __last - __first;
+    if (_DifferenceType(1) < __n)
+    {
+        par_backend::buffer<bool> __mask_buf(std::forward<_ExecutionPolicy>(__exec), __n);
+        return internal::except_handler(
+            [&__exec, __n, __first, __last, __out_true, __out_false, __is_vector, __pred, &__mask_buf]() {
+                bool* __mask = __mask_buf.get();
+                _ReturnType __m{};
+                par_backend::parallel_strict_scan(
+                    std::forward<_ExecutionPolicy>(__exec), __n, std::make_pair(_DifferenceType(0), _DifferenceType(0)),
+                    [=](_DifferenceType __i, _DifferenceType __len) { // Reduce
+                        return internal::brick_calc_mask_1<_DifferenceType>(__first + __i, __first + (__i + __len),
+                                                                            __mask + __i, __pred, __is_vector);
+                    },
+                    [](const _ReturnType& __x, const _ReturnType& __y) -> _ReturnType {
+                        return std::make_pair(__x.first + __y.first, __x.second + __y.second);
+                    },                                                                       // Combine
+                    [=](_DifferenceType __i, _DifferenceType __len, _ReturnType __initial) { // Scan
+                        internal::brick_partition_by_mask(__first + __i, __first + (__i + __len),
+                                                          __out_true + __initial.first, __out_false + __initial.second,
+                                                          __mask + __i, __is_vector);
+                    },
+                    [&__m](_ReturnType __total) { __m = __total; });
+                return std::make_pair(__out_true + __m.first, __out_false + __m.second);
+            });
+    }
+    // trivial sequence - use serial algorithm
+    return internal::brick_partition_copy(__first, __last, __out_true, __out_false, __pred, __is_vector);
+}
+#endif
+
+//------------------------------------------------------------------------
+// sort
+//------------------------------------------------------------------------
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector,
+          class _IsMoveConstructible>
+void
+pattern_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+             _IsVector /*is_vector*/, /*is_parallel=*/std::false_type, _IsMoveConstructible) noexcept
+{
+    std::sort(__first, __last, __comp);
+}
+
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
+void
+pattern_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+             _IsVector /*is_vector*/, /*is_parallel=*/std::true_type, /*is_move_constructible=*/std::true_type)
+{
+    except_handler([&]() {
+        par_backend::parallel_stable_sort(std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+                                          [](_RandomAccessIterator __first, _RandomAccessIterator __last,
+                                             _Compare __comp) { std::sort(__first, __last, __comp); },
+                                          __last - __first);
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// stable_sort
+//------------------------------------------------------------------------
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
+void
+pattern_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+                    _IsVector /*is_vector*/, /*is_parallel=*/std::false_type) noexcept
+{
+    std::stable_sort(__first, __last, __comp);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
+void
+pattern_stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                    _Compare __comp, _IsVector /*is_vector*/, /*is_parallel=*/std::true_type)
+{
+    internal::except_handler([&]() {
+        par_backend::parallel_stable_sort(std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+                                          [](_RandomAccessIterator __first, _RandomAccessIterator __last,
+                                             _Compare __comp) { std::stable_sort(__first, __last, __comp); });
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// partial_sort
+//------------------------------------------------------------------------
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
+void
+pattern_partial_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __middle,
+                     _RandomAccessIterator __last, _Compare __comp, _IsVector, /*is_parallel=*/std::false_type) noexcept
+{
+    std::partial_sort(__first, __middle, __last, __comp);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
+void
+pattern_partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle,
+                     _RandomAccessIterator __last, _Compare __comp, _IsVector, /*is_parallel=*/std::true_type)
+{
+    const auto __n = __middle - __first;
+    except_handler([&]() {
+        par_backend::parallel_stable_sort(
+            std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+            [__n](_RandomAccessIterator __begin, _RandomAccessIterator __end, _Compare __comp) {
+                if (__n < __end - __begin)
+                    std::partial_sort(__begin, __begin + __n, __end, __comp);
+                else
+                    std::sort(__begin, __end, __comp);
+            },
+            __n);
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// partial_sort_copy
+//------------------------------------------------------------------------
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare, class _IsVector>
+_RandomAccessIterator
+pattern_partial_sort_copy(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+                          _RandomAccessIterator __d_first, _RandomAccessIterator __d_last, _Compare __comp, _IsVector,
+                          /*is_parallel=*/std::false_type) noexcept
+{
+    return std::partial_sort_copy(__first, __last, __d_first, __d_last, __comp);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare, class _IsVector>
+_RandomAccessIterator
+pattern_partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+                          _RandomAccessIterator __d_first, _RandomAccessIterator __d_last, _Compare __comp,
+                          _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+    if (__last == __first || __d_last == __d_first)
+    {
+        return __d_first;
+    }
+    auto __n1 = __last - __first;
+    auto __n2 = __d_last - __d_first;
+    return except_handler([&]() {
+        if (__n2 >= __n1)
+        {
+            par_backend::parallel_stable_sort(
+                std::forward<_ExecutionPolicy>(__exec), __d_first, __d_first + __n1, __comp,
+                [__n1, __first, __d_first, __is_vector](_RandomAccessIterator __i, _RandomAccessIterator __j,
+                                                        _Compare __comp) {
+                    _ForwardIterator __i1 = __first + (__i - __d_first);
+                    _ForwardIterator __j1 = __first + (__j - __d_first);
+
+                // 1. Copy elements from input to output
+#if !__PSTL_ICC_18_OMP_SIMD_BROKEN
+                    brick_copy(__i1, __j1, __i, __is_vector);
+#else
+                    std::copy(__i1, __j1, __i);
+#endif
+                    // 2. Sort elements in output sequence
+                    std::sort(__i, __j, __comp);
+                },
+                __n1);
+            return __d_first + __n1;
+        }
+        else
+        {
+            typedef typename std::iterator_traits<_ForwardIterator>::value_type _T1;
+            typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _T2;
+            par_backend::buffer<_T1> __buf(std::forward<_ExecutionPolicy>(__exec), __n1);
+            _T1* __r = __buf.get();
+
+            par_backend::parallel_stable_sort(std::forward<_ExecutionPolicy>(__exec), __r, __r + __n1, __comp,
+                                              [__n2, __first, __r](_T1* __i, _T1* __j, _Compare __comp) {
+                                                  _ForwardIterator __it = __first + (__i - __r);
+
+                                                  // 1. Copy elements from input to raw memory
+                                                  for (_T1* __k = __i; __k != __j; ++__k, ++__it)
+                                                  {
+                                                      ::new (__k) _T2(*__it);
+                                                  }
+
+                                                  // 2. Sort elements in temporary buffer
+                                                  if (__n2 < __j - __i)
+                                                      std::partial_sort(__i, __i + __n2, __j, __comp);
+                                                  else
+                                                      std::sort(__i, __j, __comp);
+                                              },
+                                              __n2);
+
+            // 3. Move elements from temporary buffer to output
+            par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __r, __r + __n2,
+                                      [__r, __d_first, __is_vector](_T1* __i, _T1* __j) {
+                                          brick_move(__i, __j, __d_first + (__i - __r), __is_vector);
+                                      });
+            return __d_first + __n2;
+        }
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// adjacent_find
+//------------------------------------------------------------------------
+template <class _ForwardIterator, class _BinaryPredicate>
+_ForwardIterator
+brick_adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred,
+                    /* IsVector = */ std::true_type, bool __or_semantic) noexcept
+{
+    return unseq_backend::simd_adjacent_find(__first, __last, __pred, __or_semantic);
+}
+
+template <class _ForwardIterator, class _BinaryPredicate>
+_ForwardIterator
+brick_adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred,
+                    /* IsVector = */ std::false_type, bool __or_semantic) noexcept
+{
+    return std::adjacent_find(__first, __last, __pred);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate, class _IsVector>
+_ForwardIterator
+pattern_adjacent_find(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred,
+                      /* is_parallel */ std::false_type, _IsVector __is_vector, bool __or_semantic) noexcept
+{
+    return internal::brick_adjacent_find(__first, __last, __pred, __is_vector, __or_semantic);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _BinaryPredicate, class _IsVector>
+_RandomAccessIterator
+pattern_adjacent_find(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                      _BinaryPredicate __pred, /* is_parallel */ std::true_type, _IsVector __is_vector,
+                      bool __or_semantic)
+{
+    if (__last - __first < 2)
+        return __last;
+
+    return internal::except_handler([&]() {
+        return par_backend::parallel_reduce(
+            std::forward<_ExecutionPolicy>(__exec), __first, __last, __last,
+            [__last, __pred, __is_vector, __or_semantic](_RandomAccessIterator __begin, _RandomAccessIterator __end,
+                                                         _RandomAccessIterator __value) -> _RandomAccessIterator {
+                // TODO: investigate performance benefits from the use of shared variable for the result,
+                // checking (compare_and_swap idiom) its __value at __first.
+                if (__or_semantic && __value < __last)
+                { //found
+                    par_backend::cancel_execution();
+                    return __value;
+                }
+
+                if (__value > __begin)
+                {
+                    // modify __end to check the predicate on the boundary __values;
+                    // TODO: to use a custom range with boundaries overlapping
+                    // TODO: investigate what if we remove "if" below and run algorithm on range [__first, __last-1)
+                    // then check the pair [__last-1, __last)
+                    if (__end != __last)
+                        ++__end;
+
+                    //correct the global result iterator if the "brick" returns a local "__last"
+                    const _RandomAccessIterator __res =
+                        internal::brick_adjacent_find(__begin, __end, __pred, __is_vector, __or_semantic);
+                    if (__res < __end)
+                        __value = __res;
+                }
+                return __value;
+            },
+            [](_RandomAccessIterator __x, _RandomAccessIterator __y) -> _RandomAccessIterator {
+                return __x < __y ? __x : __y;
+            } //reduce a __value
+        );
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// nth_element
+//------------------------------------------------------------------------
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
+void
+pattern_nth_element(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __nth,
+                    _RandomAccessIterator __last, _Compare __comp, _IsVector, /*is_parallel=*/std::false_type) noexcept
+{
+    std::nth_element(__first, __nth, __last, __comp);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
+void
+pattern_nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth,
+                    _RandomAccessIterator __last, _Compare __comp, _IsVector __is_vector,
+                    /*is_parallel=*/std::true_type) noexcept
+{
+    if (__first == __last || __nth == __last)
+    {
+        return;
+    }
+
+    using std::iter_swap;
+    typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
+    _RandomAccessIterator __x;
+    do
+    {
+        __x = pattern_partition(std::forward<_ExecutionPolicy>(__exec), __first + 1, __last,
+                                [&__comp, __first](const _Tp& __x) { return __comp(__x, *__first); }, __is_vector,
+                                /*is_parallel=*/std::true_type());
+        --__x;
+        if (__x != __first)
+        {
+            iter_swap(__first, __x);
+        }
+        // if x > nth then our new range for partition is [first, x)
+        if (__x - __nth > 0)
+        {
+            __last = __x;
+        }
+        // if x < nth then our new range for partition is [x, last)
+        else if (__x - __nth < 0)
+        {
+            // if *x == *nth then we can start new partition with x+1
+            if (!__comp(*__nth, *__x) && !__comp(*__x, *__nth))
+            {
+                ++__x;
+            }
+            else
+            {
+                iter_swap(__nth, __x);
+            }
+            __first = __x;
+        }
+    } while (__x != __nth);
+}
+#endif
+
+//------------------------------------------------------------------------
+// fill, fill_n
+//------------------------------------------------------------------------
+template <class _ForwardIterator, class _Tp>
+void
+brick_fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value,
+           /* __is_vector = */ std::true_type) noexcept
+{
+    unseq_backend::simd_fill_n(__first, __last - __first, __value);
+}
+
+template <class _ForwardIterator, class _Tp>
+void
+brick_fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value,
+           /* __is_vector = */ std::false_type) noexcept
+{
+    std::fill(__first, __last, __value);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _IsVector>
+void
+pattern_fill(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value,
+             /*is_parallel=*/std::false_type, _IsVector __is_vector) noexcept
+{
+    internal::brick_fill(__first, __last, __value, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _IsVector>
+_ForwardIterator
+pattern_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value,
+             /*is_parallel=*/std::true_type, _IsVector __is_vector)
+{
+    return except_handler([&__exec, __first, __last, &__value, __is_vector]() {
+        par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                  [&__value, __is_vector](_ForwardIterator __begin, _ForwardIterator __end) {
+                                      internal::brick_fill(__begin, __end, __value, __is_vector);
+                                  });
+        return __last;
+    });
+}
+#endif
+
+template <class _OutputIterator, class _Size, class _Tp>
+_OutputIterator
+brick_fill_n(_OutputIterator __first, _Size __count, const _Tp& __value, /* __is_vector = */ std::true_type) noexcept
+{
+    return unseq_backend::simd_fill_n(__first, __count, __value);
+}
+
+template <class _OutputIterator, class _Size, class _Tp>
+_OutputIterator
+brick_fill_n(_OutputIterator __first, _Size __count, const _Tp& __value, /* __is_vector = */ std::false_type) noexcept
+{
+    return std::fill_n(__first, __count, __value);
+}
+
+template <class _ExecutionPolicy, class _OutputIterator, class _Size, class _Tp, class _IsVector>
+_OutputIterator
+pattern_fill_n(_ExecutionPolicy&&, _OutputIterator __first, _Size __count, const _Tp& __value,
+               /*is_parallel=*/std::false_type, _IsVector __is_vector) noexcept
+{
+    return internal::brick_fill_n(__first, __count, __value, __is_vector);
+}
+
+template <class _ExecutionPolicy, class _OutputIterator, class _Size, class _Tp, class _IsVector>
+_OutputIterator
+pattern_fill_n(_ExecutionPolicy&& __exec, _OutputIterator __first, _Size __count, const _Tp& __value,
+               /*is_parallel=*/std::true_type, _IsVector __is_vector)
+{
+    return internal::pattern_fill(std::forward<_ExecutionPolicy>(__exec), __first, __first + __count, __value,
+                                  std::true_type(), __is_vector);
+}
+
+//------------------------------------------------------------------------
+// generate, generate_n
+//------------------------------------------------------------------------
+template <class _RandomAccessIterator, class _Generator>
+void
+brick_generate(_RandomAccessIterator __first, _RandomAccessIterator __last, _Generator __g,
+               /* is_vector = */ std::true_type) noexcept
+{
+    unseq_backend::simd_generate_n(__first, __last - __first, __g);
+}
+
+template <class _ForwardIterator, class _Generator>
+void
+brick_generate(_ForwardIterator __first, _ForwardIterator __last, _Generator __g,
+               /* is_vector = */ std::false_type) noexcept
+{
+    std::generate(__first, __last, __g);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Generator, class _IsVector>
+void
+pattern_generate(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Generator __g,
+                 /*is_parallel=*/std::false_type, _IsVector __is_vector) noexcept
+{
+    internal::brick_generate(__first, __last, __g, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _Generator, class _IsVector>
+_ForwardIterator
+pattern_generate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Generator __g,
+                 /*is_parallel=*/std::true_type, _IsVector __is_vector)
+{
+    return internal::except_handler([&]() {
+        par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                  [__g, __is_vector](_ForwardIterator __begin, _ForwardIterator __end) {
+                                      internal::brick_generate(__begin, __end, __g, __is_vector);
+                                  });
+        return __last;
+    });
+}
+#endif
+
+template <class OutputIterator, class Size, class _Generator>
+OutputIterator
+brick_generate_n(OutputIterator __first, Size __count, _Generator __g, /* is_vector = */ std::true_type) noexcept
+{
+    return unseq_backend::simd_generate_n(__first, __count, __g);
+}
+
+template <class OutputIterator, class Size, class _Generator>
+OutputIterator
+brick_generate_n(OutputIterator __first, Size __count, _Generator __g, /* is_vector = */ std::false_type) noexcept
+{
+    return std::generate_n(__first, __count, __g);
+}
+
+template <class _ExecutionPolicy, class _OutputIterator, class _Size, class _Generator, class _IsVector>
+_OutputIterator
+pattern_generate_n(_ExecutionPolicy&&, _OutputIterator __first, _Size __count, _Generator __g,
+                   /*is_parallel=*/std::false_type, _IsVector __is_vector) noexcept
+{
+    return internal::brick_generate_n(__first, __count, __g, __is_vector);
+}
+
+template <class _ExecutionPolicy, class _OutputIterator, class _Size, class _Generator, class _IsVector>
+_OutputIterator
+pattern_generate_n(_ExecutionPolicy&& __exec, _OutputIterator __first, _Size __count, _Generator __g,
+                   /*is_parallel=*/std::true_type, _IsVector __is_vector)
+{
+    static_assert(internal::is_random_access_iterator<_OutputIterator>::value,
+                  "Pattern-brick error. Should be a random access iterator.");
+    return internal::pattern_generate(std::forward<_ExecutionPolicy>(__exec), __first, __first + __count, __g,
+                                      std::true_type(), __is_vector);
+}
+
+//------------------------------------------------------------------------
+// remove
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class _UnaryPredicate>
+_ForwardIterator
+brick_remove_if(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+                /* __is_vector = */ std::false_type) noexcept
+{
+    return std::remove_if(__first, __last, __pred);
+}
+
+template <class _RandomAccessIterator, class _UnaryPredicate>
+_RandomAccessIterator
+brick_remove_if(_RandomAccessIterator __first, _RandomAccessIterator __last, _UnaryPredicate __pred,
+                /* __is_vector = */ std::true_type) noexcept
+{
+#if __PSTL_MONOTONIC_PRESENT
+    return unseq_backend::simd_remove_if(__first, __last - __first, __pred);
+#else
+    return std::remove_if(__first, __last, __pred);
+#endif
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+_ForwardIterator
+pattern_remove_if(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+                  _IsVector __is_vector, /*is_parallel*/ std::false_type) noexcept
+{
+    return internal::brick_remove_if(__first, __last, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+_ForwardIterator
+pattern_remove_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+                  _IsVector __is_vector, /*is_parallel*/ std::true_type) noexcept
+{
+    typedef typename std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
+
+    if (__first == __last || __first + 1 == __last)
+    {
+        // Trivial sequence - use serial algorithm
+        return brick_remove_if(__first, __last, __pred, __is_vector);
+    }
+
+    return remove_elements(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        [&__pred, __is_vector](bool* __b, bool* __e, _ForwardIterator __it) {
+            brick_walk2(__b, __e, __it, [&__pred](bool& __x, _ReferenceType __y) { __x = !__pred(__y); }, __is_vector);
+        },
+        __is_vector);
+}
+#endif
+
+//------------------------------------------------------------------------
+// merge
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator
+brick_merge(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+            _ForwardIterator2 __last2, _OutputIterator __d_first, _Compare __comp,
+            /* __is_vector = */ std::false_type) noexcept
+{
+    return std::merge(__first1, __last1, __first2, __last2, __d_first, __comp);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator
+brick_merge(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+            _ForwardIterator2 __last2, _OutputIterator __d_first, _Compare __comp,
+            /* __is_vector = */ std::true_type) noexcept
+{
+    __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
+    return std::merge(__first1, __last1, __first2, __last2, __d_first, __comp);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
+          class _Compare, class _IsVector>
+_OutputIterator
+pattern_merge(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+              _ForwardIterator2 __last2, _OutputIterator __d_first, _Compare __comp, _IsVector __is_vector,
+              /* is_parallel = */ std::false_type) noexcept
+{
+    return internal::brick_merge(__first1, __last1, __first2, __last2, __d_first, __comp, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2, class _OutputIterator,
+          class _Compare, class _IsVector>
+_OutputIterator
+pattern_merge(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
+              _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2, _OutputIterator __d_first,
+              _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::true_type)
+{
+    par_backend::parallel_merge(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __d_first, __comp,
+        [__is_vector](_RandomAccessIterator1 __f1, _RandomAccessIterator1 __l1, _RandomAccessIterator2 __f2,
+                      _RandomAccessIterator2 __l2, _OutputIterator __f3,
+                      _Compare __comp) { return brick_merge(__f1, __l1, __f2, __l2, __f3, __comp, __is_vector); });
+    return __d_first + (__last1 - __first1) + (__last2 - __first2);
+}
+#endif
+
+//------------------------------------------------------------------------
+// inplace_merge
+//------------------------------------------------------------------------
+template <class _BidirectionalIterator, class _Compare>
+void
+brick_inplace_merge(_BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last,
+                    _Compare __comp, /* __is_vector = */ std::false_type) noexcept
+{
+    std::inplace_merge(__first, __middle, __last, __comp);
+}
+
+template <class _BidirectionalIterator, class _Compare>
+void
+brick_inplace_merge(_BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last,
+                    _Compare __comp, /* __is_vector = */ std::true_type) noexcept
+{
+    __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial")
+    std::inplace_merge(__first, __middle, __last, __comp);
+}
+
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _Compare, class _IsVector>
+void
+pattern_inplace_merge(_ExecutionPolicy&&, _BidirectionalIterator __first, _BidirectionalIterator __middle,
+                      _BidirectionalIterator __last, _Compare __comp, _IsVector __is_vector,
+                      /* is_parallel = */ std::false_type) noexcept
+{
+    internal::brick_inplace_merge(__first, __middle, __last, __comp, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _Compare, class _IsVector>
+void
+pattern_inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle,
+                      _BidirectionalIterator __last, _Compare __comp, _IsVector __is_vector,
+                      /*is_parallel=*/std::true_type)
+{
+    if (__first == __last || __first == __middle || __middle == __last)
+    {
+        return;
+    }
+    typedef typename std::iterator_traits<_BidirectionalIterator>::value_type _Tp;
+    auto __n = __last - __first;
+    par_backend::buffer<_Tp> __buf(std::forward<_ExecutionPolicy>(__exec), __n);
+    _Tp* __r = __buf.get();
+    except_handler([&]() {
+        auto __move_values = [](_BidirectionalIterator __x, _Tp* __z) {
+            invoke_if_else(std::is_trivial<_Tp>(), [&]() { *__z = std::move(*__x); },
+                           [&]() { ::new (std::addressof(*__z)) _Tp(std::move(*__x)); });
+        };
+
+        auto __move_sequences = [](_BidirectionalIterator __first1, _BidirectionalIterator __last1, _Tp* __first2) {
+            return brick_uninitialized_move(__first1, __last1, __first2, _IsVector());
+        };
+
+        par_backend::parallel_merge(
+            std::forward<_ExecutionPolicy>(__exec), __first, __middle, __middle, __last, __r, __comp,
+            [__n, __move_values, __move_sequences](_BidirectionalIterator __f1, _BidirectionalIterator __l1,
+                                                   _BidirectionalIterator __f2, _BidirectionalIterator __l2, _Tp* __f3,
+                                                   _Compare __comp) {
+                auto __func = par_backend::serial_move_merge<decltype(__move_values), decltype(__move_sequences)>(
+                    __n, __move_values, __move_sequences);
+                __func(__f1, __l1, __f2, __l2, __f3, __comp);
+                return __f3 + (__l1 - __f1) + (__l2 - __f2);
+            });
+        par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __r, __r + __n,
+                                  [__r, __first, __is_vector](_Tp* __i, _Tp* __j) {
+                                      brick_move(__i, __j, __first + (__i - __r), __is_vector);
+                                  });
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// includes
+//------------------------------------------------------------------------
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare, class _IsVector>
+bool
+pattern_includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                 _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, _IsVector,
+                 /*is_parallel=*/std::false_type) noexcept
+{
+    return std::includes(__first1, __last1, __first2, __last2, __comp);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare, class _IsVector>
+bool
+pattern_includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                 _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, _IsVector __is_vector,
+                 /*is_parallel=*/std::true_type)
+{
+    if (__first2 >= __last2)
+        return true;
+
+    if (__first1 >= __last1 || __comp(*__first2, *__first1) || __comp(*(__last1 - 1), *(__last2 - 1)))
+        return false;
+
+    __first1 = std::lower_bound(__first1, __last1, *__first2, __comp);
+    if (__first1 == __last1)
+        return false;
+
+    if (__last2 - __first2 == 1)
+        return !__comp(*__first1, *__first2) && !__comp(*__first2, *__first1);
+
+    return except_handler([&]() {
+        return !internal::parallel_or(
+            std::forward<_ExecutionPolicy>(__exec), __first2, __last2,
+            [__first1, __last1, __first2, __last2, &__comp](_ForwardIterator2 __i, _ForwardIterator2 __j) {
+                assert(__j > __i);
+                //assert(__j - __i > 1);
+
+                //1. moving boundaries to "consume" subsequence of equal elements
+                auto __is_equal = [&__comp](_ForwardIterator2 __a, _ForwardIterator2 __b) -> bool {
+                    return !__comp(*__a, *__b) && !__comp(*__b, *__a);
+                };
+
+                //1.1 left bound, case "aaa[aaaxyz...]" - searching "x"
+                if (__i > __first2 && __is_equal(__i, __i - 1))
+                {
+                    //whole subrange continues to content equal elements - return "no op"
+                    if (__is_equal(__i, __j - 1))
+                        return false;
+
+                    __i = std::upper_bound(__i, __last2, *__i, __comp);
+                }
+
+                //1.2 right bound, case "[...aaa]aaaxyz" - searching "x"
+                if (__j < __last2 && __is_equal(__j - 1, __j))
+                    __j = std::upper_bound(__j, __last2, *__j, __comp);
+
+                //2. testing is __a subsequence of the second range included into the first range
+                auto __b = std::lower_bound(__first1, __last1, *__i, __comp);
+
+                assert(!__comp(*(__last1 - 1), *__b));
+                assert(!__comp(*(__j - 1), *__i));
+                return !std::includes(__b, __last1, __i, __j, __comp);
+            });
+    });
+}
+#endif
+
+constexpr auto __set_algo_cut_off = 1000;
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
+          class _Compare, class _IsVector, class _SizeFunction, class _SetOP>
+_OutputIterator
+parallel_set_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                _SizeFunction __size_func, _SetOP __set_op, _IsVector __is_vector)
+{
+    typedef typename std::iterator_traits<_ForwardIterator1>::difference_type _DifferenceType;
+    typedef typename std::iterator_traits<_OutputIterator>::value_type _T;
+
+    struct _SetRange
+    {
+        _DifferenceType __pos, __len, __buf_pos;
+        bool
+        empty() const
+        {
+            return __len == 0;
+        }
+    };
+
+    const _DifferenceType __n1 = __last1 - __first1;
+    const _DifferenceType __n2 = __last2 - __first2;
+
+    par_backend::buffer<_T> __buf(std::forward<_ExecutionPolicy>(__exec), __size_func(__n1, __n2));
+
+    return except_handler([&__exec, __n1, __first1, __last1, __first2, __last2, __result, __is_vector, __comp,
+                           __size_func, __set_op, &__buf]() {
+        auto __buffer = __buf.get();
+        _DifferenceType __m{};
+        auto __scan = [=](_DifferenceType, _DifferenceType, const _SetRange& __s) { // Scan
+            if (!__s.empty())
+                brick_move(__buffer + __s.__buf_pos, __buffer + (__s.__buf_pos + __s.__len), __result + __s.__pos,
+                           __is_vector);
+        };
+        par_backend::parallel_strict_scan(
+            std::forward<_ExecutionPolicy>(__exec), __n1, _SetRange{0, 0, 0}, //-1, 0},
+            [=](_DifferenceType __i, _DifferenceType __len) {                 // Reduce
+                //[__b; __e) - a subrange of the first sequence, to reduce
+                _ForwardIterator1 __b = __first1 + __i, __e = __first1 + (__i + __len);
+
+                //try searching for the first element which not equal to *__b
+                if (__b != __first1)
+                    __b = std::upper_bound(__b, __last1, *__b, __comp);
+
+                //try searching for the first element which not equal to *__e
+                if (__e != __last1)
+                    __e = std::upper_bound(__e, __last1, *__e, __comp);
+
+                //check is [__b; __e) empty
+                if (__e - __b < 1)
+                {
+                    _ForwardIterator2 __bb = __last2;
+                    if (__b != __last1)
+                        __bb = std::lower_bound(__first2, __last2, *__b, __comp);
+
+                    const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
+                    return _SetRange{0, 0, __buf_pos};
+                }
+
+                //try searching for "corresponding" subrange [__bb; __ee) in the second sequence
+                _ForwardIterator2 __bb = __first2;
+                if (__b != __first1)
+                    __bb = std::lower_bound(__first2, __last2, *__b, __comp);
+
+                _ForwardIterator2 __ee = __last2;
+                if (__e != __last1)
+                    __ee = std::lower_bound(__bb, __last2, *__e, __comp);
+
+                const _DifferenceType __buf_pos = __size_func((__b - __first1), (__bb - __first2));
+                auto __buffer_b = __buffer + __buf_pos;
+                auto __res = __set_op(__b, __e, __bb, __ee, __buffer_b, __comp);
+
+                return _SetRange{0, __res - __buffer_b, __buf_pos};
+            },
+            [](const _SetRange& __a, const _SetRange& __b) { // Combine
+                if (__b.__buf_pos > __a.__buf_pos || ((__b.__buf_pos == __a.__buf_pos) && !__b.empty()))
+                    return _SetRange{__a.__pos + __a.__len + __b.__pos, __b.__len, __b.__buf_pos};
+                return _SetRange{__b.__pos + __b.__len + __a.__pos, __a.__len, __a.__buf_pos};
+            },
+            __scan,                                     // Scan
+            [&__m, &__scan](const _SetRange& __total) { // Apex
+                //final scan
+                __scan(0, 0, __total);
+                __m = __total.__pos + __total.__len;
+            });
+        return __result + __m;
+    });
+}
+#endif
+
+#if __PSTL_USE_PAR_POLICIES
+//a shared parallel pattern for 'pattern_set_union' and 'pattern_set_symmetric_difference'
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
+          class _Compare, class _SetUnionOp, class _IsVector>
+_OutputIterator
+parallel_set_union_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                      _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                      _SetUnionOp __set_union_op, _IsVector __is_vector)
+{
+    typedef typename std::iterator_traits<_OutputIterator>::value_type _T;
+    typedef typename std::iterator_traits<_ForwardIterator1>::difference_type _DifferenceType;
+
+    const auto __n1 = __last1 - __first1;
+    const auto __n2 = __last2 - __first2;
+
+    auto copy_range1 = [__is_vector](_ForwardIterator1 __begin, _ForwardIterator1 __end, _OutputIterator __res) {
+        return brick_copy(__begin, __end, __res, __is_vector);
+    };
+    auto copy_range2 = [__is_vector](_ForwardIterator2 __begin, _ForwardIterator2 __end, _OutputIterator __res) {
+        return brick_copy(__begin, __end, __res, __is_vector);
+    };
+
+    // {1} {}: parallel copying just first sequence
+    if (__n2 == 0)
+        return pattern_walk2_brick(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result, copy_range1,
+                                   std::true_type());
+
+    // {} {2}: parallel copying justmake  second sequence
+    if (__n1 == 0)
+        return pattern_walk2_brick(std::forward<_ExecutionPolicy>(__exec), __first2, __last2, __result, copy_range2,
+                                   std::true_type());
+
+    // testing  whether the sequences are intersected
+    _ForwardIterator1 __left_bound_seq_1 = lower_bound(__first1, __last1, *__first2, __comp);
+
+    if (__left_bound_seq_1 == __last1)
+    {
+        //{1} < {2}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
+        par_backend::parallel_invoke(std::forward<_ExecutionPolicy>(__exec),
+                                     [=] {
+                                         pattern_walk2_brick(std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+                                                             __result, copy_range1, std::true_type());
+                                     },
+                                     [=] {
+                                         pattern_walk2_brick(std::forward<_ExecutionPolicy>(__exec), __first2, __last2,
+                                                             __result + __n1, copy_range2, std::true_type());
+                                     });
+        return __result + __n1 + __n2;
+    }
+
+    // testing  whether the sequences are intersected
+    _ForwardIterator2 __left_bound_seq_2 = lower_bound(__first2, __last2, *__first1, __comp);
+
+    if (__left_bound_seq_2 == __last2)
+    {
+        //{2} < {1}: seq2 is wholly greater than seq1, so, do parallel copying seq1 and seq2
+        par_backend::parallel_invoke(std::forward<_ExecutionPolicy>(__exec),
+                                     [=] {
+                                         pattern_walk2_brick(std::forward<_ExecutionPolicy>(__exec), __first2, __last2,
+                                                             __result, copy_range2, std::true_type());
+                                     },
+                                     [=] {
+                                         pattern_walk2_brick(std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+                                                             __result + __n2, copy_range1, std::true_type());
+                                     });
+        return __result + __n1 + __n2;
+    }
+
+    const auto __m1 = __left_bound_seq_1 - __first1;
+    if (__m1 > __set_algo_cut_off)
+    {
+        auto __res_or = __result;
+        __result += __m1; //we know proper offset due to [first1; left_bound_seq_1) < [first2; last2)
+        par_backend::parallel_invoke(
+            std::forward<_ExecutionPolicy>(__exec),
+            //do parallel copying of [first1; left_bound_seq_1)
+            [=] {
+                pattern_walk2_brick(std::forward<_ExecutionPolicy>(__exec), __first1, __left_bound_seq_1, __res_or,
+                                    copy_range1, std::true_type());
+            },
+            [=, &__result] {
+                __result = parallel_set_op(std::forward<_ExecutionPolicy>(__exec), __left_bound_seq_1, __last1,
+                                           __first2, __last2, __result, __comp,
+                                           [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; },
+                                           __set_union_op, __is_vector);
+            });
+        return __result;
+    }
+
+    const auto __m2 = __left_bound_seq_2 - __first2;
+    assert(__m1 == 0 || __m2 == 0);
+    if (__m2 > __set_algo_cut_off)
+    {
+        auto __res_or = __result;
+        __result += __m2; //we know proper offset due to [first2; left_bound_seq_2) < [first1; last1)
+        par_backend::parallel_invoke(
+            std::forward<_ExecutionPolicy>(__exec),
+            //do parallel copying of [first2; left_bound_seq_2)
+            [=] {
+                pattern_walk2_brick(std::forward<_ExecutionPolicy>(__exec), __first2, __left_bound_seq_2, __res_or,
+                                    copy_range2, std::true_type());
+            },
+            [=, &__result] {
+                __result = parallel_set_op(std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+                                           __left_bound_seq_2, __last2, __result, __comp,
+                                           [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; },
+                                           __set_union_op, __is_vector);
+            });
+        return __result;
+    }
+
+    return parallel_set_op(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result,
+                           __comp, [](_DifferenceType __n, _DifferenceType __m) { return __n + __m; }, __set_union_op,
+                           __is_vector);
+}
+#endif
+
+//------------------------------------------------------------------------
+// set_union
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator
+brick_set_union(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                /*__is_vector=*/std::false_type) noexcept
+{
+    return std::set_union(__first1, __last1, __first2, __last2, __result, __comp);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator
+brick_set_union(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                /*__is_vector=*/std::true_type) noexcept
+{
+    __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
+    return std::set_union(__first1, __last1, __first2, __last2, __result, __comp);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
+          class _Compare, class _IsVector>
+_OutputIterator
+pattern_set_union(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                  _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, _IsVector __is_vector,
+                  /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_set_union(__first1, __last1, __first2, __last2, __result, __comp, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
+          class _Compare, class _IsVector>
+_OutputIterator
+pattern_set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                  _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                  _IsVector __is_vector, /*__is_parallel=*/std::true_type)
+{
+
+    const auto __n1 = __last1 - __first1;
+    const auto __n2 = __last2 - __first2;
+
+    // use serial algorithm
+    if (__n1 + __n2 <= __set_algo_cut_off)
+        return std::set_union(__first1, __last1, __first2, __last2, __result, __comp);
+
+    typedef typename std::iterator_traits<_OutputIterator>::value_type _T;
+    return parallel_set_union_op(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result,
+                                 __comp,
+                                 [](_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                                    _ForwardIterator2 __last2, _T* __result, _Compare __comp) {
+                                     return std::set_union(__first1, __last1, __first2, __last2, __result, __comp);
+                                 },
+                                 __is_vector);
+}
+#endif
+
+//------------------------------------------------------------------------
+// set_intersection
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator
+brick_set_intersection(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                       _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                       /*__is_vector=*/std::false_type) noexcept
+{
+    return std::set_intersection(__first1, __last1, __first2, __last2, __result, __comp);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator
+brick_set_intersection(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                       _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                       /*__is_vector=*/std::true_type) noexcept
+{
+    __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
+    return std::set_intersection(__first1, __last1, __first2, __last2, __result, __comp);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
+          class _Compare, class _IsVector>
+_OutputIterator
+pattern_set_intersection(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                         _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result,
+                         _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_set_intersection(__first1, __last1, __first2, __last2, __result, __comp, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
+          class _Compare, class _IsVector>
+_OutputIterator
+pattern_set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                         _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result,
+                         _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+    typedef typename std::iterator_traits<_OutputIterator>::value_type _T;
+    typedef typename std::iterator_traits<_ForwardIterator1>::difference_type _DifferenceType;
+
+    const auto __n1 = __last1 - __first1;
+    const auto __n2 = __last2 - __first2;
+
+    // intersection is empty
+    if (__n1 == 0 || __n2 == 0)
+        return __result;
+
+    // testing  whether the sequences are intersected
+    _ForwardIterator1 __left_bound_seq_1 = lower_bound(__first1, __last1, *__first2, __comp);
+    //{1} < {2}: seq 2 is wholly greater than seq 1, so, the intersection is empty
+    if (__left_bound_seq_1 == __last1)
+        return __result;
+
+    // testing  whether the sequences are intersected
+    _ForwardIterator2 __left_bound_seq_2 = lower_bound(__first2, __last2, *__first1, __comp);
+    //{2} < {1}: seq 1 is wholly greater than seq 2, so, the intersection is empty
+    if (__left_bound_seq_2 == __last2)
+        return __result;
+
+    const auto __m1 = __last1 - __left_bound_seq_1 + __n2;
+    if (__m1 > __set_algo_cut_off)
+    {
+        //we know proper offset due to [first1; left_bound_seq_1) < [first2; last2)
+        return parallel_set_op(std::forward<_ExecutionPolicy>(__exec), __left_bound_seq_1, __last1, __first2, __last2,
+                               __result, __comp,
+                               [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
+                               [](_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                                  _ForwardIterator2 __last2, _T* __result, _Compare __comp) {
+                                   return std::set_intersection(__first1, __last1, __first2, __last2, __result, __comp);
+                               },
+                               __is_vector);
+    }
+
+    const auto __m2 = __last2 - __left_bound_seq_2 + __n1;
+    if (__m2 > __set_algo_cut_off)
+    {
+        //we know proper offset due to [first2; left_bound_seq_2) < [first1; last1)
+        __result = parallel_set_op(
+            std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __left_bound_seq_2, __last2, __result, __comp,
+            [](_DifferenceType __n, _DifferenceType __m) { return std::min(__n, __m); },
+            [](_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+               _ForwardIterator2 __last2, _T* __result, _Compare __comp) {
+                return std::set_intersection(__first2, __last2, __first1, __last1, __result, __comp);
+            },
+            __is_vector);
+        return __result;
+    }
+
+    // [left_bound_seq_1; last1) and [left_bound_seq_2; last2) - use serial algorithm
+    return std::set_intersection(__left_bound_seq_1, __last1, __left_bound_seq_2, __last2, __result, __comp);
+}
+#endif
+
+//------------------------------------------------------------------------
+// set_difference
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator
+brick_set_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                     _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                     /*__is_vector=*/std::false_type) noexcept
+{
+    return std::set_difference(__first1, __last1, __first2, __last2, __result, __comp);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator
+brick_set_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                     _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                     /*__is_vector=*/std::true_type) noexcept
+{
+    __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
+    return std::set_difference(__first1, __last1, __first2, __last2, __result, __comp);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
+          class _Compare, class _IsVector>
+_OutputIterator
+pattern_set_difference(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                       _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                       _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_set_difference(__first1, __last1, __first2, __last2, __result, __comp, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
+          class _Compare, class _IsVector>
+_OutputIterator
+pattern_set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                       _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                       _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+    typedef typename std::iterator_traits<_OutputIterator>::value_type _T;
+    typedef typename std::iterator_traits<_ForwardIterator1>::difference_type _DifferenceType;
+
+    const auto __n1 = __last1 - __first1;
+    const auto __n2 = __last2 - __first2;
+
+    // {} \ {2}: the difference is empty
+    if (__n1 == 0)
+        return __result;
+
+    // {1} \ {}: parallel copying just first sequence
+    if (__n2 == 0)
+        return pattern_walk2_brick(
+            std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
+            [__is_vector](_ForwardIterator1 __begin, _ForwardIterator1 __end, _OutputIterator __res) {
+                return brick_copy(__begin, __end, __res, __is_vector);
+            },
+            std::true_type());
+
+    // testing  whether the sequences are intersected
+    _ForwardIterator1 __left_bound_seq_1 = lower_bound(__first1, __last1, *__first2, __comp);
+    //{1} < {2}: seq 2 is wholly greater than seq 1, so, parallel copying just first sequence
+    if (__left_bound_seq_1 == __last1)
+        return pattern_walk2_brick(
+            std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
+            [__is_vector](_ForwardIterator1 __begin, _ForwardIterator1 __end, _OutputIterator __res) {
+                return brick_copy(__begin, __end, __res, __is_vector);
+            },
+            std::true_type());
+
+    // testing  whether the sequences are intersected
+    _ForwardIterator2 __left_bound_seq_2 = lower_bound(__first2, __last2, *__first1, __comp);
+    //{2} < {1}: seq 1 is wholly greater than seq 2, so, parallel copying just first sequence
+    if (__left_bound_seq_2 == __last2)
+        return pattern_walk2_brick(
+            std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __result,
+            [__is_vector](_ForwardIterator1 __begin, _ForwardIterator1 __end, _OutputIterator __res) {
+                return brick_copy(__begin, __end, __res, __is_vector);
+            },
+            std::true_type());
+
+    if (__n1 + __n2 > __set_algo_cut_off)
+        return parallel_set_op(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result,
+                               __comp, [](_DifferenceType __n, _DifferenceType __m) { return __n; },
+                               [](_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                                  _ForwardIterator2 __last2, _T* __result, _Compare __comp) {
+                                   return std::set_difference(__first1, __last1, __first2, __last2, __result, __comp);
+                               },
+                               __is_vector);
+
+    // use serial algorithm
+    return std::set_difference(__first1, __last1, __first2, __last2, __result, __comp);
+}
+#endif
+
+//------------------------------------------------------------------------
+// set_symmetric_difference
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator
+brick_set_symmetric_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                               _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                               /*__is_vector=*/std::false_type) noexcept
+{
+    return std::set_symmetric_difference(__first1, __last1, __first2, __last2, __result, __comp);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator
+brick_set_symmetric_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                               _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                               /*__is_vector=*/std::true_type) noexcept
+{
+    __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
+    return std::set_symmetric_difference(__first1, __last1, __first2, __last2, __result, __comp);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
+          class _Compare, class _IsVector>
+_OutputIterator
+pattern_set_symmetric_difference(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                                 _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result,
+                                 _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_set_symmetric_difference(__first1, __last1, __first2, __last2, __result, __comp,
+                                                    __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator,
+          class _Compare, class _IsVector>
+_OutputIterator
+pattern_set_symmetric_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                                 _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result,
+                                 _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+
+    const auto __n1 = __last1 - __first1;
+    const auto __n2 = __last2 - __first2;
+
+    // use serial algorithm
+    if (__n1 + __n2 <= __set_algo_cut_off)
+        return std::set_symmetric_difference(__first1, __last1, __first2, __last2, __result, __comp);
+
+    typedef typename std::iterator_traits<_OutputIterator>::value_type _T;
+    return parallel_set_union_op(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, __comp,
+        [](_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+           _T* __result, _Compare __comp) {
+            return std::set_symmetric_difference(__first1, __last1, __first2, __last2, __result, __comp);
+        },
+        __is_vector);
+}
+#endif
+
+//------------------------------------------------------------------------
+// is_heap_until
+//------------------------------------------------------------------------
+
+template <class _RandomAccessIterator, class _Compare>
+_RandomAccessIterator
+brick_is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+                    /* __is_vector = */ std::false_type) noexcept
+{
+    return std::is_heap_until(__first, __last, __comp);
+}
+
+template <class _RandomAccessIterator, class _Compare>
+_RandomAccessIterator
+brick_is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+                    /* __is_vector = */ std::true_type) noexcept
+{
+    if (__last - __first < 2)
+        return __last;
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _SizeType;
+    return unseq_backend::simd_first(
+        __first, _SizeType(0), __last - __first,
+        [&__comp](_RandomAccessIterator __it, _SizeType __i) { return __comp(__it[(__i - 1) / 2], __it[__i]); });
+}
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
+_RandomAccessIterator
+pattern_is_heap_until(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+                      _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept
+{
+    return internal::brick_is_heap_until(__first, __last, __comp, __is_vector);
+}
+
+template <class _RandomAccessIterator, class _DifferenceType, class _Compare>
+_RandomAccessIterator
+is_heap_until_local(_RandomAccessIterator __first, _DifferenceType __begin, _DifferenceType __end, _Compare __comp,
+                    /* __is_vector = */ std::false_type) noexcept
+{
+    _DifferenceType __i = __begin;
+    for (; __i < __end; ++__i)
+    {
+        if (__comp(__first[(__i - 1) / 2], __first[__i]))
+        {
+            break;
+        }
+    }
+    return __first + __i;
+}
+
+template <class _RandomAccessIterator, class _DifferenceType, class _Compare>
+_RandomAccessIterator
+is_heap_until_local(_RandomAccessIterator __first, _DifferenceType __begin, _DifferenceType __end, _Compare __comp,
+                    /* __is_vector = */ std::true_type) noexcept
+{
+    return unseq_backend::simd_first(
+        __first, __begin, __end,
+        [&__comp](_RandomAccessIterator __it, _DifferenceType __i) { return __comp(__it[(__i - 1) / 2], __it[__i]); });
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
+_RandomAccessIterator
+pattern_is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                      _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::true_type) noexcept
+{
+    if (__last - __first < 2)
+        return __last;
+
+    return internal::except_handler([&]() {
+        return internal::parallel_find(
+            std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            [__first, __last, __comp, __is_vector](_RandomAccessIterator __i, _RandomAccessIterator __j) {
+                return internal::is_heap_until_local(__first, __i - __first, __j - __first, __comp, __is_vector);
+            },
+            std::less<typename std::iterator_traits<_RandomAccessIterator>::difference_type>(), /*is_first=*/true);
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// min_element
+//------------------------------------------------------------------------
+
+template <typename _ForwardIterator, typename _Compare>
+_ForwardIterator
+brick_min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp,
+                  /* __is_vector = */ std::false_type) noexcept
+{
+    return std::min_element(__first, __last, __comp);
+}
+
+template <typename _ForwardIterator, typename _Compare>
+_ForwardIterator
+brick_min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp,
+                  /* __is_vector = */ std::true_type) noexcept
+{
+#if __PSTL_UDR_PRESENT
+    return unseq_backend::simd_min_element(__first, __last - __first, __comp);
+#else
+    return std::min_element(__first, __last, __comp);
+#endif
+}
+
+template <typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare, typename _IsVector>
+_ForwardIterator
+pattern_min_element(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp,
+                    _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept
+{
+    return internal::brick_min_element(__first, __last, __comp, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <typename _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _IsVector>
+_RandomAccessIterator
+pattern_min_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                    _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::true_type)
+{
+    if (__first == __last)
+        return __last;
+
+    return internal::except_handler([&]() {
+        return par_backend::parallel_reduce(
+            std::forward<_ExecutionPolicy>(__exec), __first + 1, __last, __first,
+            [=](_RandomAccessIterator __begin, _RandomAccessIterator __end,
+                _RandomAccessIterator __init) -> _RandomAccessIterator {
+                const _RandomAccessIterator subresult = brick_min_element(__begin, __end, __comp, __is_vector);
+                return internal::cmp_iterators_by_values(__init, subresult, __comp);
+            },
+            [=](_RandomAccessIterator __it1, _RandomAccessIterator __it2) -> _RandomAccessIterator {
+                return internal::cmp_iterators_by_values(__it1, __it2, __comp);
+            });
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// minmax_element
+//------------------------------------------------------------------------
+
+template <typename _ForwardIterator, typename _Compare>
+std::pair<_ForwardIterator, _ForwardIterator>
+brick_minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp,
+                     /* __is_vector = */ std::false_type) noexcept
+{
+    return std::minmax_element(__first, __last, __comp);
+}
+
+template <typename _ForwardIterator, typename _Compare>
+std::pair<_ForwardIterator, _ForwardIterator>
+brick_minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp,
+                     /* __is_vector = */ std::true_type) noexcept
+{
+#if __PSTL_UDR_PRESENT
+    return unseq_backend::simd_minmax_element(__first, __last - __first, __comp);
+#else
+    return std::minmax_element(__first, __last, __comp);
+#endif
+}
+
+template <typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare, typename _IsVector>
+std::pair<_ForwardIterator, _ForwardIterator>
+pattern_minmax_element(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp,
+                       _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept
+{
+    return internal::brick_minmax_element(__first, __last, __comp, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare, typename _IsVector>
+std::pair<_ForwardIterator, _ForwardIterator>
+pattern_minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp,
+                       _IsVector __is_vector, /* is_parallel = */ std::true_type)
+{
+    if (__first == __last)
+        return std::make_pair(__first, __first);
+
+    return internal::except_handler([&]() {
+        typedef std::pair<_ForwardIterator, _ForwardIterator> _Result;
+
+        return par_backend::parallel_reduce(
+            std::forward<_ExecutionPolicy>(__exec), __first + 1, __last, std::make_pair(__first, __first),
+            [=](_ForwardIterator __begin, _ForwardIterator __end, _Result __init) -> _Result {
+                const _Result __subresult = brick_minmax_element(__begin, __end, __comp, __is_vector);
+                return std::make_pair(internal::cmp_iterators_by_values(__subresult.first, __init.first, __comp),
+                                      internal::cmp_iterators_by_values(__init.second, __subresult.second,
+                                                                        internal::not_pred<_Compare>(__comp)));
+            },
+            [=](_Result __p1, _Result __p2) -> _Result {
+                return std::make_pair(
+                    internal::cmp_iterators_by_values(__p1.first, __p2.first, __comp),
+                    internal::cmp_iterators_by_values(__p2.second, __p1.second, internal::not_pred<_Compare>(__comp)));
+            });
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// mismatch
+//------------------------------------------------------------------------
+template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+std::pair<_ForwardIterator1, _ForwardIterator2>
+mismatch_serial(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                _ForwardIterator2 __last2, _BinaryPredicate __pred)
+{
+#if __PSTL_CPP14_2RANGE_MISMATCH_EQUAL_PRESENT
+    return std::mismatch(__first1, __last1, __first2, __last2, __pred);
+#else
+    for (; __first1 != __last1 && __first2 != __last2 && __pred(*__first1, *__first2); ++__first1, ++__first2)
+    {
+    }
+    return std::make_pair(__first1, __first2);
+#endif
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+std::pair<_ForwardIterator1, _ForwardIterator2>
+brick_mismatch(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+               _ForwardIterator2 __last2, _Predicate __pred, /* __is_vector = */ std::false_type) noexcept
+{
+    return internal::mismatch_serial(__first1, __last1, __first2, __last2, __pred);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+std::pair<_ForwardIterator1, _ForwardIterator2>
+brick_mismatch(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+               _ForwardIterator2 __last2, _Predicate __pred, /* __is_vector = */ std::true_type) noexcept
+{
+    auto __n = std::min(__last1 - __first1, __last2 - __first2);
+    return unseq_backend::simd_first(__first1, __n, __first2, not_pred<_Predicate>(__pred));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate, class _IsVector>
+std::pair<_ForwardIterator1, _ForwardIterator2>
+pattern_mismatch(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                 _ForwardIterator2 __last2, _Predicate __pred, _IsVector __is_vector,
+                 /* is_parallel = */ std::false_type) noexcept
+{
+    return internal::brick_mismatch(__first1, __last1, __first2, __last2, __pred, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2, class _Predicate,
+          class _IsVector>
+std::pair<_RandomAccessIterator1, _RandomAccessIterator2>
+pattern_mismatch(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
+                 _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2, _Predicate __pred,
+                 _IsVector __is_vector, /* is_parallel = */ std::true_type) noexcept
+{
+    return internal::except_handler([&]() {
+        auto __n = std::min(__last1 - __first1, __last2 - __first2);
+        auto __result = internal::parallel_find(
+            std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
+            [__first1, __first2, __pred, __is_vector](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
+                return internal::brick_mismatch(__i, __j, __first2 + (__i - __first1), __first2 + (__j - __first1),
+                                                __pred, __is_vector)
+                    .first;
+            },
+            std::less<typename std::iterator_traits<_RandomAccessIterator1>::difference_type>(), /*is_first=*/true);
+        return std::make_pair(__result, __first2 + (__result - __first1));
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// lexicographical_compare
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+bool
+brick_lexicographical_compare(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                              _ForwardIterator2 __last2, _Compare __comp, /* __is_vector = */ std::false_type) noexcept
+{
+    return std::lexicographical_compare(__first1, __last1, __first2, __last2, __comp);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+bool
+brick_lexicographical_compare(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                              _ForwardIterator2 __last2, _Compare __comp, /* __is_vector = */ std::true_type) noexcept
+{
+    if (__first2 == __last2)
+    { // if second sequence is empty
+        return false;
+    }
+    else if (__first1 == __last1)
+    { // if first sequence is empty
+        return true;
+    }
+    else
+    {
+        typedef typename std::iterator_traits<_ForwardIterator1>::reference ref_type1;
+        typedef typename std::iterator_traits<_ForwardIterator2>::reference ref_type2;
+        --__last1;
+        --__last2;
+        auto __n = std::min(__last1 - __first1, __last2 - __first2);
+        std::pair<_ForwardIterator1, _ForwardIterator2> __result = unseq_backend::simd_first(
+            __first1, __n, __first2, [__comp](const ref_type1 __x, const ref_type2 __y) mutable {
+                return __comp(__x, __y) || __comp(__y, __x);
+            });
+
+        if (__result.first == __last1 && __result.second != __last2)
+        { // if first sequence shorter than second
+            return !__comp(*__result.second, *__result.first);
+        }
+        else
+        { // if second sequence shorter than first or both have the same number of elements
+            return __comp(*__result.first, *__result.second);
+        }
+    }
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare, class _IsVector>
+bool
+pattern_lexicographical_compare(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                                _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp,
+                                _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept
+{
+    return internal::brick_lexicographical_compare(__first1, __last1, __first2, __last2, __comp, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare, class _IsVector>
+bool
+pattern_lexicographical_compare(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                                _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp,
+                                _IsVector __is_vector, /* is_parallel = */ std::true_type) noexcept
+{
+    if (__first2 == __last2)
+    { // if second sequence is empty
+        return false;
+    }
+    else if (__first1 == __last1)
+    { // if first sequence is empty
+        return true;
+    }
+    else
+    {
+        typedef typename std::iterator_traits<_ForwardIterator1>::reference _RefType1;
+        typedef typename std::iterator_traits<_ForwardIterator2>::reference _RefType2;
+        --__last1;
+        --__last2;
+        auto __n = std::min(__last1 - __first1, __last2 - __first2);
+        auto __result = internal::parallel_find(
+            std::forward<_ExecutionPolicy>(__exec), __first1, __first1 + __n,
+            [__first1, __first2, &__comp, __is_vector](_ForwardIterator1 __i, _ForwardIterator1 __j) {
+                return brick_mismatch(__i, __j, __first2 + (__i - __first1), __first2 + (__j - __first1),
+                                      [&__comp](const _RefType1 __x, const _RefType2 __y) {
+                                          return !__comp(__x, __y) && !__comp(__y, __x);
+                                      },
+                                      __is_vector)
+                    .first;
+            },
+            std::less<typename std::iterator_traits<_ForwardIterator1>::difference_type>(), /*is_first=*/true);
+
+        if (__result == __last1 && __first2 + (__result - __first1) != __last2)
+        { // if first sequence shorter than second
+            return !__comp(*(__first2 + (__result - __first1)), *__result);
+        }
+        else
+        { // if second sequence shorter than first or both have the same number of elements
+            return __comp(*__result, *(__first2 + (__result - __first1)));
+        }
+    }
+}
+#endif
+
+} // namespace internal
+} // namespace __pstl
+
+#endif /* __PSTL_algorithm_impl_H */

--- a/cpp/pstl/include/pstl/internal/execution_defs.h
+++ b/cpp/pstl/include/pstl/internal/execution_defs.h
@@ -1,0 +1,168 @@
+// -*- C++ -*-
+//===-- execution_defs.h --------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_execution_policy_defs_H
+#define __PSTL_execution_policy_defs_H
+
+#include <type_traits>
+
+namespace __pstl
+{
+namespace execution
+{
+inline namespace v1
+{
+
+// 2.4, Sequential execution policy
+class sequenced_policy
+{
+  public:
+    // For internal use only
+    static constexpr std::false_type
+    __allow_unsequenced()
+    {
+        return std::false_type{};
+    }
+    static constexpr std::false_type
+    __allow_vector()
+    {
+        return std::false_type{};
+    }
+    static constexpr std::false_type
+    __allow_parallel()
+    {
+        return std::false_type{};
+    }
+};
+
+#if __PSTL_USE_PAR_POLICIES
+// 2.5, Parallel execution policy
+class parallel_policy
+{
+  public:
+    // For internal use only
+    static constexpr std::false_type
+    __allow_unsequenced()
+    {
+        return std::false_type{};
+    }
+    static constexpr std::false_type
+    __allow_vector()
+    {
+        return std::false_type{};
+    }
+    static constexpr std::true_type
+    __allow_parallel()
+    {
+        return std::true_type{};
+    }
+};
+
+// 2.6, Parallel+Vector execution policy
+class parallel_unsequenced_policy
+{
+  public:
+    // For internal use only
+    static constexpr std::true_type
+    __allow_unsequenced()
+    {
+        return std::true_type{};
+    }
+    static constexpr std::true_type
+    __allow_vector()
+    {
+        return std::true_type{};
+    }
+    static constexpr std::true_type
+    __allow_parallel()
+    {
+        return std::true_type{};
+    }
+};
+#endif
+
+class unsequenced_policy
+{
+  public:
+    // For internal use only
+    static constexpr std::true_type
+    __allow_unsequenced()
+    {
+        return std::true_type{};
+    }
+    static constexpr std::true_type
+    __allow_vector()
+    {
+        return std::true_type{};
+    }
+    static constexpr std::false_type
+    __allow_parallel()
+    {
+        return std::false_type{};
+    }
+};
+
+// 2.8, Execution policy objects
+constexpr sequenced_policy seq{};
+#if __PSTL_USE_PAR_POLICIES
+constexpr parallel_policy par{};
+constexpr parallel_unsequenced_policy par_unseq{};
+#endif
+constexpr unsequenced_policy unseq{};
+
+// 2.3, Execution policy type trait
+template <class T>
+struct is_execution_policy : std::false_type
+{
+};
+
+template <>
+struct is_execution_policy<sequenced_policy> : std::true_type
+{
+};
+#if __PSTL_USE_PAR_POLICIES
+template <>
+struct is_execution_policy<parallel_policy> : std::true_type
+{
+};
+template <>
+struct is_execution_policy<parallel_unsequenced_policy> : std::true_type
+{
+};
+#endif
+template <>
+struct is_execution_policy<unsequenced_policy> : std::true_type
+{
+};
+
+#if __PSTL_CPP14_VARIABLE_TEMPLATES_PRESENT
+template <class T>
+constexpr bool is_execution_policy_v = is_execution_policy<T>::value;
+#endif
+
+} // namespace v1
+} // namespace execution
+
+namespace internal
+{
+template <class ExecPolicy, class T>
+using enable_if_execution_policy =
+    typename std::enable_if<__pstl::execution::is_execution_policy<typename std::decay<ExecPolicy>::type>::value,
+                            T>::type;
+} // namespace internal
+
+} // namespace __pstl
+
+#endif /* __PSTL_execution_policy_defs_H */

--- a/cpp/pstl/include/pstl/internal/execution_impl.h
+++ b/cpp/pstl/include/pstl/internal/execution_impl.h
@@ -1,0 +1,162 @@
+// -*- C++ -*-
+//===-- execution_impl.h --------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_execution_impl_H
+#define __PSTL_execution_impl_H
+
+#include <iterator>
+#include <type_traits>
+
+#include "execution_defs.h"
+
+namespace __pstl
+{
+namespace internal
+{
+
+using namespace __pstl::execution;
+
+/* predicate */
+
+template <typename _Tp>
+std::false_type lazy_and(_Tp, std::false_type)
+{
+    return std::false_type{};
+};
+
+template <typename _Tp>
+inline _Tp
+lazy_and(_Tp __a, std::true_type)
+{
+    return __a;
+}
+
+template <typename _Tp>
+std::true_type lazy_or(_Tp, std::true_type)
+{
+    return std::true_type{};
+};
+
+template <typename _Tp>
+inline _Tp
+lazy_or(_Tp __a, std::false_type)
+{
+    return __a;
+}
+
+/* iterator */
+template <typename _IteratorType, typename... _OtherIteratorTypes>
+struct is_random_access_iterator
+{
+    static constexpr bool value =
+        is_random_access_iterator<_IteratorType>::value && is_random_access_iterator<_OtherIteratorTypes...>::value;
+    typedef std::integral_constant<bool, value> type;
+};
+
+template <typename _IteratorType>
+struct is_random_access_iterator<_IteratorType>
+    : std::is_same<typename std::iterator_traits<_IteratorType>::iterator_category, std::random_access_iterator_tag>
+{
+};
+
+/* policy */
+template <typename Policy>
+struct policy_traits
+{
+};
+
+template <>
+struct policy_traits<sequenced_policy>
+{
+    typedef std::false_type allow_parallel;
+    typedef std::false_type allow_unsequenced;
+    typedef std::false_type allow_vector;
+};
+
+template <>
+struct policy_traits<unsequenced_policy>
+{
+    typedef std::false_type allow_parallel;
+    typedef std::true_type allow_unsequenced;
+    typedef std::true_type allow_vector;
+};
+
+
+#if __PSTL_USE_PAR_POLICIES
+template <>
+struct policy_traits<parallel_policy>
+{
+    typedef std::true_type allow_parallel;
+    typedef std::false_type allow_unsequenced;
+    typedef std::false_type allow_vector;
+};
+
+template <>
+struct policy_traits<parallel_unsequenced_policy>
+{
+    typedef std::true_type allow_parallel;
+    typedef std::true_type allow_unsequenced;
+    typedef std::true_type allow_vector;
+};
+#endif
+
+template <typename _ExecutionPolicy>
+using collector_t = typename policy_traits<typename std::decay<_ExecutionPolicy>::type>::collector_type;
+
+template <typename _ExecutionPolicy>
+using allow_vector = typename internal::policy_traits<typename std::decay<_ExecutionPolicy>::type>::allow_vector;
+
+template <typename _ExecutionPolicy>
+using allow_unsequenced =
+    typename internal::policy_traits<typename std::decay<_ExecutionPolicy>::type>::allow_unsequenced;
+
+template <typename _ExecutionPolicy>
+using allow_parallel = typename internal::policy_traits<typename std::decay<_ExecutionPolicy>::type>::allow_parallel;
+
+template <typename _ExecutionPolicy, typename... _IteratorTypes>
+auto
+is_vectorization_preferred(_ExecutionPolicy&& __exec)
+    -> decltype(lazy_and(__exec.__allow_vector(), typename is_random_access_iterator<_IteratorTypes...>::type()))
+{
+    return internal::lazy_and(__exec.__allow_vector(), typename is_random_access_iterator<_IteratorTypes...>::type());
+}
+
+template <typename _ExecutionPolicy, typename... _IteratorTypes>
+auto
+is_parallelization_preferred(_ExecutionPolicy&& __exec)
+    -> decltype(lazy_and(__exec.__allow_parallel(), typename is_random_access_iterator<_IteratorTypes...>::type()))
+{
+    return internal::lazy_and(__exec.__allow_parallel(), typename is_random_access_iterator<_IteratorTypes...>::type());
+}
+
+template <typename policy, typename... _IteratorTypes>
+struct prefer_unsequenced_tag
+{
+    static constexpr bool value =
+        allow_unsequenced<policy>::value && is_random_access_iterator<_IteratorTypes...>::value;
+    typedef std::integral_constant<bool, value> type;
+};
+
+template <typename policy, typename... _IteratorTypes>
+struct prefer_parallel_tag
+{
+    static constexpr bool value = allow_parallel<policy>::value && is_random_access_iterator<_IteratorTypes...>::value;
+    typedef std::integral_constant<bool, value> type;
+};
+
+} // namespace internal
+} // namespace __pstl
+
+#endif /* __PSTL_execution_impl_H */

--- a/cpp/pstl/include/pstl/internal/glue_algorithm_defs.h
+++ b/cpp/pstl/include/pstl/internal/glue_algorithm_defs.h
@@ -1,0 +1,557 @@
+// -*- C++ -*-
+//===-- glue_algorithm_defs.h ---------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_glue_algorithm_defs_H
+#define __PSTL_glue_algorithm_defs_H
+
+#include <functional>
+
+#include "execution_defs.h"
+
+namespace std
+{
+
+// [alg.any_of]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+any_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
+
+// [alg.all_of]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+all_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
+
+// [alg.none_of]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+none_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
+
+// [alg.foreach]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Function>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+for_each_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, _Function __f);
+
+// [alg.find]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find_if_not(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
+
+// [alg.find.end]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_end(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+         _ForwardIterator2 __s_last, _BinaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_end(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+         _ForwardIterator2 __s_last);
+
+// [alg.find_first_of]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+              _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+              _ForwardIterator2 __s_first, _ForwardIterator2 __s_last);
+
+// [alg.adjacent_find]
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred);
+
+// [alg.count]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,
+                                           typename iterator_traits<_ForwardIterator>::difference_type>
+count(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,
+                                           typename iterator_traits<_ForwardIterator>::difference_type>
+count_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
+
+// [alg.search]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+       _ForwardIterator2 __s_last, _BinaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+       _ForwardIterator2 __s_last);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count,
+         const _Tp& __value, _BinaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count,
+         const _Tp& __value);
+
+// [alg.copy]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Size __n, _ForwardIterator2 __result);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 result,
+        _Predicate __pred);
+
+// [alg.swap]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+swap_ranges(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+            _ForwardIterator2 __first2);
+
+// [alg.transform]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+          _UnaryOperation __op);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+          _ForwardIterator __result, _BinaryOperation __op);
+
+// [alg.replace]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+           const _Tp& __new_value);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+replace(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __old_value,
+        const _Tp& __new_value);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                _ForwardIterator2 __result, _UnaryPredicate __pred, const _Tp& __new_value);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+replace_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+             const _Tp& __old_value, const _Tp& __new_value);
+
+// [alg.fill]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, const _Tp& __value);
+
+// [alg.generate]
+template <class _ExecutionPolicy, class _ForwardIterator, class _Generator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+generate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Generator __g);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Generator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+generate_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size count, _Generator __g);
+
+// [alg.remove]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+remove_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result, _Predicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+remove_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+            const _Tp& __value);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+remove_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+remove(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
+
+// [alg.unique]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+            _BinaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result);
+
+// [alg.reverse]
+
+template <class _ExecutionPolicy, class _BidirectionalIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+reverse(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last);
+
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last,
+             _ForwardIterator __d_first);
+
+// [alg.rotate]
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+rotate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+rotate_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __middle, _ForwardIterator1 __last,
+            _ForwardIterator2 __result);
+
+// [alg.partitions]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_partitioned(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+partition(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _BidirectionalIterator>
+stable_partition(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last,
+                 _UnaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _ForwardIterator1, class _ForwardIterator2,
+          class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+               _ForwardIterator1 __out_true, _ForwardIterator2 __out_false, _UnaryPredicate __pred);
+
+// [alg.sort]
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
+
+// [stable.sort]
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
+
+// [mismatch]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+         _ForwardIterator2 __last2, _BinaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+         _BinaryPredicate __pred);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+         _ForwardIterator2 __last2);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2);
+
+// [alg.equal]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+      _BinaryPredicate __p);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+      _ForwardIterator2 __last2, _BinaryPredicate __p);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+      _ForwardIterator2 __last2);
+
+// [alg.move]
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first);
+
+// [partial.sort]
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle,
+             _RandomAccessIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle,
+             _RandomAccessIterator __last);
+
+// [partial.sort.copy]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+                  _RandomAccessIterator __d_first, _RandomAccessIterator __d_last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+                  _RandomAccessIterator __d_first, _RandomAccessIterator __d_last);
+
+// [is.sorted]
+template <class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
+
+// [alg.nth.element]
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth,
+            _RandomAccessIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth,
+            _RandomAccessIterator __last);
+
+// [alg.merge]
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+      _ForwardIterator2 __last2, _ForwardIterator __d_first, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+      _ForwardIterator2 __last2, _ForwardIterator __d_first);
+
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle,
+              _BidirectionalIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _BidirectionalIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle,
+              _BidirectionalIterator __last);
+
+// [includes]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+         _ForwardIterator2 __last2, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+         _ForwardIterator2 __last2);
+
+// [set.union]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+          _ForwardIterator2 __last2, _ForwardIterator __result, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+          _ForwardIterator2 __last2, _ForwardIterator __result);
+
+// [set.intersection]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                 _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator __result, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                 _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator __result);
+
+// [set.difference]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+               _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator __result, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+               _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator __result);
+
+// [set.symmetric.difference]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_symmetric_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                         _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator result,
+                         _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_symmetric_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                         _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator __result);
+
+// [is.heap]
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
+
+// [alg.min.max]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
+
+// [alg.lex.comparison]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+lexicographical_compare(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                        _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+lexicographical_compare(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                        _ForwardIterator2 __first2, _ForwardIterator2 __last2);
+
+} // namespace std
+#endif /* __PSTL_glue_algorithm_defs_H */

--- a/cpp/pstl/include/pstl/internal/glue_algorithm_impl.h
+++ b/cpp/pstl/include/pstl/internal/glue_algorithm_impl.h
@@ -1,0 +1,1177 @@
+// -*- C++ -*-
+//===-- glue_algorithm_impl.h ---------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_glue_algorithm_impl_H
+#define __PSTL_glue_algorithm_impl_H
+
+#include <functional>
+
+#include "execution_defs.h"
+#include "utils.h"
+#include "algorithm_impl.h"
+
+namespace std
+{
+
+// [alg.any_of]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+any_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_any_of(std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
+                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                    internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+// [alg.all_of]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Pred>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+all_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Pred __pred)
+{
+    return !std::any_of(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                        __pstl::internal::not_pred<_Pred>(__pred));
+}
+
+// [alg.none_of]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+none_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
+{
+    return !std::any_of(std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred);
+}
+
+// [alg.foreach]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f)
+{
+    using namespace __pstl;
+    internal::pattern_walk1(std::forward<_ExecutionPolicy>(__exec), __first, __last, __f,
+                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                            internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Function>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+for_each_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, _Function __f)
+{
+    using namespace __pstl;
+    return internal::pattern_walk1_n(
+        std::forward<_ExecutionPolicy>(__exec), __first, __n, __f,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+// [alg.find]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_find_if(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find_if_not(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
+{
+    return std::find_if(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                        __pstl::internal::not_pred<_Predicate>(__pred));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
+{
+    return std::find_if(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                        __pstl::internal::equal_value<_Tp>(__value));
+}
+
+// [alg.find.end]
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_end(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+         _ForwardIterator2 __s_last, _BinaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_find_end(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_end(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+         _ForwardIterator2 __s_last)
+{
+    return std::find_end(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last,
+                         __pstl::internal::pstl_equal());
+}
+
+// [alg.find_first_of]
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+              _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_find_first_of(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+              _ForwardIterator2 __s_first, _ForwardIterator2 __s_last)
+{
+    return std::find_first_of(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last,
+                              __pstl::internal::pstl_equal());
+}
+
+// [alg.adjacent_find]
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    using namespace __pstl;
+    return internal::pattern_adjacent_find(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, std::equal_to<_ValueType>(),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*first_semantic*/ false);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_adjacent_find(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*first_semantic*/ false);
+}
+
+// [alg.count]
+
+// Implementation note: count and count_if call the pattern directly instead of calling std::transform_reduce
+// so that we do not have to include <numeric>.
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,
+                                           typename iterator_traits<_ForwardIterator>::difference_type>
+count(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    using namespace __pstl;
+    return internal::pattern_count(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                   [&__value](const _ValueType& __x) { return __value == __x; },
+                                   internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                   internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,
+                                           typename iterator_traits<_ForwardIterator>::difference_type>
+count_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_count(std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
+                                   internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                   internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+// [alg.search]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+       _ForwardIterator2 __s_last, _BinaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_search(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+       _ForwardIterator2 __s_last)
+{
+    return std::search(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last,
+                       __pstl::internal::pstl_equal());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count,
+         const _Tp& __value, _BinaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_search_n(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __count, __value, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count,
+         const _Tp& __value)
+{
+    return std::search_n(std::forward<_ExecutionPolicy>(__exec), __first, __last, __count, __value,
+                         std::equal_to<typename iterator_traits<_ForwardIterator>::value_type>());
+}
+
+// [alg.copy]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result)
+{
+    using namespace __pstl;
+    const auto __is_vector =
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec);
+
+    return internal::pattern_walk2_brick(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+        [__is_vector](_ForwardIterator1 __begin, _ForwardIterator1 __end, _ForwardIterator2 __res) {
+            return internal::brick_copy(__begin, __end, __res, __is_vector);
+        },
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Size __n, _ForwardIterator2 __result)
+{
+    using namespace __pstl;
+    const auto __is_vector =
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec);
+
+    return internal::pattern_walk2_brick_n(
+        std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+        [__is_vector](_ForwardIterator1 __begin, _Size __sz, _ForwardIterator2 __res) {
+            return internal::brick_copy_n(__begin, __sz, __res, __is_vector);
+        },
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+        _Predicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_copy_if(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+// [alg.swap]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+swap_ranges(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+            _ForwardIterator2 __first2)
+{
+    using namespace __pstl;
+    typedef typename iterator_traits<_ForwardIterator1>::reference _ReferenceType1;
+    typedef typename iterator_traits<_ForwardIterator2>::reference _ReferenceType2;
+    return internal::pattern_walk2(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+        [](_ReferenceType1 __x, _ReferenceType2 __y) {
+            using std::swap;
+            swap(__x, __y);
+        },
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+// [alg.transform]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+          _UnaryOperation __op)
+{
+    typedef typename iterator_traits<_ForwardIterator1>::reference _InputType;
+    typedef typename iterator_traits<_ForwardIterator2>::reference _OutputType;
+    using namespace __pstl;
+    return internal::pattern_walk2(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+        [__op](_InputType __x, _OutputType __y) mutable { __y = __op(__x); },
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+          _ForwardIterator __result, _BinaryOperation __op)
+{
+    typedef typename iterator_traits<_ForwardIterator1>::reference _Input1Type;
+    typedef typename iterator_traits<_ForwardIterator2>::reference _Input2Type;
+    typedef typename iterator_traits<_ForwardIterator>::reference _OutputType;
+    using namespace __pstl;
+    return internal::pattern_walk3(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
+        [__op](_Input1Type x, _Input2Type y, _OutputType z) mutable { z = __op(x, y); },
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(
+            __exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2,
+                                               _ForwardIterator>(__exec));
+}
+
+// [alg.replace]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
+           const _Tp& __new_value)
+{
+    using namespace __pstl;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ElementType;
+    internal::pattern_walk1(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                            [&__pred, &__new_value](_ElementType __elem) {
+                                if (__pred(__elem))
+                                {
+                                    __elem = __new_value;
+                                }
+                            },
+                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                            internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+replace(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __old_value,
+        const _Tp& __new_value)
+{
+    std::replace_if(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                    __pstl::internal::equal_value<_Tp>(__old_value), __new_value);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                _ForwardIterator2 __result, _UnaryPredicate __pred, const _Tp& __new_value)
+{
+    typedef typename iterator_traits<_ForwardIterator1>::reference _InputType;
+    typedef typename iterator_traits<_ForwardIterator2>::reference _OutputType;
+    using namespace __pstl;
+    return internal::pattern_walk2(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+        [__pred, &__new_value](_InputType __x, _OutputType __y) mutable { __y = __pred(__x) ? __new_value : __x; },
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+replace_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+             const _Tp& __old_value, const _Tp& __new_value)
+{
+    return std::replace_copy_if(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+                                __pstl::internal::equal_value<_Tp>(__old_value), __new_value);
+}
+
+// [alg.fill]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
+{
+    using namespace __pstl;
+    internal::pattern_fill(std::forward<_ExecutionPolicy>(__exec), __first, __last, __value,
+                           internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                           internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, const _Tp& __value)
+{
+    if (__count <= 0)
+        return __first;
+
+    using namespace __pstl;
+    return internal::pattern_fill_n(std::forward<_ExecutionPolicy>(__exec), __first, __count, __value,
+                                    internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+// [alg.generate]
+template <class _ExecutionPolicy, class _ForwardIterator, class _Generator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+generate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Generator __g)
+{
+    using namespace __pstl;
+    internal::pattern_generate(std::forward<_ExecutionPolicy>(__exec), __first, __last, __g,
+                               internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                               internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Generator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+generate_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, _Generator __g)
+{
+    if (__count <= 0)
+        return __first;
+
+    using namespace __pstl;
+    return internal::pattern_generate_n(
+        std::forward<_ExecutionPolicy>(__exec), __first, __count, __g,
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+// [alg.remove]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+remove_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result, _Predicate __pred)
+{
+    return std::copy_if(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+                        __pstl::internal::not_pred<_Predicate>(__pred));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+remove_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+            const _Tp& __value)
+{
+    return std::copy_if(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+                        __pstl::internal::not_equal_value<_Tp>(__value));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+remove_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_remove_if(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+remove(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
+{
+    return std::remove_if(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                          __pstl::internal::equal_value<_Tp>(__value));
+}
+
+// [alg.unique]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_unique(std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
+                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                    internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    return std::unique(std::forward<_ExecutionPolicy>(__exec), __first, __last, __pstl::internal::pstl_equal());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+            _BinaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_unique_copy(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result)
+{
+    return std::unique_copy(__exec, __first, __last, __result, __pstl::internal::pstl_equal());
+}
+
+// [alg.reverse]
+
+template <class _ExecutionPolicy, class _BidirectionalIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+reverse(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last)
+{
+    using namespace __pstl;
+    internal::pattern_reverse(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                              internal::is_vectorization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec),
+                              internal::is_parallelization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last,
+             _ForwardIterator __d_first)
+{
+    using namespace __pstl;
+    return internal::pattern_reverse_copy(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _BidirectionalIterator, _ForwardIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _BidirectionalIterator, _ForwardIterator>(__exec));
+}
+
+// [alg.rotate]
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+rotate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last)
+{
+    using namespace __pstl;
+    return internal::pattern_rotate(std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last,
+                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                    internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+rotate_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __middle, _ForwardIterator1 __last,
+            _ForwardIterator2 __result)
+{
+    using namespace __pstl;
+    return internal::pattern_rotate_copy(
+        std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last, __result,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+// [alg.partitions]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_partitioned(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_is_partitioned(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+partition(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_partition(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _BidirectionalIterator>
+stable_partition(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last,
+                 _UnaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_stable_partition(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _ForwardIterator1, class _ForwardIterator2,
+          class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+               _ForwardIterator1 __out_true, _ForwardIterator2 __out_false, _UnaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_partition_copy(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __out_true, __out_false, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator, _ForwardIterator1, _ForwardIterator2>(
+            __exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator, _ForwardIterator1,
+                                               _ForwardIterator2>(__exec));
+}
+
+// [alg.sort]
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
+{
+    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    using namespace __pstl;
+    return internal::pattern_sort(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
+        typename std::is_move_constructible<_InputType>::type());
+}
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last)
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    std::sort(std::forward<_ExecutionPolicy>(__exec), __first, __last, std::less<_InputType>());
+}
+
+// [stable.sort]
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_stable_sort(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last)
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    std::stable_sort(__exec, __first, __last, std::less<_InputType>());
+}
+
+// [mismatch]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+         _ForwardIterator2 __last2, _BinaryPredicate __pred)
+{
+    using namespace __pstl;
+    return internal::pattern_mismatch(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __pred,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+         _BinaryPredicate __pred)
+{
+    return std::mismatch(__exec, __first1, __last1, __first2, std::next(__first2, std::distance(__first1, __last1)),
+                         __pred);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+         _ForwardIterator2 __last2)
+{
+    return std::mismatch(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2,
+                         __pstl::internal::pstl_equal());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2)
+{
+    //TODO: to get rid of "distance"
+    return std::mismatch(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+                         std::next(__first2, std::distance(__first1, __last1)));
+}
+
+// [alg.equal]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+      _BinaryPredicate __p)
+{
+    using namespace __pstl;
+    return internal::pattern_equal(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __p,
+                                   internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1>(__exec),
+                                   internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2)
+{
+    return std::equal(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2,
+                      __pstl::internal::pstl_equal());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+      _ForwardIterator2 __last2, _BinaryPredicate __p)
+{
+    //TODO: to get rid of "distance"
+    if (std::distance(__first1, __last1) == std::distance(__first2, __last2))
+        return std::equal(__first1, __last1, __first2, __p);
+    else
+        return false;
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+      _ForwardIterator2 __last2)
+{
+    return equal(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __pstl::internal::pstl_equal());
+}
+
+// [alg.move]
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first)
+{
+    using namespace __pstl;
+    const auto __is_vector =
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec);
+
+    return internal::pattern_walk2_brick(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first,
+        [__is_vector](_ForwardIterator1 __begin, _ForwardIterator1 __end, _ForwardIterator2 __res) {
+            return internal::brick_move(__begin, __end, __res, __is_vector);
+        },
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+// [partial.sort]
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle,
+             _RandomAccessIterator __last, _Compare __comp)
+{
+    using namespace __pstl;
+    internal::pattern_partial_sort(
+        std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle,
+             _RandomAccessIterator __last)
+{
+    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    std::partial_sort(__exec, __first, __middle, __last, std::less<_InputType>());
+}
+
+// [partial.sort.copy]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+                  _RandomAccessIterator __d_first, _RandomAccessIterator __d_last, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_partial_sort_copy(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first, __d_last, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator, _RandomAccessIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator, _RandomAccessIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+                  _RandomAccessIterator __d_first, _RandomAccessIterator __d_last)
+{
+    return std::partial_sort_copy(std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first, __d_last,
+                                  __pstl::internal::pstl_less());
+}
+
+// [is.sorted]
+template <class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
+{
+    using namespace __pstl;
+    const _ForwardIterator __res = internal::pattern_adjacent_find(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __pstl::internal::reorder_pred<_Compare>(__comp),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*first_semantic*/ false);
+    return __res == __last ? __last : std::next(__res);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _InputType;
+    return is_sorted_until(std::forward<_ExecutionPolicy>(__exec), __first, __last, std::less<_InputType>());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_adjacent_find(
+               std::forward<_ExecutionPolicy>(__exec), __first, __last, internal::reorder_pred<_Compare>(__comp),
+               internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+               internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+               /*or_semantic*/ true) == __last;
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _InputType;
+    return std::is_sorted(std::forward<_ExecutionPolicy>(__exec), __first, __last, std::less<_InputType>());
+}
+
+// [alg.merge]
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+      _ForwardIterator2 __last2, _ForwardIterator __d_first, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_merge(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __d_first, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(
+            __exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2,
+                                               _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+      _ForwardIterator2 __last2, _ForwardIterator __d_first)
+{
+    return std::merge(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __d_first,
+                      __pstl::internal::pstl_less());
+}
+
+template <class _ExecutionPolicy, class _BidirectionalIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle,
+              _BidirectionalIterator __last, _Compare __comp)
+{
+    using namespace __pstl;
+    internal::pattern_inplace_merge(
+        std::forward<_ExecutionPolicy>(__exec), __first, __middle, __last, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _BidirectionalIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle,
+              _BidirectionalIterator __last)
+{
+    typedef typename std::iterator_traits<_BidirectionalIterator>::value_type _InputType;
+    std::inplace_merge(__exec, __first, __middle, __last, std::less<_InputType>());
+}
+
+// [includes]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+         _ForwardIterator2 __last2, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_includes(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+         _ForwardIterator2 __last2)
+{
+    return std::includes(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2,
+                         __pstl::internal::pstl_less());
+}
+
+// [set.union]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+          _ForwardIterator2 __last2, _ForwardIterator __result, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_set_union(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(
+            __exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2,
+                                               _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+          _ForwardIterator2 __last2, _ForwardIterator __result)
+{
+    return std::set_union(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result,
+                          __pstl::internal::pstl_less());
+}
+
+// [set.intersection]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                 _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator __result, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_set_intersection(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(
+            __exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2,
+                                               _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                 _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator __result)
+{
+    return std::set_intersection(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result,
+                                 __pstl::internal::pstl_less());
+}
+
+// [set.difference]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+               _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator __result, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_set_difference(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(
+            __exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2,
+                                               _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+               _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator __result)
+{
+    return std::set_difference(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result,
+                               __pstl::internal::pstl_less());
+}
+
+// [set.symmetric.difference]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator,
+          class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_symmetric_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                         _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator __result,
+                         _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_set_symmetric_difference(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(
+            __exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2,
+                                               _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_symmetric_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                         _ForwardIterator2 __first2, _ForwardIterator2 __last2, _ForwardIterator __result)
+{
+    return std::set_symmetric_difference(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2,
+                                         __result, __pstl::internal::pstl_less());
+}
+
+// [is.heap]
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_is_heap_until(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last)
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    return std::is_heap_until(std::forward<_ExecutionPolicy>(__exec), __first, __last, std::less<_InputType>());
+}
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
+{
+    return std::is_heap_until(std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp) == __last;
+}
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last)
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    return std::is_heap(std::forward<_ExecutionPolicy>(__exec), __first, __last, std::less<_InputType>());
+}
+
+// [alg.min.max]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_min_element(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _InputType;
+    return std::min_element(std::forward<_ExecutionPolicy>(__exec), __first, __last, std::less<_InputType>());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
+{
+    return min_element(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                       __pstl::internal::reorder_pred<_Compare>(__comp));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _InputType;
+    return std::min_element(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                            __pstl::internal::reorder_pred<std::less<_InputType>>(std::less<_InputType>()));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_minmax_element(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    return std::minmax_element(std::forward<_ExecutionPolicy>(__exec), __first, __last, std::less<_ValueType>());
+}
+
+// [alg.nth.element]
+
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth,
+            _RandomAccessIterator __last, _Compare __comp)
+{
+    using namespace __pstl;
+    internal::pattern_nth_element(
+        std::forward<_ExecutionPolicy>(__exec), __first, __nth, __last, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec));
+}
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth,
+            _RandomAccessIterator __last)
+{
+    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    std::nth_element(std::forward<_ExecutionPolicy>(__exec), __first, __nth, __last, std::less<_InputType>());
+}
+
+// [alg.lex.comparison]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+lexicographical_compare(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                        _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp)
+{
+    using namespace __pstl;
+    return internal::pattern_lexicographical_compare(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __comp,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+lexicographical_compare(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                        _ForwardIterator2 __first2, _ForwardIterator2 __last2)
+{
+    return std::lexicographical_compare(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2,
+                                        __pstl::internal::pstl_less());
+}
+
+} // namespace std
+
+#endif /* __PSTL_glue_algorithm_impl_H */

--- a/cpp/pstl/include/pstl/internal/glue_execution_defs.h
+++ b/cpp/pstl/include/pstl/internal/glue_execution_defs.h
@@ -1,0 +1,58 @@
+// -*- C++ -*-
+//===-- glue_execution_defs.h ---------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_glue_execution_defs_H
+#define __PSTL_glue_execution_defs_H
+
+#include <type_traits>
+
+#include "execution_defs.h"
+
+namespace std
+{
+// Type trait
+using __pstl::execution::is_execution_policy;
+#if __PSTL_CPP14_VARIABLE_TEMPLATES_PRESENT
+#if __INTEL_COMPILER
+template <class T>
+constexpr bool is_execution_policy_v = is_execution_policy<T>::value;
+#else
+using __pstl::execution::is_execution_policy_v;
+#endif
+#endif
+
+namespace execution
+{
+// Standard C++ policy classes
+using __pstl::execution::sequenced_policy;
+#if __PSTL_USE_PAR_POLICIES
+using __pstl::execution::parallel_policy;
+using __pstl::execution::parallel_unsequenced_policy;
+#endif
+// Standard predefined policy instances
+using __pstl::execution::seq;
+#if __PSTL_USE_PAR_POLICIES
+using __pstl::execution::par;
+using __pstl::execution::par_unseq;
+#endif
+// Implementation-defined names
+// Unsequenced policy is not yet standard, but for consistency
+// we include it into namespace std::execution as well
+using __pstl::execution::unseq;
+using __pstl::execution::unsequenced_policy;
+} // namespace execution
+} // namespace std
+
+#endif /* __PSTL_glue_execution_defs_H */

--- a/cpp/pstl/include/pstl/internal/glue_memory_defs.h
+++ b/cpp/pstl/include/pstl/internal/glue_memory_defs.h
@@ -1,0 +1,85 @@
+// -*- C++ -*-
+//===-- glue_memory_defs.h ------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_glue_memory_defs_H
+#define __PSTL_glue_memory_defs_H
+
+#include "execution_defs.h"
+
+namespace std
+{
+
+// [uninitialized.copy]
+
+template <class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result);
+
+template <class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result);
+
+// [uninitialized.move]
+
+template <class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result);
+
+template <class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result);
+
+// [uninitialized.fill]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, const _Tp& __value);
+
+// [specialized.destroy]
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n);
+
+// [uninitialized.construct.default]
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n);
+
+// [uninitialized.construct.value]
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n);
+
+} //  namespace std
+#endif /* __PSTL_glue_memory_defs_H */

--- a/cpp/pstl/include/pstl/internal/glue_memory_impl.h
+++ b/cpp/pstl/include/pstl/internal/glue_memory_impl.h
@@ -1,0 +1,362 @@
+// -*- C++ -*-
+//===-- glue_memory_impl.h ------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_glue_memory_impl_H
+#define __PSTL_glue_memory_impl_H
+
+#include "utils.h"
+#include "algorithm_impl.h"
+
+namespace std
+{
+
+// [uninitialized.copy]
+
+template <class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result)
+{
+    typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
+    typedef typename iterator_traits<_InputIterator>::reference _ReferenceType1;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType2;
+    using namespace __pstl;
+
+    const auto __is_parallel =
+        internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+    const auto __is_vector =
+        internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+
+    return internal::invoke_if_else(
+        std::integral_constant < bool, std::is_trivial<_ValueType1>::value&& std::is_trivial<_ValueType2>::value > (),
+        [&]() {
+            return internal::pattern_walk2_brick(
+                std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+                [__is_vector](_InputIterator __begin, _InputIterator __end, _ForwardIterator __res) {
+                    return internal::brick_copy(__begin, __end, __res, __is_vector);
+                },
+                __is_parallel);
+        },
+        [&]() {
+            return internal::pattern_walk2(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+                                           [](_ReferenceType1 __val1, _ReferenceType2 __val2) {
+                                               ::new (std::addressof(__val2)) _ValueType2(__val1);
+                                           },
+                                           __is_vector, __is_parallel);
+        });
+}
+
+template <class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result)
+{
+    typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
+    typedef typename iterator_traits<_InputIterator>::reference _ReferenceType1;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType2;
+    using namespace __pstl;
+
+    const auto __is_parallel =
+        internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+    const auto __is_vector =
+        internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+
+    return internal::invoke_if_else(
+        std::integral_constant < bool, std::is_trivial<_ValueType1>::value&& std::is_trivial<_ValueType2>::value > (),
+        [&]() {
+            return internal::pattern_walk2_brick_n(
+                std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+                [__is_vector](_InputIterator __begin, _Size __sz, _ForwardIterator __res) {
+                    return internal::brick_copy_n(__begin, __sz, __res, __is_vector);
+                },
+                __is_parallel);
+        },
+        [&]() {
+            return internal::pattern_walk2_n(std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+                                             [](_ReferenceType1 __val1, _ReferenceType2 __val2) {
+                                                 ::new (std::addressof(__val2)) _ValueType2(__val1);
+                                             },
+                                             __is_vector, __is_parallel);
+        });
+}
+
+// [uninitialized.move]
+
+template <class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result)
+{
+    typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
+    typedef typename iterator_traits<_InputIterator>::reference _ReferenceType1;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType2;
+    using namespace __pstl;
+
+    const auto __is_parallel =
+        internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+    const auto __is_vector =
+        internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+
+    return internal::invoke_if_else(
+        std::integral_constant < bool, std::is_trivial<_ValueType1>::value&& std::is_trivial<_ValueType2>::value > (),
+        [&]() {
+            return internal::pattern_walk2_brick(
+                std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+                [__is_vector](_InputIterator __begin, _InputIterator __end, _ForwardIterator __res) {
+                    return internal::brick_copy(__begin, __end, __res, __is_vector);
+                },
+                __is_parallel);
+        },
+        [&]() {
+            return internal::pattern_walk2(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+                                           [](_ReferenceType1 __val1, _ReferenceType2 __val2) {
+                                               ::new (std::addressof(__val2)) _ValueType2(std::move(__val1));
+                                           },
+                                           __is_vector, __is_parallel);
+        });
+}
+
+template <class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result)
+{
+    typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
+    typedef typename iterator_traits<_InputIterator>::reference _ReferenceType1;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType2;
+    using namespace __pstl;
+
+    const auto __is_parallel =
+        internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+    const auto __is_vector =
+        internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+
+    return internal::invoke_if_else(
+        std::integral_constant < bool, std::is_trivial<_ValueType1>::value&& std::is_trivial<_ValueType2>::value > (),
+        [&]() {
+            return internal::pattern_walk2_brick_n(
+                std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+                [__is_vector](_InputIterator __begin, _Size __sz, _ForwardIterator __res) {
+                    return internal::brick_copy_n(__begin, __sz, __res, __is_vector);
+                },
+                __is_parallel);
+        },
+        [&]() {
+            return internal::pattern_walk2_n(std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+                                             [](_ReferenceType1 __val1, _ReferenceType2 __val2) {
+                                                 ::new (std::addressof(__val2)) _ValueType2(std::move(__val1));
+                                             },
+                                             __is_vector, __is_parallel);
+        });
+}
+
+// [uninitialized.fill]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType;
+    using namespace __pstl;
+
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+
+    internal::invoke_if_else(
+        std::is_arithmetic<_ValueType>(),
+        [&]() {
+            internal::pattern_walk_brick(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                         [&__value, &__is_vector](_ForwardIterator __begin, _ForwardIterator __end) {
+                                             internal::brick_fill(__begin, __end, _ValueType(__value), __is_vector);
+                                         },
+                                         __is_parallel);
+        },
+        [&]() {
+            internal::pattern_walk1(
+                std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                [&__value](_ReferenceType __val) { ::new (std::addressof(__val)) _ValueType(__value); }, __is_vector,
+                __is_parallel);
+        });
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, const _Tp& __value)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType;
+    using namespace __pstl;
+
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+
+    return internal::invoke_if_else(
+        std::is_arithmetic<_ValueType>(),
+        [&]() {
+            return internal::pattern_walk_brick_n(std::forward<_ExecutionPolicy>(__exec), __first, __n,
+                                                  [&__value, &__is_vector](_ForwardIterator __begin, _Size __count) {
+                                                      return internal::brick_fill_n(__begin, __count,
+                                                                                    _ValueType(__value), __is_vector);
+                                                  },
+                                                  __is_parallel);
+        },
+        [&]() {
+            return internal::pattern_walk1_n(
+                std::forward<_ExecutionPolicy>(__exec), __first, __n,
+                [&__value](_ReferenceType __val) { ::new (std::addressof(__val)) _ValueType(__value); }, __is_vector,
+                __is_parallel);
+        });
+}
+
+// [specialized.destroy]
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType;
+    using namespace __pstl;
+
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+
+    internal::invoke_if_not(std::is_trivially_destructible<_ValueType>(), [&]() {
+        internal::pattern_walk1(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                [](_ReferenceType __val) { __val.~_ValueType(); }, __is_vector, __is_parallel);
+    });
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType;
+    using namespace __pstl;
+
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+
+    return internal::invoke_if_else(
+        std::is_trivially_destructible<_ValueType>(), [&]() { return std::next(__first, __n); },
+        [&]() {
+            return internal::pattern_walk1_n(std::forward<_ExecutionPolicy>(__exec), __first, __n,
+                                             [](_ReferenceType __val) { __val.~_ValueType(); }, __is_vector,
+                                             __is_parallel);
+        });
+}
+
+// [uninitialized.construct.default]
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType;
+    using namespace __pstl;
+
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+
+    internal::invoke_if_not(std::is_trivial<_ValueType>(), [&]() {
+        internal::pattern_walk1(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                [](_ReferenceType __val) { ::new (std::addressof(__val)) _ValueType; }, __is_vector,
+                                __is_parallel);
+    });
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType;
+    using namespace __pstl;
+
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+
+    return internal::invoke_if_else(std::is_trivial<_ValueType>(), [&]() { return std::next(__first, __n); },
+                                    [&]() {
+                                        return internal::pattern_walk1_n(
+                                            std::forward<_ExecutionPolicy>(__exec), __first, __n,
+                                            [](_ReferenceType __val) { ::new (std::addressof(__val)) _ValueType; },
+                                            __is_vector, __is_parallel);
+                                    });
+}
+
+// [uninitialized.construct.value]
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType;
+    using namespace __pstl;
+
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+
+    internal::invoke_if_else(
+        std::is_trivial<_ValueType>(),
+        [&]() {
+            internal::pattern_walk_brick(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                         [__is_vector](_ForwardIterator __begin, _ForwardIterator __end) {
+                                             internal::brick_fill(__begin, __end, _ValueType(), __is_vector);
+                                         },
+                                         __is_parallel);
+        },
+        [&]() {
+            internal::pattern_walk1(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                    [](_ReferenceType __val) { ::new (std::addressof(__val)) _ValueType(); },
+                                    __is_vector, __is_parallel);
+        });
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ReferenceType;
+    using namespace __pstl;
+
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+
+    return internal::invoke_if_else(
+        std::is_trivial<_ValueType>(),
+        [&]() {
+            return internal::pattern_walk_brick_n(std::forward<_ExecutionPolicy>(__exec), __first, __n,
+                                                  [__is_vector](_ForwardIterator __begin, _Size __count) {
+                                                      return internal::brick_fill_n(__begin, __count, _ValueType(),
+                                                                                    __is_vector);
+                                                  },
+                                                  __is_parallel);
+        },
+        [&]() {
+            return internal::pattern_walk1_n(std::forward<_ExecutionPolicy>(__exec), __first, __n,
+                                             [](_ReferenceType __val) { ::new (std::addressof(__val)) _ValueType(); },
+                                             __is_vector, __is_parallel);
+        });
+}
+
+} // namespace std
+
+#endif /* __PSTL_glue_memory_imple_H */

--- a/cpp/pstl/include/pstl/internal/glue_numeric_defs.h
+++ b/cpp/pstl/include/pstl/internal/glue_numeric_defs.h
@@ -1,0 +1,123 @@
+// -*- C++ -*-
+//===-- glue_numeric_defs.h -----------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_glue_numeric_defs_H
+#define __PSTL_glue_numeric_defs_H
+
+#include <functional>
+
+#include "execution_defs.h"
+
+namespace std
+{
+// [reduce]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
+       _BinaryOperation __binary_op);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init);
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, typename iterator_traits<_ForwardIterator>::value_type>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                 _ForwardIterator2 __first2, _Tp __init);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1,
+          class _BinaryOperation2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                 _ForwardIterator2 __first2, _Tp __init, _BinaryOperation1 __binary_op1,
+                 _BinaryOperation2 __binary_op2);
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
+                 _BinaryOperation __binary_op, _UnaryOperation __unary_op);
+
+// [exclusive.scan]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result, _Tp __init);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
+_ForwardIterator2
+exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result, _Tp __init, _BinaryOperation __binary_op);
+
+// [inclusive.scan]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result, _BinaryOperation __binary_op);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result, _BinaryOperation __binary_op, _Tp __init);
+
+// [transform.exclusive.scan]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation,
+          class _UnaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+transform_exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                         _ForwardIterator2 __result, _Tp __init, _BinaryOperation __binary_op,
+                         _UnaryOperation __unary_op);
+
+// [transform.inclusive.scan]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation,
+          class _UnaryOperation, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                         _ForwardIterator2 __result, _BinaryOperation __binary_op, _UnaryOperation __unary_op,
+                         _Tp __init);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryOperation,
+          class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                         _ForwardIterator2 __result, _BinaryOperation __binary_op, _UnaryOperation __unary_op);
+
+// [adjacent.difference]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                    _ForwardIterator2 __d_first, _BinaryOperation op);
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                    _ForwardIterator2 __d_first);
+
+} // namespace std
+#endif /* __PSTL_glue_numeric_defs_H */

--- a/cpp/pstl/include/pstl/internal/glue_numeric_impl.h
+++ b/cpp/pstl/include/pstl/internal/glue_numeric_impl.h
@@ -1,0 +1,230 @@
+// -*- C++ -*-
+//===-- glue_numeric_impl.h -----------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_glue_numeric_impl_H
+#define __PSTL_glue_numeric_impl_H
+
+#include <functional>
+
+#include "utils.h"
+#include "numeric_impl.h"
+
+namespace std
+{
+
+// [reduce]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
+       _BinaryOperation __binary_op)
+{
+    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op,
+                            __pstl::internal::no_op());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init)
+{
+    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, std::plus<_Tp>(),
+                            __pstl::internal::no_op());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, typename iterator_traits<_ForwardIterator>::value_type>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    return transform_reduce(std::forward<_ExecutionPolicy>(__exec), __first, __last, _ValueType{},
+                            std::plus<_ValueType>(), __pstl::internal::no_op());
+}
+
+// [transform.reduce]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                 _ForwardIterator2 __first2, _Tp __init)
+{
+    typedef typename iterator_traits<_ForwardIterator1>::value_type _InputType;
+    using namespace __pstl;
+    return internal::pattern_transform_reduce(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __init, std::plus<_InputType>(),
+        std::multiplies<_InputType>(),
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1,
+          class _BinaryOperation2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                 _ForwardIterator2 __first2, _Tp __init, _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2)
+{
+    using namespace __pstl;
+    return internal::pattern_transform_reduce(
+        std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __init, __binary_op1, __binary_op2,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
+                 _BinaryOperation __binary_op, _UnaryOperation __unary_op)
+{
+    using namespace __pstl;
+    return internal::pattern_transform_reduce(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op, __unary_op,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+}
+
+// [exclusive.scan]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result, _Tp __init)
+{
+    return transform_exclusive_scan(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, __init,
+                                    std::plus<_Tp>(), __pstl::internal::no_op());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
+_ForwardIterator2
+exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result, _Tp __init, _BinaryOperation __binary_op)
+{
+    return transform_exclusive_scan(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, __init,
+                                    __binary_op, __pstl::internal::no_op());
+}
+
+// [inclusive.scan]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result)
+{
+    typedef typename iterator_traits<_ForwardIterator1>::value_type _InputType;
+    return transform_inclusive_scan(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+                                    std::plus<_InputType>(), __pstl::internal::no_op());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result, _BinaryOperation __binary_op)
+{
+    return transform_inclusive_scan(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, __binary_op,
+                                    __pstl::internal::no_op());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+               _ForwardIterator2 __result, _BinaryOperation __binary_op, _Tp __init)
+{
+    return transform_inclusive_scan(std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, __binary_op,
+                                    __pstl::internal::no_op(), __init);
+}
+
+// [transform.exclusive.scan]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation,
+          class _UnaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+transform_exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                         _ForwardIterator2 __result, _Tp __init, _BinaryOperation __binary_op,
+                         _UnaryOperation __unary_op)
+{
+    using namespace __pstl;
+    return internal::pattern_transform_scan(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, __unary_op, __init, __binary_op,
+        /*inclusive=*/std::false_type(),
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+// [transform.inclusive.scan]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation,
+          class _UnaryOperation, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                         _ForwardIterator2 __result, _BinaryOperation __binary_op, _UnaryOperation __unary_op,
+                         _Tp __init)
+{
+    using namespace __pstl;
+    return internal::pattern_transform_scan(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __result, __unary_op, __init, __binary_op,
+        /*inclusive=*/std::true_type(),
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryOperation,
+          class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                         _ForwardIterator2 __result, _BinaryOperation __binary_op, _UnaryOperation __unary_op)
+{
+    typedef typename iterator_traits<_ForwardIterator1>::value_type _ValueType;
+    if (__first != __last)
+    {
+        _ValueType __tmp = __unary_op(*__first);
+        *__result = __tmp;
+        return transform_inclusive_scan(std::forward<_ExecutionPolicy>(__exec), ++__first, __last, ++__result,
+                                        __binary_op, __unary_op, __tmp);
+    }
+    else
+    {
+        return __result;
+    }
+}
+
+// [adjacent.difference]
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                    _ForwardIterator2 __d_first, _BinaryOperation __op)
+{
+
+    if (__first == __last)
+        return __d_first;
+
+    using namespace __pstl;
+    return internal::pattern_adjacent_difference(
+        std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first, __op,
+        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                    _ForwardIterator2 __d_first)
+{
+    typedef typename iterator_traits<_ForwardIterator1>::value_type _ValueType;
+    return adjacent_difference(std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first,
+                               std::minus<_ValueType>());
+}
+
+} // namespace std
+
+#endif /* __PSTL_glue_numeric_impl_H_ */

--- a/cpp/pstl/include/pstl/internal/memory_impl.h
+++ b/cpp/pstl/include/pstl/internal/memory_impl.h
@@ -1,0 +1,62 @@
+// -*- C++ -*-
+//===-- memory_impl.h -----------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_memory_impl_H
+#define __PSTL_memory_impl_H
+
+#include <iterator>
+
+#include "unseq_backend_simd.h"
+
+namespace __pstl
+{
+namespace internal
+{
+
+//------------------------------------------------------------------------
+// uninitialized_move
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class _OutputIterator>
+_OutputIterator
+brick_uninitialized_move(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                         /*vector=*/std::false_type) noexcept
+{
+    typedef typename std::iterator_traits<_OutputIterator>::value_type _ValueType2;
+    for (; __first != __last; ++__first, ++__result)
+    {
+        ::new (std::addressof(*__result)) _ValueType2(std::move(*__first));
+    }
+    return __result;
+}
+
+template <class _ForwardIterator, class _OutputIterator>
+_OutputIterator
+brick_uninitialized_move(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                         /*vector=*/std::true_type) noexcept
+{
+    typedef typename std::iterator_traits<_OutputIterator>::value_type __ValueType2;
+    typedef typename std::iterator_traits<_ForwardIterator>::reference _ReferenceType1;
+    typedef typename std::iterator_traits<_OutputIterator>::reference _ReferenceType2;
+
+    return unseq_backend::simd_walk_2(
+        __first, __last - __first, __result,
+        [](_ReferenceType1 __x, _ReferenceType2 __y) { ::new (std::addressof(__y)) __ValueType2(std::move(__x)); });
+}
+
+} // namespace internal
+} // namespace __pstl
+
+#endif /* __PSTL_memory_impl_H */

--- a/cpp/pstl/include/pstl/internal/numeric_impl.h
+++ b/cpp/pstl/include/pstl/internal/numeric_impl.h
@@ -1,0 +1,377 @@
+// -*- C++ -*-
+//===-- numeric_impl.h ----------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_numeric_impl_H
+#define __PSTL_numeric_impl_H
+
+#include <cassert>
+#include <iterator>
+#include <type_traits>
+#include <numeric>
+
+#include "pstl_config.h"
+#include "execution_impl.h"
+#include "unseq_backend_simd.h"
+
+#if __PSTL_USE_PAR_POLICIES
+#include "parallel_backend.h"
+#endif
+
+namespace __pstl
+{
+namespace internal
+{
+
+//------------------------------------------------------------------------
+// transform_reduce (version with two binary functions, according to draft N4659)
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1, class _BinaryOperation2>
+_Tp
+brick_transform_reduce(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init,
+                       _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2,
+                       /*is_vector=*/std::false_type) noexcept
+{
+    return std::inner_product(__first1, __last1, __first2, __init, __binary_op1, __binary_op2);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1, class _BinaryOperation2>
+_Tp
+brick_transform_reduce(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init,
+                       _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2,
+                       /*is_vector=*/std::true_type) noexcept
+{
+    typedef typename std::iterator_traits<_ForwardIterator1>::difference_type _DifferenceType;
+    return unseq_backend::simd_transform_reduce(
+        __last1 - __first1, __init, __binary_op1,
+        [=, &__binary_op2](_DifferenceType __i) { return __binary_op2(__first1[__i], __first2[__i]); });
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1,
+          class _BinaryOperation2, class _IsVector>
+_Tp
+pattern_transform_reduce(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                         _ForwardIterator2 __first2, _Tp __init, _BinaryOperation1 __binary_op1,
+                         _BinaryOperation2 __binary_op2, _IsVector __is_vector,
+                         /*is_parallel=*/std::false_type) noexcept
+{
+    return brick_transform_reduce(__first1, __last1, __first2, __init, __binary_op1, __binary_op2, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2, class _Tp,
+          class _BinaryOperation1, class _BinaryOperation2, class _IsVector>
+_Tp
+pattern_transform_reduce(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
+                         _RandomAccessIterator2 __first2, _Tp __init, _BinaryOperation1 __binary_op1,
+                         _BinaryOperation2 __binary_op2, _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+    return internal::except_handler([&]() {
+        return par_backend::parallel_transform_reduce(
+            std::forward<_ExecutionPolicy>(__exec), __first1, __last1,
+            [__first1, __first2, __binary_op2](_RandomAccessIterator1 __i) mutable {
+                return __binary_op2(*__i, *(__first2 + (__i - __first1)));
+            },
+            __init,
+            __binary_op1, // Combine
+            [__first1, __first2, __binary_op1, __binary_op2,
+             __is_vector](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j, _Tp __init) -> _Tp {
+                return internal::brick_transform_reduce(__i, __j, __first2 + (__i - __first1), __init, __binary_op1,
+                                                        __binary_op2, __is_vector);
+            });
+    });
+}
+#endif
+
+//------------------------------------------------------------------------
+// transform_reduce (version with unary and binary functions)
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation>
+_Tp
+brick_transform_reduce(_ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op,
+                       _UnaryOperation __unary_op, /*is_vector=*/std::false_type) noexcept
+{
+    for (; __first != __last; ++__first)
+    {
+        __init = __binary_op(__init, __unary_op(*__first));
+    }
+    return __init;
+}
+
+template <class _ForwardIterator, class _Tp, class _UnaryOperation, class _BinaryOperation>
+_Tp
+brick_transform_reduce(_ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op,
+                       _UnaryOperation __unary_op, /*is_vector=*/std::true_type) noexcept
+{
+    typedef typename std::iterator_traits<_ForwardIterator>::difference_type _DifferenceType;
+    return unseq_backend::simd_transform_reduce(
+        __last - __first, __init, __binary_op,
+        [=, &__unary_op](_DifferenceType __i) { return __unary_op(__first[__i]); });
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation,
+          class _IsVector>
+_Tp
+pattern_transform_reduce(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
+                         _BinaryOperation __binary_op, _UnaryOperation __unary_op, _IsVector __is_vector,
+                         /*is_parallel=*/std::false_type) noexcept
+{
+    return brick_transform_reduce(__first, __last, __init, __binary_op, __unary_op, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation,
+          class _IsVector>
+_Tp
+pattern_transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
+                         _BinaryOperation __binary_op, _UnaryOperation __unary_op, _IsVector __is_vector,
+                         /*is_parallel=*/std::true_type)
+{
+    return except_handler([&]() {
+        return par_backend::parallel_transform_reduce(
+            std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            [__unary_op](_ForwardIterator __i) mutable { return __unary_op(*__i); }, __init, __binary_op,
+            [__unary_op, __binary_op, __is_vector](_ForwardIterator __i, _ForwardIterator __j, _Tp __init) {
+                return brick_transform_reduce(__i, __j, __init, __binary_op, __unary_op, __is_vector);
+            });
+    });
+}
+#endif
+
+
+//------------------------------------------------------------------------
+// transform_exclusive_scan
+//
+// walk3 evaluates f(x,y,z) for (x,y,z) drawn from [first1,last1), [first2,...), [first3,...)
+//------------------------------------------------------------------------
+
+// Exclusive form
+template <class _ForwardIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation>
+std::pair<_OutputIterator, _Tp>
+brick_transform_scan(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                     _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
+                     /*Inclusive*/ std::false_type, /*is_vector=*/std::false_type) noexcept
+{
+    for (; __first != __last; ++__first, ++__result)
+    {
+        *__result = __init;
+        __PSTL_PRAGMA_FORCEINLINE
+        __init = __binary_op(__init, __unary_op(*__first));
+    }
+    return std::make_pair(__result, __init);
+}
+
+// Inclusive form
+template <class _ForwardIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation>
+std::pair<_OutputIterator, _Tp>
+brick_transform_scan(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                     _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
+                     /*Inclusive*/ std::true_type, /*is_vector=*/std::false_type) noexcept
+{
+    for (; __first != __last; ++__first, ++__result)
+    {
+        __PSTL_PRAGMA_FORCEINLINE
+        __init = __binary_op(__init, __unary_op(*__first));
+        *__result = __init;
+    }
+    return std::make_pair(__result, __init);
+}
+
+// type is arithmetic and binary operation is a user defined operation.
+template <typename _Tp, typename _BinaryOperation>
+using is_arithmetic_udop = std::integral_constant<bool, std::is_arithmetic<_Tp>::value &&
+                                                            !std::is_same<_BinaryOperation, std::plus<_Tp>>::value>;
+
+// [restriction] - T shall be DefaultConstructible.
+// [violation] - default ctor of T shall set the identity value for binary_op.
+template <class _ForwardIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
+          class _Inclusive>
+typename std::enable_if<!is_arithmetic_udop<_Tp, _BinaryOperation>::value, std::pair<_OutputIterator, _Tp>>::type
+brick_transform_scan(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                     _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
+                     /*is_vector=*/std::true_type) noexcept
+{
+#if (__PSTL_UDS_PRESENT)
+    return unseq_backend::simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op, _Inclusive());
+#else
+    // We need to call serial brick here to call function for inclusive and exclusive scan that depends on _Inclusive() value
+    return brick_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op, _Inclusive(),
+                                /*is_vector=*/std::false_type());
+#endif
+}
+
+template <class _ForwardIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
+          class _Inclusive>
+typename std::enable_if<is_arithmetic_udop<_Tp, _BinaryOperation>::value, std::pair<_OutputIterator, _Tp>>::type
+brick_transform_scan(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                     _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
+                     /*is_vector=*/std::true_type) noexcept
+{
+    return brick_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op, _Inclusive(),
+                                /*is_vector=*/std::false_type());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _UnaryOperation, class _Tp,
+          class _BinaryOperation, class _Inclusive, class _IsVector>
+_OutputIterator
+pattern_transform_scan(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                       _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
+                       _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept
+{
+    return internal::brick_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op, _Inclusive(),
+                                          __is_vector)
+        .first;
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp,
+          class _BinaryOperation, class _Inclusive, class _IsVector>
+typename std::enable_if<!std::is_floating_point<_Tp>::value, _OutputIterator>::type
+pattern_transform_scan(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                       _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
+                       _Inclusive, _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
+
+    return internal::except_handler([&]() {
+        par_backend::parallel_transform_scan(
+            std::forward<_ExecutionPolicy>(__exec), __last - __first,
+            [__first, __unary_op](_DifferenceType __i) mutable { return __unary_op(__first[__i]); }, __init,
+            __binary_op,
+            [__first, __unary_op, __binary_op, __is_vector](_DifferenceType __i, _DifferenceType __j, _Tp __init) {
+                // Execute serial brick_transform_reduce, due to the explicit SIMD vectorization (reduction) requires a commutative operation for the guarantee of correct scan.
+                return internal::brick_transform_reduce(__first + __i, __first + __j, __init, __binary_op, __unary_op,
+                                                        /*__is_vector*/ std::false_type());
+            },
+            [__first, __unary_op, __binary_op, __result, __is_vector](_DifferenceType __i, _DifferenceType __j,
+                                                                      _Tp __init) {
+                return internal::brick_transform_scan(__first + __i, __first + __j, __result + __i, __unary_op, __init,
+                                                      __binary_op, _Inclusive(), __is_vector)
+                    .second;
+            });
+        return __result + (__last - __first);
+    });
+}
+#endif
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp,
+          class _BinaryOperation, class _Inclusive, class _IsVector>
+typename std::enable_if<std::is_floating_point<_Tp>::value, _OutputIterator>::type
+pattern_transform_scan(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
+                       _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
+                       _Inclusive, _IsVector __is_vector, /*is_parallel=*/std::true_type)
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
+    _DifferenceType __n = __last - __first;
+
+    if (__n <= 0)
+    {
+        return __result;
+    }
+    return except_handler([&]() {
+        par_backend::parallel_strict_scan(
+            std::forward<_ExecutionPolicy>(__exec), __n, __init,
+            [__first, __unary_op, __binary_op, __result, __is_vector](_DifferenceType __i, _DifferenceType __len) {
+                return brick_transform_scan(__first + __i, __first + (__i + __len), __result + __i, __unary_op, _Tp{},
+                                            __binary_op, _Inclusive(), __is_vector)
+                    .second;
+            },
+            __binary_op,
+            [__result, &__binary_op](_DifferenceType __i, _DifferenceType __len, _Tp __initial) {
+                return *(std::transform(__result + __i, __result + __i + __len, __result + __i,
+                                        [&__initial, &__binary_op](const _Tp& __x) {
+                                            __PSTL_PRAGMA_FORCEINLINE
+                                            return __binary_op(__initial, __x);
+                                        }) -
+                         1);
+            },
+            [](_Tp __res) {});
+        return __result + (__last - __first);
+    });
+}
+#endif
+
+
+//------------------------------------------------------------------------
+// adjacent_difference
+//------------------------------------------------------------------------
+
+template <class _ForwardIterator, class _OutputIterator, class _BinaryOperation>
+_OutputIterator
+brick_adjacent_difference(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __d_first,
+                          _BinaryOperation __op, /*is_vector*/ std::false_type) noexcept
+{
+    return std::adjacent_difference(__first, __last, __d_first, __op);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class BinaryOperation>
+_ForwardIterator2
+brick_adjacent_difference(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first,
+                          BinaryOperation __op, /*is_vector=*/std::true_type) noexcept
+{
+    assert(__first != __last);
+
+    typedef typename std::iterator_traits<_ForwardIterator1>::reference _ReferenceType1;
+    typedef typename std::iterator_traits<_ForwardIterator2>::reference _ReferenceType2;
+
+    auto __n = __last - __first;
+    *__d_first = *__first;
+    return unseq_backend::simd_walk_3(
+        __first + 1, __n - 1, __first, __d_first + 1,
+        [&__op](_ReferenceType1 __x, _ReferenceType1 __y, _ReferenceType2 __z) { __z = __op(__x, __y); });
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _OutputIterator, class _BinaryOperation,
+          class _IsVector>
+_OutputIterator
+pattern_adjacent_difference(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+                            _OutputIterator __d_first, _BinaryOperation __op, _IsVector __is_vector,
+                            /*is_parallel*/ std::false_type) noexcept
+{
+    return internal::brick_adjacent_difference(__first, __last, __d_first, __op, __is_vector);
+}
+
+#if __PSTL_USE_PAR_POLICIES
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation,
+          class _IsVector>
+_ForwardIterator2
+pattern_adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last,
+                            _ForwardIterator2 __d_first, _BinaryOperation __op, _IsVector __is_vector,
+                            /*is_parallel=*/std::true_type)
+{
+    assert(__first != __last);
+    typedef typename std::iterator_traits<_ForwardIterator1>::reference _ReferenceType1;
+    typedef typename std::iterator_traits<_ForwardIterator2>::reference _ReferenceType2;
+
+    *__d_first = *__first;
+    par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __first, __last - 1,
+                              [&__op, __is_vector, __d_first, __first](_ForwardIterator1 __b, _ForwardIterator1 __e) {
+                                  _ForwardIterator2 __d_b = __d_first + (__b - __first);
+                                  brick_walk3(__b, __e, __b + 1, __d_b + 1,
+                                              [&__op](_ReferenceType1 __x, _ReferenceType1 __y, _ReferenceType2 __z) {
+                                                  __z = __op(__y, __x);
+                                              },
+                                              __is_vector);
+                              });
+    return __d_first + (__last - __first);
+}
+#endif
+
+} // namespace internal
+} // namespace __pstl
+
+#endif /* __PSTL_numeric_impl_H */

--- a/cpp/pstl/include/pstl/internal/parallel_backend.h
+++ b/cpp/pstl/include/pstl/internal/parallel_backend.h
@@ -1,0 +1,25 @@
+// -*- C++ -*-
+//===-- parallel_backend.h ------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_parallel_backend_H
+#define __PSTL_parallel_backend_H
+
+#if __PSTL_PAR_BACKEND_TBB
+#include "parallel_backend_tbb.h"
+#else
+__PSTL_PRAGMA_MESSAGE("Parallel backend was not specified");
+#endif
+
+#endif /* __PSTL_parallel_backend_H */

--- a/cpp/pstl/include/pstl/internal/parallel_backend_tbb.h
+++ b/cpp/pstl/include/pstl/internal/parallel_backend_tbb.h
@@ -1,0 +1,663 @@
+// -*- C++ -*-
+//===-- parallel_backend_tbb.h --------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_parallel_backend_tbb_H
+#define __PSTL_parallel_backend_tbb_H
+
+#include <cassert>
+#include <algorithm>
+#include <type_traits>
+
+#include "parallel_backend_utils.h"
+
+// Bring in minimal required subset of Intel TBB
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
+#include <tbb/parallel_reduce.h>
+#include <tbb/parallel_scan.h>
+#include <tbb/parallel_invoke.h>
+#include <tbb/task_arena.h>
+#include <tbb/tbb_allocator.h>
+
+#if TBB_INTERFACE_VERSION < 10000
+#error Intel(R) Threading Building Blocks 2018 is required; older versions are not supported.
+#endif
+
+namespace __pstl
+{
+namespace par_backend
+{
+
+//! Raw memory buffer with automatic freeing and no exceptions.
+/** Some of our algorithms need to start with raw memory buffer,
+not an initialize array, because initialization/destruction
+would make the span be at least O(N). */
+// tbb::allocator can improve performance in some cases.
+template <typename _Tp>
+class buffer
+{
+    tbb::tbb_allocator<_Tp> _M_allocator;
+    _Tp* _M_ptr;
+    const std::size_t _M_buf_size;
+    buffer(const buffer&) = delete;
+    void
+    operator=(const buffer&) = delete;
+
+  public:
+    //! Try to obtain buffer of given size to store objects of _Tp type
+    template <typename _ExecutionPolicy>
+    buffer(_ExecutionPolicy&&, std::size_t __n) : _M_allocator(), _M_ptr(_M_allocator.allocate(__n)), _M_buf_size(__n) {}
+    //! True if buffer was successfully obtained, zero otherwise.
+    operator bool() const { return _M_ptr != NULL; }
+    //! Return pointer to buffer, or  NULL if buffer could not be obtained.
+    _Tp*
+    get() const
+    {
+        return _M_ptr;
+    }
+    //! Destroy buffer
+    ~buffer() { _M_allocator.deallocate(_M_ptr, _M_buf_size); }
+};
+
+// Wrapper for tbb::task
+inline void
+cancel_execution()
+{
+    tbb::task::self().group()->cancel_group_execution();
+}
+
+//------------------------------------------------------------------------
+// parallel_for
+//------------------------------------------------------------------------
+
+template <class _Index, class _RealBody>
+class parallel_for_body
+{
+  public:
+    parallel_for_body(const _RealBody& __body) : _M_body(__body) {}
+    parallel_for_body(const parallel_for_body& __body) : _M_body(__body._M_body) {}
+    void
+    operator()(const tbb::blocked_range<_Index>& __range) const
+    {
+        _M_body(__range.begin(), __range.end());
+    }
+
+  private:
+    _RealBody _M_body;
+};
+
+//! Evaluation of brick f[i,j) for each subrange [i,j) of [first,last)
+// wrapper over tbb::parallel_for
+template <class _ExecutionPolicy, class _Index, class _Fp>
+void
+parallel_for(_ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f)
+{
+    tbb::this_task_arena::isolate(
+        [=]() { tbb::parallel_for(tbb::blocked_range<_Index>(__first, __last), parallel_for_body<_Index, _Fp>(__f)); });
+}
+
+//! Evaluation of brick f[i,j) for each subrange [i,j) of [first,last)
+// wrapper over tbb::parallel_reduce
+template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
+_Value
+parallel_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, const _Value& __identity,
+                const _RealBody& __real_body, const _Reduction& __reduction)
+{
+    return tbb::this_task_arena::isolate([__first, __last, &__identity, &__real_body, &__reduction]() -> _Value {
+        return tbb::parallel_reduce(
+            tbb::blocked_range<_Index>(__first, __last), __identity,
+            [__real_body](const tbb::blocked_range<_Index>& __r, const _Value& __value) -> _Value {
+                return __real_body(__r.begin(), __r.end(), __value);
+            },
+            __reduction);
+    });
+}
+
+//------------------------------------------------------------------------
+// parallel_transform_reduce
+//
+// Notation:
+//      r(i,j,init) returns reduction of init with reduction over [i,j)
+//      u(i) returns f(i,i+1,identity) for a hypothetical left identity element of r
+//      c(x,y) combines values x and y that were the result of r or u
+//------------------------------------------------------------------------
+
+template <class _Index, class _Up, class _Tp, class _Cp, class _Rp>
+struct par_trans_red_body
+{
+    alignas(_Tp) char _M_sum_storage[sizeof(_Tp)]; // Holds generalized non-commutative sum when has_sum==true
+    _Rp _M_brick_reduce;                           // Most likely to have non-empty layout
+    _Up _M_u;
+    _Cp _M_combine;
+    bool _M_has_sum; // Put last to minimize size of class
+    _Tp&
+    sum()
+    {
+        __TBB_ASSERT(_M_has_sum, "sum expected");
+        return *(_Tp*)_M_sum_storage;
+    }
+    par_trans_red_body(_Up __u, _Tp __init, _Cp __c, _Rp __r)
+        : _M_brick_reduce(__r), _M_u(__u), _M_combine(__c), _M_has_sum(true)
+    {
+        new (_M_sum_storage) _Tp(__init);
+    }
+
+    par_trans_red_body(par_trans_red_body& __left, tbb::split)
+        : _M_brick_reduce(__left._M_brick_reduce), _M_u(__left._M_u), _M_combine(__left._M_combine), _M_has_sum(false)
+    {
+    }
+
+    ~par_trans_red_body()
+    {
+        // 17.6.5.12 tells us to not worry about catching exceptions from destructors.
+        if (_M_has_sum)
+            sum().~_Tp();
+    }
+
+    void
+    join(par_trans_red_body& __rhs)
+    {
+        sum() = _M_combine(sum(), __rhs.sum());
+    }
+
+    void
+    operator()(const tbb::blocked_range<_Index>& __range)
+    {
+        _Index __i = __range.begin();
+        _Index __j = __range.end();
+        if (!_M_has_sum)
+        {
+            __TBB_ASSERT(__range.size() > 1, "there should be at least 2 elements");
+            new (&_M_sum_storage)
+                _Tp(_M_combine(_M_u(__i), _M_u(__i + 1))); // The condition i+1 < j is provided by the grain size of 3
+            _M_has_sum = true;
+            std::advance(__i, 2);
+            if (__i == __j)
+                return;
+        }
+        sum() = _M_brick_reduce(__i, __j, sum());
+    }
+};
+
+template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp>
+_Tp
+parallel_transform_reduce(_ExecutionPolicy&&, _Index __first, _Index __last, _Up __u, _Tp __init, _Cp __combine,
+                          _Rp __brick_reduce)
+{
+    par_trans_red_body<_Index, _Up, _Tp, _Cp, _Rp> __body(__u, __init, __combine, __brick_reduce);
+    // The grain size of 3 is used in order to provide mininum 2 elements for each body
+    tbb::this_task_arena::isolate(
+        [__first, __last, &__body]() { tbb::parallel_reduce(tbb::blocked_range<_Index>(__first, __last, 3), __body); });
+    return __body.sum();
+}
+
+//------------------------------------------------------------------------
+// parallel_scan
+//------------------------------------------------------------------------
+
+template <class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
+class trans_scan_body
+{
+    alignas(_Tp) char _M_sum_storage[sizeof(_Tp)]; // Holds generalized non-commutative sum when has_sum==true
+    _Rp _M_brick_reduce;                           // Most likely to have non-empty layout
+    _Up _M_u;
+    _Cp _M_combine;
+    _Sp _M_scan;
+    bool _M_has_sum; // Put last to minimize size of class
+  public:
+    trans_scan_body(_Up __u, _Tp __init, _Cp __combine, _Rp __reduce, _Sp __scan)
+        : _M_brick_reduce(__reduce), _M_u(__u), _M_combine(__combine), _M_scan(__scan), _M_has_sum(true)
+    {
+        new (_M_sum_storage) _Tp(__init);
+    }
+
+    trans_scan_body(trans_scan_body& __b, tbb::split)
+        : _M_brick_reduce(__b._M_brick_reduce), _M_u(__b._M_u), _M_combine(__b._M_combine), _M_scan(__b._M_scan),
+          _M_has_sum(false)
+    {
+    }
+
+    ~trans_scan_body()
+    {
+        // 17.6.5.12 tells us to not worry about catching exceptions from destructors.
+        if (_M_has_sum)
+            sum().~_Tp();
+    }
+
+    _Tp&
+    sum() const
+    {
+        __TBB_ASSERT(_M_has_sum, "sum expected");
+        return *(_Tp*)_M_sum_storage;
+    }
+
+    void
+    operator()(const tbb::blocked_range<_Index>& __range, tbb::pre_scan_tag)
+    {
+        _Index __i = __range.begin();
+        _Index __j = __range.end();
+        if (!_M_has_sum)
+        {
+            new (&_M_sum_storage) _Tp(_M_u(__i));
+            _M_has_sum = true;
+            ++__i;
+            if (__i == __j)
+                return;
+        }
+        sum() = _M_brick_reduce(__i, __j, sum());
+    }
+
+    void
+    operator()(const tbb::blocked_range<_Index>& __range, tbb::final_scan_tag)
+    {
+        sum() = _M_scan(__range.begin(), __range.end(), sum());
+    }
+
+    void
+    reverse_join(trans_scan_body& __a)
+    {
+        if (_M_has_sum)
+        {
+            sum() = _M_combine(__a.sum(), sum());
+        }
+        else
+        {
+            new (&_M_sum_storage) _Tp(__a.sum());
+            _M_has_sum = true;
+        }
+    }
+
+    void
+    assign(trans_scan_body& __b)
+    {
+        sum() = __b.sum();
+    }
+};
+
+template <typename _Index>
+_Index
+split(_Index __m)
+{
+    _Index __k = 1;
+    while (2 * __k < __m)
+        __k *= 2;
+    return __k;
+}
+
+//------------------------------------------------------------------------
+// parallel_strict_scan
+//------------------------------------------------------------------------
+
+
+template <typename _Index, typename _Tp, typename _Rp, typename _Cp>
+void
+upsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsize, _Rp __reduce, _Cp __combine)
+{
+    if (__m == 1)
+        __r[0] = __reduce(__i * __tilesize, __lastsize);
+    else
+    {
+        _Index __k = split(__m);
+        tbb::parallel_invoke([=] { par_backend::upsweep(__i, __k, __tilesize, __r, __tilesize, __reduce, __combine); },
+                             [=] {
+                                 par_backend::upsweep(__i + __k, __m - __k, __tilesize, __r + __k, __lastsize, __reduce,
+                                                      __combine);
+                             });
+        if (__m == 2 * __k)
+            __r[__m - 1] = __combine(__r[__k - 1], __r[__m - 1]);
+    }
+}
+
+template <typename _Index, typename _Tp, typename _Cp, typename _Sp>
+void
+downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsize, _Tp __initial, _Cp __combine,
+          _Sp __scan)
+{
+    if (__m == 1)
+        __scan(__i * __tilesize, __lastsize, __initial);
+    else
+    {
+        const _Index __k = par_backend::split(__m);
+        tbb::parallel_invoke(
+            [=] { par_backend::downsweep(__i, __k, __tilesize, __r, __tilesize, __initial, __combine, __scan); },
+            // Assumes that __combine never throws.
+            //TODO: Consider adding a requirement for user functors to be constant.
+            [=, &__combine] {
+                par_backend::downsweep(__i + __k, __m - __k, __tilesize, __r + __k, __lastsize,
+                                       __combine(__initial, __r[__k - 1]), __combine, __scan);
+            });
+    }
+}
+
+// Adapted from Intel(R) Cilk(TM) version from cilkpub.
+// Let i:len denote a counted interval of length n starting at i.  s denotes a generalized-sum value.
+// Expected actions of the functors are:
+//     reduce(i,len) -> s  -- return reduction value of i:len.
+//     combine(s1,s2) -> s -- return merged sum
+//     apex(s) -- do any processing necessary between reduce and scan.
+//     scan(i,len,initial) -- perform scan over i:len starting with initial.
+// The initial range 0:n is partitioned into consecutive subranges.
+// reduce and scan are each called exactly once per subrange.
+// Thus callers can rely upon side effects in reduce.
+// combine must not throw an exception.
+// apex is called exactly once, after all calls to reduce and before all calls to scan.
+// For example, it's useful for allocating a buffer used by scan but whose size is the sum of all reduction values.
+// T must have a trivial constructor and destructor.
+template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
+void
+parallel_strict_scan(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine, _Sp __scan, _Ap __apex)
+{
+    tbb::this_task_arena::isolate([=, &__exec, &__combine]() {
+        if (__n > 1)
+        {
+            _Index __p = tbb::this_task_arena::max_concurrency();
+            const _Index __slack = 4;
+            _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
+            _Index __m = (__n - 1) / __tilesize;
+            buffer<_Tp> __buf(std::forward<_ExecutionPolicy>(__exec), __m + 1);
+            _Tp* __r = __buf.get();
+            par_backend::upsweep(_Index(0), _Index(__m + 1), __tilesize, __r, __n - __m * __tilesize, __reduce,
+                                 __combine);
+            // When __apex is a no-op and __combine has no side effects, a good optimizer
+            // should be able to eliminate all code between here and __apex.
+            // Alternatively, provide a default value for __apex that can be
+            // recognized by metaprogramming that conditionlly executes the following.
+            size_t __k = __m + 1;
+            _Tp __t = __r[__k - 1];
+            while ((__k &= __k - 1))
+                __t = __combine(__r[__k - 1], __t);
+            __apex(__combine(__initial, __t));
+            par_backend::downsweep(_Index(0), _Index(__m + 1), __tilesize, __r, __n - __m * __tilesize, __initial,
+                                   __combine, __scan);
+            return;
+        }
+        // Fewer than 2 elements in sequence, or out of memory.  Handle has single block.
+        _Tp __sum = __initial;
+        if (__n)
+            __sum = __combine(__sum, __reduce(_Index(0), __n));
+        __apex(__sum);
+        if (__n)
+            __scan(_Index(0), __n, __initial);
+    });
+}
+
+template <class _ExecutionPolicy, class _Index, class _Up, class _Tp, class _Cp, class _Rp, class _Sp>
+_Tp
+parallel_transform_scan(_ExecutionPolicy&&, _Index __n, _Up __u, _Tp __init, _Cp __combine, _Rp __brick_reduce,
+                        _Sp __scan)
+{
+    trans_scan_body<_Index, _Up, _Tp, _Cp, _Rp, _Sp> __body(__u, __init, __combine, __brick_reduce, __scan);
+    auto __range = tbb::blocked_range<_Index>(0, __n);
+    tbb::this_task_arena::isolate([__range, &__body]() { tbb::parallel_scan(__range, __body); });
+    return __body.sum();
+}
+
+//------------------------------------------------------------------------
+// parallel_stable_sort
+//------------------------------------------------------------------------
+
+//------------------------------------------------------------------------
+// stable_sort utilities
+//
+// These are used by parallel implementations but do not depend on them.
+//------------------------------------------------------------------------
+
+template <typename _RandomAccessIterator1, typename _RandomAccessIterator2, typename _RandomAccessIterator3,
+          typename _Compare, typename _Cleanup, typename _LeafMerge>
+class merge_task : public tbb::task
+{
+    /*override*/ tbb::task*
+    execute();
+    _RandomAccessIterator1 _M_xs, _M_xe;
+    _RandomAccessIterator2 _M_ys, _M_ye;
+    _RandomAccessIterator3 _M_zs;
+    _Compare _M_comp;
+    _Cleanup _M_cleanup;
+    _LeafMerge _M_leaf_merge;
+
+  public:
+    merge_task(_RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe, _RandomAccessIterator2 __ys,
+               _RandomAccessIterator2 __ye, _RandomAccessIterator3 __zs, _Compare __comp, _Cleanup __cleanup,
+               _LeafMerge __leaf_merge)
+        : _M_xs(__xs), _M_xe(__xe), _M_ys(__ys), _M_ye(__ye), _M_zs(__zs), _M_comp(__comp), _M_cleanup(__cleanup),
+          _M_leaf_merge(__leaf_merge)
+    {
+    }
+};
+
+#define __PSTL_MERGE_CUT_OFF 2000
+
+template <typename _RandomAccessIterator1, typename _RandomAccessIterator2, typename _RandomAccessIterator3,
+          typename __M_Compare, typename _Cleanup, typename _LeafMerge>
+tbb::task*
+merge_task<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3, __M_Compare, _Cleanup,
+           _LeafMerge>::execute()
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType1;
+    typedef typename std::iterator_traits<_RandomAccessIterator2>::difference_type _DifferenceType2;
+    typedef typename std::common_type<_DifferenceType1, _DifferenceType2>::type _SizeType;
+    const _SizeType __n = (_M_xe - _M_xs) + (_M_ye - _M_ys);
+    const _SizeType __merge_cut_off = __PSTL_MERGE_CUT_OFF;
+    if (__n <= __merge_cut_off)
+    {
+        _M_leaf_merge(_M_xs, _M_xe, _M_ys, _M_ye, _M_zs, _M_comp);
+
+        //we clean the buffer one time on last step of the sort
+        _M_cleanup(_M_xs, _M_xe);
+        _M_cleanup(_M_ys, _M_ye);
+        return nullptr;
+    }
+    else
+    {
+        _RandomAccessIterator1 __xm;
+        _RandomAccessIterator2 __ym;
+        if (_M_xe - _M_xs < _M_ye - _M_ys)
+        {
+            __ym = _M_ys + (_M_ye - _M_ys) / 2;
+            __xm = std::upper_bound(_M_xs, _M_xe, *__ym, _M_comp);
+        }
+        else
+        {
+            __xm = _M_xs + (_M_xe - _M_xs) / 2;
+            __ym = std::lower_bound(_M_ys, _M_ye, *__xm, _M_comp);
+        }
+        const _RandomAccessIterator3 __zm = _M_zs + ((__xm - _M_xs) + (__ym - _M_ys));
+        tbb::task* __right = new (tbb::task::allocate_additional_child_of(*parent()))
+            merge_task(__xm, _M_xe, __ym, _M_ye, __zm, _M_comp, _M_cleanup, _M_leaf_merge);
+        tbb::task::spawn(*__right);
+        tbb::task::recycle_as_continuation();
+        _M_xe = __xm;
+        _M_ye = __ym;
+    }
+    return this;
+}
+
+template <typename _RandomAccessIterator1, typename _RandomAccessIterator2, typename _Compare, typename _LeafSort>
+class stable_sort_task : public tbb::task
+{
+  public:
+    typedef typename std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType1;
+    typedef typename std::iterator_traits<_RandomAccessIterator2>::difference_type _DifferenceType2;
+    typedef typename std::common_type<_DifferenceType1, _DifferenceType2>::type _SizeType;
+
+  private:
+    /*override*/ tbb::task*
+    execute();
+    _RandomAccessIterator1 _M_xs, _M_xe;
+    _RandomAccessIterator2 _M_zs;
+    _Compare _M_comp;
+    _LeafSort _M_leaf_sort;
+    int32_t _M_inplace;
+    _SizeType _M_nsort;
+
+  public:
+    stable_sort_task(_RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe, _RandomAccessIterator2 __zs,
+                     int32_t __inplace, _Compare __comp, _LeafSort __leaf_sort, _SizeType __n)
+        : _M_xs(__xs), _M_xe(__xe), _M_zs(__zs), _M_inplace(__inplace), _M_comp(__comp), _M_leaf_sort(__leaf_sort),
+          _M_nsort(__n)
+    {
+    }
+};
+
+//! Binary operator that does nothing
+struct binary_no_op
+{
+    template <typename _T>
+    void operator()(_T, _T)
+    {
+    }
+};
+
+#define __PSTL_STABLE_SORT_CUT_OFF 500
+
+template <typename _RandomAccessIterator1, typename _RandomAccessIterator2, typename _Compare, typename _LeafSort>
+tbb::task*
+stable_sort_task<_RandomAccessIterator1, _RandomAccessIterator2, _Compare, _LeafSort>::execute()
+{
+    const _SizeType __n = _M_xe - _M_xs;
+    const _SizeType __nmerge = _M_nsort > 0 ? _M_nsort : __n;
+    const _SizeType __sort_cut_off = __PSTL_STABLE_SORT_CUT_OFF;
+    if (__n <= __sort_cut_off)
+    {
+        _M_leaf_sort(_M_xs, _M_xe, _M_comp);
+        if (_M_inplace != 2)
+            init_buf(_M_xs, _M_xe, _M_zs, _M_inplace == 0);
+        return NULL;
+    }
+    else
+    {
+        const _RandomAccessIterator1 __xm = _M_xs + __n / 2;
+        const _RandomAccessIterator2 __zm = _M_zs + (__xm - _M_xs);
+        const _RandomAccessIterator2 __ze = _M_zs + __n;
+        task* __m;
+        auto __move_values = [](_RandomAccessIterator2 __x, _RandomAccessIterator1 __z) { *__z = std::move(*__x); };
+        auto __move_sequences = [](_RandomAccessIterator2 __first1, _RandomAccessIterator2 __last1,
+                                   _RandomAccessIterator1 __first2) { return std::move(__first1, __last1, __first2); };
+        if (_M_inplace == 2)
+            __m = new (allocate_continuation())
+                merge_task<_RandomAccessIterator2, _RandomAccessIterator2, _RandomAccessIterator1, _Compare,
+                           serial_destroy, serial_move_merge<decltype(__move_values), decltype(__move_sequences)>>(
+                    _M_zs, __zm, __zm, __ze, _M_xs, _M_comp, serial_destroy(),
+                    serial_move_merge<decltype(__move_values), decltype(__move_sequences)>(__nmerge, __move_values,
+                                                                                           __move_sequences));
+        else if (_M_inplace)
+            __m = new (allocate_continuation())
+                merge_task<_RandomAccessIterator2, _RandomAccessIterator2, _RandomAccessIterator1, _Compare,
+                           binary_no_op, serial_move_merge<decltype(__move_values), decltype(__move_sequences)>>(
+                    _M_zs, __zm, __zm, __ze, _M_xs, _M_comp, binary_no_op(),
+                    serial_move_merge<decltype(__move_values), decltype(__move_sequences)>(__nmerge, __move_values,
+                                                                                           __move_sequences));
+        else
+        {
+            auto __move_values = [](_RandomAccessIterator1 __x, _RandomAccessIterator2 __z) { *__z = std::move(*__x); };
+            auto __move_sequences = [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
+                                       _RandomAccessIterator2 __first2) {
+                return std::move(__first1, __last1, __first2);
+            };
+            __m = new (allocate_continuation())
+                merge_task<_RandomAccessIterator1, _RandomAccessIterator1, _RandomAccessIterator2, _Compare,
+                           binary_no_op, serial_move_merge<decltype(__move_values), decltype(__move_sequences)>>(
+                    _M_xs, __xm, __xm, _M_xe, _M_zs, _M_comp, binary_no_op(),
+                    serial_move_merge<decltype(__move_values), decltype(__move_sequences)>(__nmerge, __move_values,
+                                                                                           __move_sequences));
+        }
+        __m->set_ref_count(2);
+        task* __right = new (__m->allocate_child())
+            stable_sort_task(__xm, _M_xe, __zm, !_M_inplace, _M_comp, _M_leaf_sort, __nmerge);
+        spawn(*__right);
+        recycle_as_child_of(*__m);
+        _M_xe = __xm;
+        _M_inplace = !_M_inplace;
+    }
+    return this;
+}
+
+template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
+void
+parallel_stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __xs, _RandomAccessIterator __xe, _Compare __comp,
+                     _LeafSort __leaf_sort, std::size_t __nsort = 0)
+{
+    tbb::this_task_arena::isolate([=, &__exec, &__nsort]() {
+        //sorting based on task tree and parallel merge
+        typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _ValueType;
+        typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
+        const _DifferenceType __n = __xe - __xs;
+        if (__nsort == 0)
+            __nsort = __n;
+
+        const _DifferenceType __sort_cut_off = __PSTL_STABLE_SORT_CUT_OFF;
+        if (__n > __sort_cut_off)
+        {
+            assert(__nsort > 0 && __nsort <= __n);
+            buffer<_ValueType> __buf(std::forward<_ExecutionPolicy>(__exec), __n);
+            using tbb::task;
+            task::spawn_root_and_wait(*new (task::allocate_root())
+                                          stable_sort_task<_RandomAccessIterator, _ValueType*, _Compare, _LeafSort>(
+                                              __xs, __xe, (_ValueType*)__buf.get(), 2, __comp, __leaf_sort, __nsort));
+            return;
+        }
+        //serial sort
+        __leaf_sort(__xs, __xe, __comp);
+    });
+}
+
+//------------------------------------------------------------------------
+// parallel_merge
+//------------------------------------------------------------------------
+
+template <class _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
+          typename _RandomAccessIterator3, typename _Compare, typename _LeafMerge>
+void
+parallel_merge(_ExecutionPolicy&&, _RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe,
+               _RandomAccessIterator2 __ys, _RandomAccessIterator2 __ye, _RandomAccessIterator3 __zs, _Compare __comp,
+               _LeafMerge __leaf_merge)
+{
+    typedef typename std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType1;
+    typedef typename std::iterator_traits<_RandomAccessIterator2>::difference_type _DifferenceType2;
+    typedef typename std::common_type<_DifferenceType1, _DifferenceType2>::type _SizeType;
+    const _SizeType __n = (__xe - __xs) + (__ye - __ys);
+    const _SizeType __merge_cut_off = __PSTL_MERGE_CUT_OFF;
+    if (__n <= __merge_cut_off)
+    {
+        // Fall back on serial merge
+        __leaf_merge(__xs, __xe, __ys, __ye, __zs, __comp);
+    }
+    else
+    {
+        tbb::this_task_arena::isolate([=]() {
+            typedef merge_task<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3, _Compare,
+                               par_backend::binary_no_op, _LeafMerge>
+                _TaskType;
+            tbb::task::spawn_root_and_wait(*new (tbb::task::allocate_root()) _TaskType(
+                __xs, __xe, __ys, __ye, __zs, __comp, par_backend::binary_no_op(), __leaf_merge));
+        });
+    }
+}
+
+//------------------------------------------------------------------------
+// parallel_invoke
+//------------------------------------------------------------------------
+template <class _ExecutionPolicy, typename _F1, typename _F2>
+void
+parallel_invoke(_ExecutionPolicy&&, _F1&& __f1, _F2&& __f2)
+{
+    //TODO: a version of tbb::this_task_arena::isolate with variadic arguments pack should be added in the future
+    tbb::this_task_arena::isolate([&]() { tbb::parallel_invoke(std::forward<_F1>(__f1), std::forward<_F2>(__f2)); });
+}
+
+} // namespace par_backend
+} // namespace __pstl
+
+#endif /* __PSTL_parallel_backend_tbb_H */

--- a/cpp/pstl/include/pstl/internal/parallel_backend_utils.h
+++ b/cpp/pstl/include/pstl/internal/parallel_backend_utils.h
@@ -1,0 +1,202 @@
+// -*- C++ -*-
+//===-- parallel_backend_utils.h ------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_parallel_backend_utils_H
+#define __PSTL_parallel_backend_utils_H
+
+#include <iterator>
+#include <utility>
+#include "utils.h"
+
+namespace __pstl
+{
+namespace par_backend
+{
+
+//! Destroy sequence [xs,xe)
+struct serial_destroy
+{
+    template <typename _RandomAccessIterator>
+    void
+    operator()(_RandomAccessIterator __zs, _RandomAccessIterator __ze)
+    {
+        typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _ValueType;
+        while (__zs != __ze)
+        {
+            --__ze;
+            (*__ze).~_ValueType();
+        }
+    }
+};
+
+//! Merge sequences [__xs,__xe) and [__ys,__ye) to output sequence [__zs,(__xe-__xs)+(__ye-__ys)), using std::move
+template <class _MoveValues, class _MoveSequences>
+struct serial_move_merge
+{
+    const std::size_t _M_nmerge;
+    _MoveValues _M_move_values;
+    _MoveSequences _M_move_sequences;
+
+    explicit serial_move_merge(std::size_t __nmerge, _MoveValues __move_values, _MoveSequences __move_sequences)
+        : _M_nmerge(__nmerge), _M_move_values(__move_values), _M_move_sequences(__move_sequences)
+    {
+    }
+    template <class _RandomAccessIterator1, class _RandomAccessIterator2, class _RandomAccessIterator3, class _Compare>
+    void
+    operator()(_RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe, _RandomAccessIterator2 __ys,
+               _RandomAccessIterator2 __ye, _RandomAccessIterator3 __zs, _Compare __comp)
+    {
+        auto __n = _M_nmerge;
+        assert(__n > 0);
+        if (__xs != __xe)
+        {
+            if (__ys != __ye)
+            {
+                for (;;)
+                {
+                    if (__comp(*__ys, *__xs))
+                    {
+                        _M_move_values(__ys, __zs);
+                        ++__zs, --__n;
+                        if (++__ys == __ye)
+                        {
+                            break;
+                        }
+                        else if (__n == 0)
+                        {
+                            __zs = _M_move_sequences(__ys, __ye, __zs);
+                            break;
+                        }
+                        else
+                        {
+                        }
+                    }
+                    else
+                    {
+                        _M_move_values(__xs, __zs);
+                        ++__zs, --__n;
+                        if (++__xs == __xe)
+                        {
+                            _M_move_sequences(__ys, __ye, __zs);
+                            return;
+                        }
+                        else if (__n == 0)
+                        {
+                            __zs = _M_move_sequences(__xs, __xe, __zs);
+                            _M_move_sequences(__ys, __ye, __zs);
+                            return;
+                        }
+                        else
+                        {
+                        }
+                    }
+                }
+            }
+            __ys = __xs;
+            __ye = __xe;
+        }
+        _M_move_sequences(__ys, __ye, __zs);
+    }
+};
+
+template <typename _RandomAccessIterator1, typename _OutputIterator>
+void
+init_buf(_RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe, _OutputIterator __zs, bool __bMove)
+{
+    const _OutputIterator __ze = __zs + (__xe - __xs);
+    typedef typename std::iterator_traits<_OutputIterator>::value_type _ValueType;
+    if (__bMove)
+    {
+        // Initialize the temporary buffer and move keys to it.
+        for (; __zs != __ze; ++__xs, ++__zs)
+            new (&*__zs) _ValueType(std::move(*__xs));
+    }
+    else
+    {
+        // Initialize the temporary buffer
+        for (; __zs != __ze; ++__zs)
+            new (&*__zs) _ValueType;
+    }
+}
+
+template <typename _Buf>
+class stack
+{
+    typedef typename std::iterator_traits<decltype(std::declval<_Buf>().get())>::value_type _ValueType;
+    typedef typename std::iterator_traits<_ValueType*>::difference_type _DifferenceType;
+
+    _Buf _M_buf;
+    _ValueType* _M_ptr;
+    _DifferenceType _M_maxsize;
+
+    stack(const stack&) = delete;
+    void
+    operator=(const stack&) = delete;
+
+  public:
+    template <typename _ExecutionPolicy>
+    stack(_ExecutionPolicy&& __exec, _DifferenceType __max_size)
+        : _M_buf(std::forward<_ExecutionPolicy>(__exec), __max_size), _M_maxsize(__max_size) { _M_ptr = _M_buf.get(); }
+
+    ~stack()
+    {
+        assert(size() <= _M_maxsize);
+        while (!empty())
+            pop();
+    }
+
+    const _Buf&
+    buffer() const
+    {
+        return _M_buf;
+    }
+    size_t
+    size() const
+    {
+        assert(_M_ptr - _M_buf.get() <= _M_maxsize);
+        assert(_M_ptr - _M_buf.get() >= 0);
+        return _M_ptr - _M_buf.get();
+    }
+    bool
+    empty() const
+    {
+        assert(_M_ptr >= _M_buf.get());
+        return _M_ptr == _M_buf.get();
+    }
+    void
+    push(const _ValueType& __v)
+    {
+        assert(size() < _M_maxsize);
+        new (_M_ptr) _ValueType(__v);
+        ++_M_ptr;
+    }
+    const _ValueType&
+    top() const
+    {
+        return *(_M_ptr - 1);
+    }
+    void
+    pop()
+    {
+        assert(_M_ptr > _M_buf.get());
+        --_M_ptr;
+        (*_M_ptr).~_ValueType();
+    }
+};
+
+} // namespace par_backend
+} // namespace __pstl
+
+#endif /* __PSTL_parallel_backend_utils_H */

--- a/cpp/pstl/include/pstl/internal/parallel_impl.h
+++ b/cpp/pstl/include/pstl/internal/parallel_impl.h
@@ -1,0 +1,87 @@
+// -*- C++ -*-
+//===-- parallel_impl.h ---------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_parallel_impl_H
+#define __PSTL_parallel_impl_H
+
+#include <atomic>
+// This header defines the minimum set of parallel routines required to support Parallel STL,
+// implemented on top of Intel(R) Threading Building Blocks (Intel(R) TBB) library
+
+namespace __pstl
+{
+namespace internal
+{
+
+//------------------------------------------------------------------------
+// parallel_find
+//-----------------------------------------------------------------------
+/** Return extremum value returned by brick f[i,j) for subranges [i,j) of [first,last)
+Each f[i,j) must return a value in [i,j). */
+template <class _ExecutionPolicy, class _Index, class _Brick, class _Compare>
+_Index
+parallel_find(_ExecutionPolicy&& __exec, _Index __first, _Index __last, _Brick __f, _Compare __comp, bool __b_first)
+{
+    typedef typename std::iterator_traits<_Index>::difference_type _DifferenceType;
+    const _DifferenceType __n = __last - __first;
+    _DifferenceType __initial_dist = __b_first ? __n : -1;
+    std::atomic<_DifferenceType> __extremum(__initial_dist);
+    // TODO: find out what is better here: parallel_for or parallel_reduce
+    par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                              [__comp, __f, __first, &__extremum](_Index __i, _Index __j) {
+                                  // See "Reducing Contention Through Priority Updates", PPoPP '13, for discussion of
+                                  // why using a shared variable scales fairly well in this situation.
+                                  if (__comp(__i - __first, __extremum))
+                                  {
+                                      _Index __res = __f(__i, __j);
+                                      // If not '__last' returned then we found what we want so put this to extremum
+                                      if (__res != __j)
+                                      {
+                                          const _DifferenceType __k = __res - __first;
+                                          for (_DifferenceType __old = __extremum; __comp(__k, __old);
+                                               __old = __extremum)
+                                          {
+                                              __extremum.compare_exchange_weak(__old, __k);
+                                          }
+                                      }
+                                  }
+                              });
+    return __extremum != __initial_dist ? __first + __extremum : __last;
+}
+
+//------------------------------------------------------------------------
+// parallel_or
+//------------------------------------------------------------------------
+//! Return true if brick f[i,j) returns true for some subrange [i,j) of [first,last)
+template <class _ExecutionPolicy, class _Index, class _Brick>
+bool
+parallel_or(_ExecutionPolicy&& __exec, _Index __first, _Index __last, _Brick __f)
+{
+    std::atomic<bool> __found(false);
+    par_backend::parallel_for(std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                              [__f, &__found](_Index __i, _Index __j) {
+                                  if (!__found.load(std::memory_order_relaxed) && __f(__i, __j))
+                                  {
+                                      __found.store(true, std::memory_order_relaxed);
+                                      par_backend::cancel_execution();
+                                  }
+                              });
+    return __found;
+}
+
+} // namespace internal
+} // namespace __pstl
+
+#endif /* __PSTL_parallel_impl_H */

--- a/cpp/pstl/include/pstl/internal/pstl_config.h
+++ b/cpp/pstl/include/pstl/internal/pstl_config.h
@@ -1,0 +1,180 @@
+// -*- C++ -*-
+//===-- pstl_config.h -----------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_config_H
+#define __PSTL_config_H
+
+#define PSTL_VERSION 204
+#define PSTL_VERSION_MAJOR (PSTL_VERSION / 100)
+#define PSTL_VERSION_MINOR (PSTL_VERSION - PSTL_VERSION_MAJOR * 100)
+
+// Check the user-defined macro for parallel policies
+#if defined(PSTL_USE_PARALLEL_POLICIES)
+#undef __PSTL_USE_PAR_POLICIES
+#define __PSTL_USE_PAR_POLICIES PSTL_USE_PARALLEL_POLICIES
+// Check the internal macro for parallel policies
+#elif !defined(__PSTL_USE_PAR_POLICIES)
+#define __PSTL_USE_PAR_POLICIES 1
+#endif
+
+#if __PSTL_USE_PAR_POLICIES
+#if !defined(__PSTL_PAR_BACKEND_TBB)
+#define __PSTL_PAR_BACKEND_TBB 1
+#endif
+#else
+#undef __PSTL_PAR_BACKEND_TBB
+#endif
+
+// Check the user-defined macro for warnings
+#if defined(PSTL_USAGE_WARNINGS)
+#undef __PSTL_USAGE_WARNINGS
+#define __PSTL_USAGE_WARNINGS PSTL_USAGE_WARNINGS
+// Check the internal macro for warnings
+#elif !defined(__PSTL_USAGE_WARNINGS)
+#define __PSTL_USAGE_WARNINGS 0
+#endif
+
+// Portability "#pragma" definition
+#ifdef _MSC_VER
+#define __PSTL_PRAGMA(x) __pragma(x)
+#else
+#define __PSTL_PRAGMA(x) _Pragma(#x)
+#endif
+
+#define __PSTL_STRING_AUX(x) #x
+#define __PSTL_STRING(x) __PSTL_STRING_AUX(x)
+#define __PSTL_STRING_CONCAT(x, y) x #y
+
+// note that when ICC or Clang is in use, __PSTL_GCC_VERSION might not fully match
+// the actual GCC version on the system.
+#define __PSTL_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+#if __clang__
+// according to clang documentation, version can be vendor specific
+#define __PSTL_CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+#endif
+
+// Enable SIMD for compilers that support OpenMP 4.0
+#if (_OPENMP >= 201307) || (__INTEL_COMPILER >= 1600) || (!defined(__INTEL_COMPILER) && __PSTL_GCC_VERSION >= 40900)
+#define __PSTL_PRAGMA_SIMD __PSTL_PRAGMA(omp simd)
+#define __PSTL_PRAGMA_DECLARE_SIMD __PSTL_PRAGMA(omp declare simd)
+#define __PSTL_PRAGMA_SIMD_REDUCTION(PRM) __PSTL_PRAGMA(omp simd reduction(PRM))
+#elif !defined(_MSC_VER) //#pragma simd
+#define __PSTL_PRAGMA_SIMD __PSTL_PRAGMA(simd)
+#define __PSTL_PRAGMA_DECLARE_SIMD
+#define __PSTL_PRAGMA_SIMD_REDUCTION(PRM) __PSTL_PRAGMA(simd reduction(PRM))
+#else //no simd
+#define __PSTL_PRAGMA_SIMD
+#define __PSTL_PRAGMA_DECLARE_SIMD
+#define __PSTL_PRAGMA_SIMD_REDUCTION(PRM)
+#endif //Enable SIMD
+
+#if (__INTEL_COMPILER)
+#define __PSTL_PRAGMA_FORCEINLINE __PSTL_PRAGMA(forceinline)
+#else
+#define __PSTL_PRAGMA_FORCEINLINE
+#endif
+
+#if (__INTEL_COMPILER >= 1900)
+#define __PSTL_PRAGMA_SIMD_SCAN(PRM) __PSTL_PRAGMA(omp simd reduction(inscan, PRM))
+#define __PSTL_PRAGMA_SIMD_INCLUSIVE_SCAN(PRM) __PSTL_PRAGMA(omp scan inclusive(PRM))
+#define __PSTL_PRAGMA_SIMD_EXCLUSIVE_SCAN(PRM) __PSTL_PRAGMA(omp scan exclusive(PRM))
+#else
+#define __PSTL_PRAGMA_SIMD_SCAN(PRM)
+#define __PSTL_PRAGMA_SIMD_INCLUSIVE_SCAN(PRM)
+#define __PSTL_PRAGMA_SIMD_EXCLUSIVE_SCAN(PRM)
+#endif
+
+// Should be defined to 1 for environments with a vendor implementation of C++17 execution policies
+#define __PSTL_CPP17_EXECUTION_POLICIES_PRESENT (_MSC_VER >= 1912)
+
+#define __PSTL_CPP14_2RANGE_MISMATCH_EQUAL_PRESENT                                                                     \
+    (_MSC_VER >= 1900 || __cplusplus >= 201300L || __cpp_lib_robust_nonmodifying_seq_ops == 201304)
+#define __PSTL_CPP14_MAKE_REVERSE_ITERATOR_PRESENT                                                                     \
+    (_MSC_VER >= 1900 || __cplusplus >= 201402L || __cpp_lib_make_reverse_iterator == 201402)
+#define __PSTL_CPP14_INTEGER_SEQUENCE_PRESENT (_MSC_VER >= 1900 || __cplusplus >= 201402L)
+#define __PSTL_CPP14_VARIABLE_TEMPLATES_PRESENT                                                                        \
+    (!__INTEL_COMPILER || __INTEL_COMPILER >= 1700) && (_MSC_FULL_VER >= 190023918 || __cplusplus >= 201402L)
+
+#define __PSTL_EARLYEXIT_PRESENT (__INTEL_COMPILER >= 1800)
+#define __PSTL_MONOTONIC_PRESENT (__INTEL_COMPILER >= 1800)
+
+#if (__INTEL_COMPILER >= 1900 || !defined(__INTEL_COMPILER) && __PSTL_GCC_VERSION >= 40900 || _OPENMP >= 201307)
+#define __PSTL_UDR_PRESENT 1
+#else
+#define __PSTL_UDR_PRESENT 0
+#endif
+
+#define __PSTL_UDS_PRESENT (__INTEL_COMPILER >= 1900 && __INTEL_COMPILER_BUILD_DATE >= 20180626)
+
+#if __PSTL_EARLYEXIT_PRESENT
+#define __PSTL_PRAGMA_SIMD_EARLYEXIT __PSTL_PRAGMA(omp simd early_exit)
+#else
+#define __PSTL_PRAGMA_SIMD_EARLYEXIT
+#endif
+
+#if __PSTL_MONOTONIC_PRESENT
+#define __PSTL_PRAGMA_SIMD_ORDERED_MONOTONIC(PRM) __PSTL_PRAGMA(omp ordered simd monotonic(PRM))
+#define __PSTL_PRAGMA_SIMD_ORDERED_MONOTONIC_2ARGS(PRM1, PRM2) __PSTL_PRAGMA(omp ordered simd monotonic(PRM1, PRM2))
+#else
+#define __PSTL_PRAGMA_SIMD_ORDERED_MONOTONIC(PRM)
+#define __PSTL_PRAGMA_SIMD_ORDERED_MONOTONIC_2ARGS(PRM1, PRM2)
+#endif
+
+// Declaration of reduction functor, where
+// NAME - the name of the functor
+// OP - type of the callable object with the reduction operation
+// omp_in - refers to the local partial result
+// omp_out - refers to the final value of the combiner operator
+// omp_priv - refers to the private copy of the initial value
+// omp_orig - refers to the original variable to be reduced
+#define __PSTL_PRAGMA_DECLARE_REDUCTION(NAME, OP)                                                                      \
+    __PSTL_PRAGMA(omp declare reduction(NAME : OP : omp_out(omp_in)) initializer(omp_priv = omp_orig))
+
+#if (__INTEL_COMPILER >= 1600)
+#define __PSTL_PRAGMA_VECTOR_UNALIGNED __PSTL_PRAGMA(vector unaligned)
+#else
+#define __PSTL_PRAGMA_VECTOR_UNALIGNED
+#endif
+
+// Check the user-defined macro to use non-temporal stores
+#if defined(PSTL_USE_NONTEMPORAL_STORES) && (__INTEL_COMPILER >= 1600)
+#define __PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED __PSTL_PRAGMA(vector nontemporal)
+#else
+#define __PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
+#endif
+
+#if _MSC_VER || __INTEL_COMPILER //the preprocessors don't type a message location
+#define __PSTL_PRAGMA_LOCATION __FILE__ ":" __PSTL_STRING(__LINE__) ": [Parallel STL message]: "
+#else
+#define __PSTL_PRAGMA_LOCATION " [Parallel STL message]: "
+#endif
+
+#define __PSTL_PRAGMA_MESSAGE_IMPL(x) __PSTL_PRAGMA(message(__PSTL_STRING_CONCAT(__PSTL_PRAGMA_LOCATION, x)))
+
+#if __PSTL_USAGE_WARNINGS
+#define __PSTL_PRAGMA_MESSAGE(x) __PSTL_PRAGMA_MESSAGE_IMPL(x)
+#define __PSTL_PRAGMA_MESSAGE_POLICIES(x) __PSTL_PRAGMA_MESSAGE_IMPL(x)
+#else
+#define __PSTL_PRAGMA_MESSAGE(x)
+#define __PSTL_PRAGMA_MESSAGE_POLICIES(x)
+#endif
+
+// broken macros
+#define __PSTL_CPP11_STD_ROTATE_BROKEN ((__GLIBCXX__ && __GLIBCXX__ < 20150716) || (_MSC_VER && _MSC_VER < 1800))
+
+#define __PSTL_ICC_18_OMP_SIMD_BROKEN (__INTEL_COMPILER == 1800)
+
+#endif /* __PSTL_config_H */

--- a/cpp/pstl/include/pstl/internal/unseq_backend_simd.h
+++ b/cpp/pstl/include/pstl/internal/unseq_backend_simd.h
@@ -1,0 +1,861 @@
+// -*- C++ -*-
+//===-- unseq_backend_simd.h ----------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_unseq_backend_simd_H
+#define __PSTL_unseq_backend_simd_H
+
+#include <type_traits>
+
+#include "pstl_config.h"
+#include "utils.h"
+
+// This header defines the minimum set of vector routines required
+// to support parallel STL.
+namespace __pstl
+{
+namespace unseq_backend
+{
+
+// Expect vector width up to 64 (or 512 bit)
+const std::size_t __lane_size = 64;
+
+template <class _Iterator, class _DifferenceType, class _Function>
+_Iterator
+simd_walk_1(_Iterator __first, _DifferenceType __n, _Function __f) noexcept
+{
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+        __f(__first[__i]);
+
+    return __first + __n;
+}
+
+template <class _Iterator1, class _DifferenceType, class _Iterator2, class _Function>
+_Iterator2
+simd_walk_2(_Iterator1 __first1, _DifferenceType __n, _Iterator2 __first2, _Function __f) noexcept
+{
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+        __f(__first1[__i], __first2[__i]);
+    return __first2 + __n;
+}
+
+template <class _Iterator1, class _DifferenceType, class _Iterator2, class _Iterator3, class _Function>
+_Iterator3
+simd_walk_3(_Iterator1 __first1, _DifferenceType __n, _Iterator2 __first2, _Iterator3 __first3, _Function __f) noexcept
+{
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+        __f(__first1[__i], __first2[__i], __first3[__i]);
+    return __first3 + __n;
+}
+
+// TODO: check whether simd_first() can be used here
+template <class _Index, class _DifferenceType, class _Pred>
+bool
+simd_or(_Index __first, _DifferenceType __n, _Pred __pred) noexcept
+{
+#if __PSTL_EARLYEXIT_PRESENT
+    _DifferenceType __i;
+    __PSTL_PRAGMA_VECTOR_UNALIGNED
+    __PSTL_PRAGMA_SIMD_EARLYEXIT
+    for (__i = 0; __i < __n; ++__i)
+        if (__pred(__first[__i]))
+            break;
+    return __i < __n;
+#else
+    _DifferenceType __block_size = 4 < __n ? 4 : __n;
+    const _Index __last = __first + __n;
+    while (__last != __first)
+    {
+        int32_t __flag = 1;
+        __PSTL_PRAGMA_SIMD_REDUCTION(& : __flag)
+        for (_DifferenceType __i = 0; __i < __block_size; ++__i)
+            if (__pred(*(__first + __i)))
+                __flag = 0;
+        if (!__flag)
+            return true;
+
+        __first += __block_size;
+        if (__last - __first >= __block_size << 1)
+        {
+            // Double the block _Size.  Any unnecessary iterations can be amortized against work done so far.
+            __block_size <<= 1;
+        }
+        else
+        {
+            __block_size = __last - __first;
+        }
+    }
+    return false;
+#endif
+}
+
+template <class _Index, class _DifferenceType, class _Compare>
+_Index
+simd_first(_Index __first, _DifferenceType __begin, _DifferenceType __end, _Compare __comp) noexcept
+{
+#if __PSTL_EARLYEXIT_PRESENT
+    _DifferenceType __i = __begin;
+    __PSTL_PRAGMA_VECTOR_UNALIGNED // Do not generate peel loop part
+        __PSTL_PRAGMA_SIMD_EARLYEXIT for (; __i < __end; ++__i)
+    {
+        if (__comp(__first, __i))
+        {
+            break;
+        }
+    }
+    return __first + __i;
+#else
+    // Experiments show good block sizes like this
+    const _DifferenceType __block_size = 8;
+    alignas(__lane_size) _DifferenceType __lane[__block_size] = {0};
+    while (__end - __begin >= __block_size)
+    {
+        _DifferenceType __found = 0;
+        __PSTL_PRAGMA_VECTOR_UNALIGNED // Do not generate peel loop part
+            __PSTL_PRAGMA_SIMD_REDUCTION(|
+                                         : __found) for (_DifferenceType __i = __begin; __i < __begin + __block_size;
+                                                         ++__i)
+        {
+            const _DifferenceType __t = __comp(__first, __i);
+            __lane[__i - __begin] = __t;
+            __found |= __t;
+        }
+        if (__found)
+        {
+            _DifferenceType __i;
+            // This will vectorize
+            for (__i = 0; __i < __block_size; ++__i)
+            {
+                if (__lane[__i])
+                {
+                    break;
+                }
+            }
+            return __first + __begin + __i;
+        }
+        __begin += __block_size;
+    }
+
+    //Keep remainder scalar
+    while (__begin != __end)
+    {
+        if (__comp(__first, __begin))
+        {
+            return __first + __begin;
+        }
+        ++__begin;
+    }
+    return __first + __end;
+#endif //__PSTL_EARLYEXIT_PRESENT
+}
+
+template <class _Index1, class _DifferenceType, class _Index2, class _Pred>
+std::pair<_Index1, _Index2>
+simd_first(_Index1 __first1, _DifferenceType __n, _Index2 __first2, _Pred __pred) noexcept
+{
+#if __PSTL_EARLYEXIT_PRESENT
+    _DifferenceType __i = 0;
+    __PSTL_PRAGMA_VECTOR_UNALIGNED
+    __PSTL_PRAGMA_SIMD_EARLYEXIT
+    for (; __i < __n; ++__i)
+        if (__pred(__first1[__i], __first2[__i]))
+            break;
+    return std::make_pair(__first1 + __i, __first2 + __i);
+#else
+    const _Index1 __last1 = __first1 + __n;
+    const _Index2 __last2 = __first2 + __n;
+    // Experiments show good block sizes like this
+    const _DifferenceType __block_size = 8;
+    alignas(__lane_size) _DifferenceType __lane[__block_size] = {0};
+    while (__last1 - __first1 >= __block_size)
+    {
+        _DifferenceType __found = 0;
+        _DifferenceType __i;
+        __PSTL_PRAGMA_VECTOR_UNALIGNED // Do not generate peel loop part
+            __PSTL_PRAGMA_SIMD_REDUCTION(|
+                                         : __found) for (__i = 0; __i < __block_size; ++__i)
+        {
+            const _DifferenceType __t = __pred(__first1[__i], __first2[__i]);
+            __lane[__i] = __t;
+            __found |= __t;
+        }
+        if (__found)
+        {
+            _DifferenceType __i;
+            // This will vectorize
+            for (__i = 0; __i < __block_size; ++__i)
+            {
+                if (__lane[__i])
+                    break;
+            }
+            return std::make_pair(__first1 + __i, __first2 + __i);
+        }
+        __first1 += __block_size;
+        __first2 += __block_size;
+    }
+
+    //Keep remainder scalar
+    for (; __last1 != __first1; ++__first1, ++__first2)
+        if (__pred(*(__first1), *(__first2)))
+            return std::make_pair(__first1, __first2);
+
+    return std::make_pair(__last1, __last2);
+#endif //__PSTL_EARLYEXIT_PRESENT
+}
+
+template <class _Index, class _DifferenceType, class _Pred>
+_DifferenceType
+simd_count(_Index __index, _DifferenceType __n, _Pred __pred) noexcept
+{
+    _DifferenceType __count = 0;
+    __PSTL_PRAGMA_SIMD_REDUCTION(+ : __count)
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+        if (__pred(*(__index + __i)))
+            ++__count;
+
+    return __count;
+}
+
+template <class _InputIterator, class _DifferenceType, class _OutputIterator, class _BinaryPredicate>
+_OutputIterator
+simd_unique_copy(_InputIterator __first, _DifferenceType __n, _OutputIterator __result,
+                 _BinaryPredicate __pred) noexcept
+{
+    if (__n == 0)
+        return __result;
+
+    _DifferenceType __cnt = 1;
+    __result[0] = __first[0];
+
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 1; __i < __n; ++__i)
+    {
+        __PSTL_PRAGMA_SIMD_ORDERED_MONOTONIC(__cnt : 1)
+        if (!__pred(__first[__i], __first[__i - 1]))
+        {
+            __result[__cnt] = __first[__i];
+            ++__cnt;
+        }
+    }
+    return __result + __cnt;
+}
+
+template <class _InputIterator, class _DifferenceType, class _OutputIterator, class _Assigner>
+_OutputIterator
+simd_assign(_InputIterator __first, _DifferenceType __n, _OutputIterator __result, _Assigner __assigner) noexcept
+{
+    __PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+        __assigner(__first + __i, __result + __i);
+    return __result + __n;
+}
+
+template <class _InputIterator, class _DifferenceType, class _OutputIterator, class _UnaryPredicate>
+_OutputIterator
+simd_copy_if(_InputIterator __first, _DifferenceType __n, _OutputIterator __result, _UnaryPredicate __pred) noexcept
+{
+    _DifferenceType __cnt = 0;
+
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+    {
+        __PSTL_PRAGMA_SIMD_ORDERED_MONOTONIC(__cnt : 1)
+        if (__pred(__first[__i]))
+        {
+            __result[__cnt] = __first[__i];
+            ++__cnt;
+        }
+    }
+    return __result + __cnt;
+}
+
+template <class _InputIterator, class _DifferenceType, class _BinaryPredicate>
+_DifferenceType
+simd_calc_mask_2(_InputIterator __first, _DifferenceType __n, bool* __mask, _BinaryPredicate __pred) noexcept
+{
+    _DifferenceType __count = 0;
+
+    __PSTL_PRAGMA_SIMD_REDUCTION(+ : __count)
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+    {
+        __mask[__i] = !__pred(__first[__i], __first[__i - 1]);
+        __count += __mask[__i];
+    }
+    return __count;
+}
+
+template <class _InputIterator, class _DifferenceType, class _UnaryPredicate>
+_DifferenceType
+simd_calc_mask_1(_InputIterator __first, _DifferenceType __n, bool* __mask, _UnaryPredicate __pred) noexcept
+{
+    _DifferenceType __count = 0;
+
+    __PSTL_PRAGMA_SIMD_REDUCTION(+ : __count)
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+    {
+        __mask[__i] = __pred(__first[__i]);
+        __count += __mask[__i];
+    }
+    return __count;
+}
+
+template <class _InputIterator, class _DifferenceType, class _OutputIterator, class _Assigner>
+void
+simd_copy_by_mask(_InputIterator __first, _DifferenceType __n, _OutputIterator __result, bool* __mask,
+                  _Assigner __assigner) noexcept
+{
+    _DifferenceType __cnt = 0;
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+    {
+        if (__mask[__i])
+        {
+            __PSTL_PRAGMA_SIMD_ORDERED_MONOTONIC(__cnt : 1)
+            {
+                __assigner(__first + __i, __result + __cnt);
+                ++__cnt;
+            }
+        }
+    }
+}
+
+template <class _InputIterator, class _DifferenceType, class _OutputIterator1, class _OutputIterator2>
+void
+simd_partition_by_mask(_InputIterator __first, _DifferenceType __n, _OutputIterator1 __out_true,
+                       _OutputIterator2 __out_false, bool* __mask) noexcept
+{
+    _DifferenceType __cnt_true = 0, __cnt_false = 0;
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+    {
+        __PSTL_PRAGMA_SIMD_ORDERED_MONOTONIC_2ARGS(__cnt_true : 1, __cnt_false : 1)
+        if (__mask[__i])
+        {
+            __out_true[__cnt_true] = __first[__i];
+            ++__cnt_true;
+        }
+        else
+        {
+            __out_false[__cnt_false] = __first[__i];
+            ++__cnt_false;
+        }
+    }
+}
+
+template <class _Index, class _DifferenceType, class _Tp>
+_Index
+simd_fill_n(_Index __first, _DifferenceType __n, const _Tp& __value) noexcept
+{
+    __PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+        __first[__i] = __value;
+    return __first + __n;
+}
+
+template <class _Index, class _DifferenceType, class _Generator>
+_Index
+simd_generate_n(_Index __first, _DifferenceType __size, _Generator __g) noexcept
+{
+    __PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 0; __i < __size; ++__i)
+        __first[__i] = __g();
+    return __first + __size;
+}
+
+template <class _Index, class _BinaryPredicate>
+_Index
+simd_adjacent_find(_Index __first, _Index __last, _BinaryPredicate __pred, bool __or_semantic) noexcept
+{
+    if (__last - __first < 2)
+        return __last;
+
+    typedef typename std::iterator_traits<_Index>::difference_type _DifferenceType;
+    _DifferenceType __i = 0;
+
+#if __PSTL_EARLYEXIT_PRESENT
+    //Some compiler versions fail to compile the following loop when iterators are used. Indices are used instead
+    const _DifferenceType __n = __last - __first - 1;
+    __PSTL_PRAGMA_VECTOR_UNALIGNED
+    __PSTL_PRAGMA_SIMD_EARLYEXIT
+    for (; __i < __n; ++__i)
+        if (__pred(__first[__i], __first[__i + 1]))
+            break;
+
+    return __i < __n ? __first + __i : __last;
+#else
+    // Experiments show good block sizes like this
+    //TODO: to consider tuning block_size for various data types
+    const _DifferenceType __block_size = 8;
+    alignas(__lane_size) _DifferenceType __lane[__block_size] = {0};
+    while (__last - __first >= __block_size)
+    {
+        _DifferenceType __found = 0;
+        __PSTL_PRAGMA_VECTOR_UNALIGNED // Do not generate peel loop part
+            __PSTL_PRAGMA_SIMD_REDUCTION(|
+                                         : __found) for (__i = 0; __i < __block_size - 1; ++__i)
+        {
+            //TODO: to improve SIMD vectorization
+            const _DifferenceType __t = __pred(*(__first + __i), *(__first + __i + 1));
+            __lane[__i] = __t;
+            __found |= __t;
+        }
+
+        //Process a pair of elements on a boundary of a data block
+        if (__first + __block_size < __last && __pred(*(__first + __i), *(__first + __i + 1)))
+            __lane[__i] = __found = 1;
+
+        if (__found)
+        {
+            if (__or_semantic)
+                return __first;
+
+            // This will vectorize
+            for (__i = 0; __i < __block_size; ++__i)
+                if (__lane[__i])
+                    break;
+            return __first + __i; //As far as found is true a __result (__lane[__i] is true) is guaranteed
+        }
+        __first += __block_size;
+    }
+    //Process the rest elements
+    for (; __last - __first > 1; ++__first)
+        if (__pred(*__first, *(__first + 1)))
+            return __first;
+
+    return __last;
+#endif
+}
+
+// It was created to reduce the code inside std::enable_if
+template <typename _Tp, typename _BinaryOperation>
+using is_arithmetic_plus = std::integral_constant<bool, std::is_arithmetic<_Tp>::value &&
+                                                            std::is_same<_BinaryOperation, std::plus<_Tp>>::value>;
+
+template <typename _DifferenceType, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
+typename std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>::type
+simd_transform_reduce(_DifferenceType __n, _Tp __init, _BinaryOperation, _UnaryOperation __f) noexcept
+{
+    __PSTL_PRAGMA_SIMD_REDUCTION(+ : __init)
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+        __init += __f(__i);
+    return __init;
+}
+
+template <typename _Size, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
+typename std::enable_if<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>::type
+simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _UnaryOperation __f) noexcept
+{
+    const std::size_t __block_size = __lane_size / sizeof(_Tp);
+    if (__n > 2 * __block_size && __block_size > 1)
+    {
+        alignas(__lane_size) char __lane_[__lane_size];
+        _Tp* __lane = reinterpret_cast<_Tp*>(__lane_);
+
+        // initializer
+        __PSTL_PRAGMA_SIMD
+        for (_Size __i = 0; __i < __block_size; ++__i)
+        {
+            ::new (__lane + __i) _Tp(__binary_op(__f(__i), __f(__block_size + __i)));
+        }
+        // main loop
+        _Size __i = 2 * __block_size;
+        const _Size last_iteration = __block_size * (__n / __block_size);
+        for (; __i < last_iteration; __i += __block_size)
+        {
+            __PSTL_PRAGMA_SIMD
+            for (_Size __j = 0; __j < __block_size; ++__j)
+            {
+                __lane[__j] = __binary_op(__lane[__j], __f(__i + __j));
+            }
+        }
+        // remainder
+        __PSTL_PRAGMA_SIMD
+        for (_Size __j = 0; __j < __n - last_iteration; ++__j)
+        {
+            __lane[__j] = __binary_op(__lane[__j], __f(last_iteration + __j));
+        }
+        // combiner
+        for (_Size __i = 0; __i < __block_size; ++__i)
+        {
+            __init = __binary_op(__init, __lane[__i]);
+        }
+        // destroyer
+        __PSTL_PRAGMA_SIMD
+        for (_Size __i = 0; __i < __block_size; ++__i)
+        {
+            __lane[__i].~_Tp();
+        }
+    }
+    else
+    {
+        for (_Size __i = 0; __i < __n; ++__i)
+        {
+            __init = __binary_op(__init, __f(__i));
+        }
+    }
+    return __init;
+}
+
+// Exclusive scan for "+" and arithmetic types
+template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
+          class _BinaryOperation>
+typename std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, std::pair<_OutputIterator, _Tp>>::type
+simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
+          _BinaryOperation, /*Inclusive*/ std::false_type)
+{
+    __PSTL_PRAGMA_SIMD_SCAN(+ : __init)
+    for (_Size __i = 0; __i < __n; ++__i)
+    {
+        __result[__i] = __init;
+        __PSTL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__init)
+        __init += __unary_op(__first[__i]);
+    }
+    return std::make_pair(__result + __n, __init);
+}
+
+// As soon as we cannot call __binary_op in "combiner" we create a wrapper over _Tp to encapsulate __binary_op
+template <typename _Tp, typename _BinaryOp>
+struct _Combiner
+{
+    _Tp __value;
+    _BinaryOp* __bin_op; // Here is a pointer to function because of default ctor
+
+    _Combiner() : __value{}, __bin_op(nullptr) {}
+    _Combiner(const _Tp& value, const _BinaryOp* bin_op) : __value(value), __bin_op(const_cast<_BinaryOp*>(bin_op)) {}
+    _Combiner(const _Combiner& __obj) : __value{}, __bin_op(__obj.__bin_op) {}
+
+    void
+    operator()(const _Combiner& __obj)
+    {
+        __value = (*__bin_op)(__value, __obj.__value);
+    }
+};
+
+// Exclusive scan for other binary operations and types
+template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
+          class _BinaryOperation>
+typename std::enable_if<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, std::pair<_OutputIterator, _Tp>>::type
+simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
+          _BinaryOperation __binary_op, /*Inclusive*/ std::false_type)
+{
+    typedef _Combiner<_Tp, _BinaryOperation> _CombinerType;
+    _CombinerType __init_{__init, &__binary_op};
+
+    __PSTL_PRAGMA_DECLARE_REDUCTION(__bin_op, _CombinerType)
+
+    __PSTL_PRAGMA_SIMD_SCAN(__bin_op : __init_)
+    for (_Size __i = 0; __i < __n; ++__i)
+    {
+        __result[__i] = __init_.__value;
+        __PSTL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__init_)
+        __PSTL_PRAGMA_FORCEINLINE
+        __init_.__value = __binary_op(__init_.__value, __unary_op(__first[__i]));
+    }
+    return std::make_pair(__result + __n, __init_.__value);
+}
+
+// Inclusive scan for "+" and arithmetic types
+template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
+          class _BinaryOperation>
+typename std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, std::pair<_OutputIterator, _Tp>>::type
+simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
+          _BinaryOperation, /*Inclusive*/ std::true_type)
+{
+    __PSTL_PRAGMA_SIMD_SCAN(+ : __init)
+    for (_Size __i = 0; __i < __n; ++__i)
+    {
+        __init += __unary_op(__first[__i]);
+        __PSTL_PRAGMA_SIMD_INCLUSIVE_SCAN(__init)
+        __result[__i] = __init;
+    }
+    return std::make_pair(__result + __n, __init);
+}
+
+// Inclusive scan for other binary operations and types
+template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
+          class _BinaryOperation>
+typename std::enable_if<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, std::pair<_OutputIterator, _Tp>>::type
+simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
+          _BinaryOperation __binary_op, std::true_type)
+{
+    typedef _Combiner<_Tp, _BinaryOperation> _CombinerType;
+    _CombinerType __init_{__init, &__binary_op};
+
+    __PSTL_PRAGMA_DECLARE_REDUCTION(__bin_op, _CombinerType)
+
+    __PSTL_PRAGMA_SIMD_SCAN(__bin_op : __init_)
+    for (_Size __i = 0; __i < __n; ++__i)
+    {
+        __PSTL_PRAGMA_FORCEINLINE
+        __init_.__value = __binary_op(__init_.__value, __unary_op(__first[__i]));
+        __PSTL_PRAGMA_SIMD_INCLUSIVE_SCAN(__init_)
+        __result[__i] = __init_.__value;
+    }
+    return std::make_pair(__result + __n, __init_.__value);
+}
+
+// [restriction] - std::iterator_traits<_ForwardIterator>::value_type should be DefaultConstructible.
+// complexity [violation] - We will have at most (__n-1 + number_of_lanes) comparisons instead of at most __n-1.
+template <typename _ForwardIterator, typename _Size, typename _Compare>
+_ForwardIterator
+simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcept
+{
+    if (__n == 0)
+    {
+        return __first;
+    }
+
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    struct _ComplexType
+    {
+        _ValueType __min_val;
+        _Size __min_ind;
+        _Compare* __min_comp;
+
+        _ComplexType() : __min_val{}, __min_ind{}, __min_comp(nullptr) {}
+        _ComplexType(const _ValueType& val, const _Compare* comp)
+            : __min_val(val), __min_ind(0), __min_comp(const_cast<_Compare*>(comp))
+        {
+        }
+        _ComplexType(const _ComplexType& __obj)
+            : __min_val(__obj.__min_val), __min_ind(__obj.__min_ind), __min_comp(__obj.__min_comp)
+        {
+        }
+
+        __PSTL_PRAGMA_DECLARE_SIMD
+        void
+        operator()(const _ComplexType& __obj)
+        {
+            if (!(*__min_comp)(__min_val, __obj.__min_val) &&
+                ((*__min_comp)(__obj.__min_val, __min_val) || __obj.__min_ind - __min_ind < 0))
+            {
+                __min_val = __obj.__min_val;
+                __min_ind = __obj.__min_ind;
+            }
+        }
+    };
+
+    _ComplexType __init{*__first, &__comp};
+
+    __PSTL_PRAGMA_DECLARE_REDUCTION(__min_func, _ComplexType)
+
+    __PSTL_PRAGMA_SIMD_REDUCTION(__min_func : __init)
+    for (_Size __i = 1; __i < __n; ++__i)
+    {
+        const _ValueType __min_val = __init.__min_val;
+        const _ValueType __current = __first[__i];
+        if (__comp(__current, __min_val))
+        {
+            __init.__min_val = __current;
+            __init.__min_ind = __i;
+        }
+    }
+    return __first + __init.__min_ind;
+}
+
+// [restriction] - std::iterator_traits<_ForwardIterator>::value_type should be DefaultConstructible.
+// complexity [violation] - We will have at most (2*(__n-1) + 4*number_of_lanes) comparisons instead of at most [1.5*(__n-1)].
+template <typename _ForwardIterator, typename _Size, typename _Compare>
+std::pair<_ForwardIterator, _ForwardIterator>
+simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcept
+{
+    if (__n == 0)
+    {
+        return std::make_pair(__first, __first);
+    }
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+
+    struct _ComplexType
+    {
+        _ValueType __min_val;
+        _ValueType __max_val;
+        _Size __min_ind;
+        _Size __max_ind;
+        _Compare* __minmax_comp;
+
+        _ComplexType() : __min_val{}, __max_val{}, __min_ind{}, __max_ind{}, __minmax_comp(nullptr) {}
+        _ComplexType(const _ValueType& min_val, const _ValueType& max_val, const _Compare* comp)
+            : __min_val(min_val), __max_val(max_val), __min_ind(0), __max_ind(0),
+              __minmax_comp(const_cast<_Compare*>(comp))
+        {
+        }
+        _ComplexType(const _ComplexType& __obj)
+            : __min_val(__obj.__min_val), __max_val(__obj.__max_val), __min_ind(__obj.__min_ind),
+              __max_ind(__obj.__max_ind), __minmax_comp(__obj.__minmax_comp)
+        {
+        }
+
+        void
+        operator()(const _ComplexType& __obj)
+        {
+            // min
+            if ((*__minmax_comp)(__obj.__min_val, __min_val))
+            {
+                __min_val = __obj.__min_val;
+                __min_ind = __obj.__min_ind;
+            }
+            else if (!(*__minmax_comp)(__min_val, __obj.__min_val))
+            {
+                __min_val = __obj.__min_val;
+                __min_ind = (__min_ind - __obj.__min_ind < 0) ? __min_ind : __obj.__min_ind;
+            }
+
+            // max
+            if ((*__minmax_comp)(__max_val, __obj.__max_val))
+            {
+                __max_val = __obj.__max_val;
+                __max_ind = __obj.__max_ind;
+            }
+            else if (!(*__minmax_comp)(__obj.__max_val, __max_val))
+            {
+                __max_val = __obj.__max_val;
+                __max_ind = (__max_ind - __obj.__max_ind < 0) ? __obj.__max_ind : __max_ind;
+            }
+        }
+    };
+
+    _ComplexType __init{*__first, *__first, &__comp};
+
+    __PSTL_PRAGMA_DECLARE_REDUCTION(__min_func, _ComplexType);
+
+    __PSTL_PRAGMA_SIMD_REDUCTION(__min_func : __init)
+    for (_Size __i = 1; __i < __n; ++__i)
+    {
+        auto __min_val = __init.__min_val;
+        auto __max_val = __init.__max_val;
+        auto __current = __first + __i;
+        if (__comp(*__current, __min_val))
+        {
+            __init.__min_val = *__current;
+            __init.__min_ind = __i;
+        }
+        else if (!__comp(*__current, __max_val))
+        {
+            __init.__max_val = *__current;
+            __init.__max_ind = __i;
+        }
+    }
+    return std::make_pair(__first + __init.__min_ind, __first + __init.__max_ind);
+}
+
+template <class _InputIterator, class _DifferenceType, class _OutputIterator1, class _OutputIterator2,
+          class _UnaryPredicate>
+std::pair<_OutputIterator1, _OutputIterator2>
+simd_partition_copy(_InputIterator __first, _DifferenceType __n, _OutputIterator1 __out_true,
+                    _OutputIterator2 __out_false, _UnaryPredicate __pred) noexcept
+{
+    _DifferenceType __cnt_true = 0, __cnt_false = 0;
+
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 0; __i < __n; ++__i)
+    {
+        __PSTL_PRAGMA_SIMD_ORDERED_MONOTONIC_2ARGS(__cnt_true : 1, __cnt_false : 1)
+        if (__pred(__first[__i]))
+        {
+            __out_true[__cnt_true] = __first[__i];
+            ++__cnt_true;
+        }
+        else
+        {
+            __out_false[__cnt_false] = __first[__i];
+            ++__cnt_false;
+        }
+    }
+    return std::make_pair(__out_true + __cnt_true, __out_false + __cnt_false);
+}
+
+template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1
+simd_find_first_of(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
+                   _ForwardIterator2 __s_last, _BinaryPredicate __pred) noexcept
+{
+    typedef typename std::iterator_traits<_ForwardIterator1>::difference_type _DifferencType;
+
+    const _DifferencType __n1 = __last - __first;
+    const _DifferencType __n2 = __s_last - __s_first;
+    if (__n1 == 0 || __n2 == 0)
+    {
+        return __last; // according to the standard
+    }
+
+    // Common case
+    // If first sequence larger than second then we'll run simd_first with parameters of first sequence.
+    // Otherwise, vice versa.
+    if (__n1 < __n2)
+    {
+        for (; __first != __last; ++__first)
+        {
+            if (simd_or(__s_first, __n2,
+                        internal::equal_value_by_pred<decltype(*__first), _BinaryPredicate>(*__first, __pred)))
+            {
+                return __first;
+            }
+        }
+    }
+    else
+    {
+        for (; __s_first != __s_last; ++__s_first)
+        {
+            const auto __result = unseq_backend::simd_first(
+                __first, _DifferencType(0), __n1, [__s_first, &__pred](_ForwardIterator1 __it, _DifferencType __i) {
+                    return __pred(__it[__i], *__s_first);
+                });
+            if (__result != __last)
+            {
+                return __result;
+            }
+        }
+    }
+    return __last;
+}
+
+template <class _RandomAccessIterator, class _DifferenceType, class _UnaryPredicate>
+_RandomAccessIterator
+simd_remove_if(_RandomAccessIterator __first, _DifferenceType __n, _UnaryPredicate __pred) noexcept
+{
+    // find first element we need to remove
+    auto __current = unseq_backend::simd_first(
+        __first, _DifferenceType(0), __n,
+        [&__pred](_RandomAccessIterator __it, _DifferenceType __i) { return __pred(__it[__i]); });
+    __n -= __current - __first;
+
+    // if we have in sequence only one element that pred(__current[1]) != false we can exit the function
+    if (__n < 2)
+    {
+        return __current;
+    }
+
+    _DifferenceType __cnt = 0;
+    __PSTL_PRAGMA_SIMD
+    for (_DifferenceType __i = 1; __i < __n; ++__i)
+    {
+        __PSTL_PRAGMA_SIMD_ORDERED_MONOTONIC(__cnt : 1)
+        if (!__pred(__current[__i]))
+        {
+            __current[__cnt] = std::move(__current[__i]);
+            ++__cnt;
+        }
+    }
+    return __current + __cnt;
+}
+} // namespace unseq_backend
+} // namespace __pstl
+
+#endif /* __PSTL_unseq_backend_simd_H */

--- a/cpp/pstl/include/pstl/internal/utils.h
+++ b/cpp/pstl/include/pstl/internal/utils.h
@@ -1,0 +1,228 @@
+// -*- C++ -*-
+//===-- utils.h -----------------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_utils_H
+#define __PSTL_utils_H
+
+#include <new>
+#include <iterator>
+
+namespace __pstl
+{
+namespace internal
+{
+
+template <typename _Fp>
+typename std::result_of<_Fp()>::type
+except_handler(_Fp __f)
+{
+    try
+    {
+        return __f();
+    }
+    catch (const std::bad_alloc&)
+    {
+        throw; // re-throw bad_alloc according to the standard [algorithms.parallel.exceptions]
+    }
+    catch (...)
+    {
+        std::terminate(); // Good bye according to the standard [algorithms.parallel.exceptions]
+    }
+}
+
+template <typename _Fp>
+void
+invoke_if(std::true_type, _Fp __f)
+{
+    __f();
+}
+
+template <typename _Fp>
+void
+invoke_if(std::false_type, _Fp __f)
+{
+}
+
+template <typename _Fp>
+void
+invoke_if_not(std::false_type, _Fp __f)
+{
+    __f();
+}
+
+template <typename _Fp>
+void
+invoke_if_not(std::true_type, _Fp __f)
+{
+}
+
+template <typename _F1, typename _F2>
+typename std::result_of<_F1()>::type
+invoke_if_else(std::true_type, _F1 __f1, _F2 __f2)
+{
+    return __f1();
+}
+
+template <typename _F1, typename _F2>
+typename std::result_of<_F2()>::type
+invoke_if_else(std::false_type, _F1 __f1, _F2 __f2)
+{
+    return __f2();
+}
+
+//! Unary operator that returns reference to its argument.
+struct no_op
+{
+    template <typename _Tp>
+    _Tp&&
+    operator()(_Tp&& __a) const
+    {
+        return std::forward<_Tp>(__a);
+    }
+};
+
+//! Logical negation of a predicate
+template <typename _Pred>
+class not_pred
+{
+    _Pred _M_pred;
+
+  public:
+    explicit not_pred(_Pred __pred) : _M_pred(__pred) {}
+
+    template <typename... _Args>
+    bool
+    operator()(_Args&&... __args)
+    {
+        return !_M_pred(std::forward<_Args>(__args)...);
+    }
+};
+
+template <typename _Pred>
+class reorder_pred
+{
+    _Pred _M_pred;
+
+  public:
+    explicit reorder_pred(_Pred __pred) : _M_pred(__pred) {}
+
+    template <typename _FTp, typename _STp>
+    bool
+    operator()(_FTp&& __a, _STp&& __b)
+    {
+        return _M_pred(std::forward<_STp>(__b), std::forward<_FTp>(__a));
+    }
+};
+
+//! "==" comparison.
+/** Not called "equal" to avoid (possibly unfounded) concerns about accidental invocation via
+    argument-dependent name lookup by code expecting to find the usual std::equal. */
+class pstl_equal
+{
+  public:
+    explicit pstl_equal() {}
+
+    template <typename _Xp, typename _Yp>
+    bool
+    operator()(_Xp&& __x, _Yp&& __y) const
+    {
+        return std::forward<_Xp>(__x) == std::forward<_Yp>(__y);
+    }
+};
+
+//! "<" comparison.
+class pstl_less
+{
+  public:
+    explicit pstl_less() {}
+
+    template <typename _Xp, typename _Yp>
+    bool
+    operator()(_Xp&& __x, _Yp&& __y) const
+    {
+        return std::forward<_Xp>(__x) < std::forward<_Yp>(__y);
+    }
+};
+
+//! Like a polymorphic lambda for pred(...,value)
+template <typename _Tp, typename _Predicate>
+class equal_value_by_pred
+{
+    const _Tp& _M_value;
+    _Predicate _M_pred;
+
+  public:
+    equal_value_by_pred(const _Tp& __value, _Predicate __pred) : _M_value(__value), _M_pred(__pred) {}
+
+    template <typename _Arg>
+    bool
+    operator()(_Arg&& __arg)
+    {
+        return _M_pred(std::forward<_Arg>(__arg), _M_value);
+    }
+};
+
+//! Like a polymorphic lambda for ==value
+template <typename _Tp>
+class equal_value
+{
+    const _Tp& _M_value;
+
+  public:
+    explicit equal_value(const _Tp& __value) : _M_value(__value) {}
+
+    template <typename _Arg>
+    bool
+    operator()(_Arg&& __arg) const
+    {
+        return std::forward<_Arg>(__arg) == _M_value;
+    }
+};
+
+//! Logical negation of ==value
+template <typename _Tp>
+class not_equal_value
+{
+    const _Tp& _M_value;
+
+  public:
+    explicit not_equal_value(const _Tp& __value) : _M_value(__value) {}
+
+    template <typename _Arg>
+    bool
+    operator()(_Arg&& __arg) const
+    {
+        return !(std::forward<_Arg>(__arg) == _M_value);
+    }
+};
+
+template <typename _ForwardIterator, typename _Compare>
+_ForwardIterator
+cmp_iterators_by_values(_ForwardIterator __a, _ForwardIterator __b, _Compare __comp)
+{
+    if (__a < __b)
+    { // we should return closer iterator
+        return __comp(*__b, *__a) ? __b : __a;
+    }
+    else
+    {
+        return __comp(*__a, *__b) ? __a : __b;
+    }
+}
+
+} // namespace internal
+} // namespace __pstl
+
+#endif /* __PSTL_utils_H */

--- a/cpp/pstl/include/pstl/iterators.h
+++ b/cpp/pstl/include/pstl/iterators.h
@@ -1,0 +1,38 @@
+// -*- C++ -*-
+//===-- iterators.h -------------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_iterators_H
+#define __PSTL_iterators_H
+
+#include <tbb/tbb_stddef.h>
+
+#if TBB_VERSION_MAJOR < 2019
+#error Threading Building Blocks (TBB) 2019 is required for usage of special iterator types
+#else
+
+#include <tbb/iterators.h>
+
+namespace pstl
+{
+using tbb::counting_iterator;
+using tbb::make_transform_iterator;
+using tbb::make_zip_iterator;
+using tbb::transform_iterator;
+using tbb::zip_iterator;
+} //namespace __pstl
+
+#endif //TBB_VERSION_MAJOR < 2019
+
+#endif /* __PSTL_iterators_H */

--- a/cpp/pstl/include/pstl/memory
+++ b/cpp/pstl/include/pstl/memory
@@ -1,0 +1,30 @@
+// -*- C++ -*-
+//===-- memory ------------------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_memory
+#define __PSTL_memory
+
+#include "internal/pstl_config.h"
+
+#if __PSTL_EXECUTION_POLICIES_DEFINED
+// If <execution> has already been included, pull in implementations
+#include "internal/glue_memory_impl.h"
+#else
+// Otherwise just pull in forward declarations
+#include "internal/glue_memory_defs.h"
+#define __PSTL_MEMORY_FORWARD_DECLARED 1
+#endif
+
+#endif /* __PSTL_memory */

--- a/cpp/pstl/include/pstl/numeric
+++ b/cpp/pstl/include/pstl/numeric
@@ -1,0 +1,30 @@
+// -*- C++ -*-
+//===-- numeric -----------------------------------------------------------===//
+//
+// Copyright (C) 2017-2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __PSTL_numeric
+#define __PSTL_numeric
+
+#include "internal/pstl_config.h"
+
+#if __PSTL_EXECUTION_POLICIES_DEFINED
+// If <execution> has already been included, pull in implementations
+#include "internal/glue_numeric_impl.h"
+#else
+// Otherwise just pull in forward declarations
+#include "internal/glue_numeric_defs.h"
+#define __PSTL_NUMERIC_FORWARD_DECLARED 1
+#endif
+
+#endif /* __PSTL_numeric */

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -200,6 +200,7 @@ else()
 endif()
 
 set( PYBIND11_INCLUDES_DIR "${CMAKE_SOURCE_DIR}/pybind11" )
+set( PSTL_INCLUDES_DIR "${CMAKE_SOURCE_DIR}/pstl/include" )
 
 file( GLOB_RECURSE SERVER_SOURCES *.h *.cpp )
 
@@ -237,6 +238,7 @@ include_directories(
   SYSTEM
   ${Boost_INCLUDE_DIR}
   ${PYBIND11_INCLUDES_DIR}
+  ${PSTL_INCLUDES_DIR}
   ${PYTHON_INCLUDE_DIRS}
   ${CLANG_INCLUDES_DIR}
   )
@@ -330,8 +332,15 @@ if ( USE_CLANG_COMPLETER AND NOT LIBCLANG_TARGET )
                           "your configuration" )
 endif()
 
+if ( USE_SYSTEM_TBB )
+  set( TBB_LIBRARY "tbb" )
+else()
+  set( TBB_LIBRARY "tbb_static" )
+endif()
+
 target_link_libraries( ${PROJECT_NAME}
                        ${Boost_LIBRARIES}
+                       ${TBB_LIBRARY}
                        ${PYTHON_LIBRARIES}
                        ${LIBCLANG_TARGET}
                        ${EXTRA_LIBS}

--- a/cpp/ycm/Result.h
+++ b/cpp/ycm/Result.h
@@ -94,6 +94,7 @@ private:
 
 template< class T >
 struct ResultAnd {
+  ResultAnd() = default;
   ResultAnd( const Result &result, T extra_object )
     : extra_object_( extra_object ),
       result_( result ) {

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -18,6 +18,9 @@
 #ifndef UTILS_H_KEPMRPBH
 #define UTILS_H_KEPMRPBH
 
+#include <algorithm>
+#include <pstl/algorithm>
+#include <pstl/execution>
 #include <boost/filesystem.hpp>
 #include <cmath>
 #include <limits>
@@ -111,6 +114,12 @@ template <typename Element>
 void PartialSort( std::vector< Element > &elements,
                   const size_t num_sorted_elements ) {
 
+#if __PSTL_CPP17_EXECUTION_POLICIES_PRESENT
+  using __pstl::execution::par;
+#else
+  using std::execution::par;
+#endif
+
   size_t nb_elements = elements.size();
   size_t max_elements = num_sorted_elements > 0 &&
                         nb_elements >= num_sorted_elements ?
@@ -128,6 +137,12 @@ void PartialSort( std::vector< Element > &elements,
     std::partial_sort( elements.begin(),
                        elements.begin() + max_elements,
                        elements.end() );
+  } else if ( 256 <= std::min( nb_elements, max_elements ) ) {
+    std::nth_element( par,
+                      elements.begin(),
+                      elements.begin() + max_elements,
+                      elements.end() );
+    std::sort( par, elements.begin(), elements.begin() + max_elements );
   } else {
     std::nth_element( elements.begin(),
                       elements.begin() + max_elements,


### PR DESCRIPTION
C++17 introduced parallel `<algorithm>`, `<numeric>` and `<memory>`. Current state is that MSVC has their `<execution>` header, but GCC and Clang don't and plan to eventually use https://github.com/intel/parallelstl. That is the same repository that is included in this PR.

### Dependencies

- Intel TBB, found at https://github.com/01org/tbb
  - We are using my fork because we need CMake. 
  - The Cmake script has been taken from https://github.com/wjakob/tbb

### Benchmarks

https://gist.github.com/bstaletic/dfa74ef0f72667c8ed41610d28b04e38

The parallel version of sorting algorithms currently kick in once there's at least 2048 candidates to return to the user, because my benchmarks on my laptop with my OS had consistently shown that was the point where parallel sorting actually outweighs the overhead of spinning up threads\*.

\*The implementation is fully allowed to disregard the user's request for a parallel sort if the array is small, however, back when I was running these benchmarks there was a tiny overhead until 2048. It might be worth checking this behaviour again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1211)
<!-- Reviewable:end -->
