### PR TITLE
Update Racerd

### DIFF
--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -111,7 +111,6 @@ rustup update
 rustc -Vv
 cargo -V
 
-echo "export RUST_SRC_PATH=$(rustc --print sysroot)/lib/rustlib/src/rust/src" >> $BASH_ENV
 echo "export PATH=${CARGO_PATH}:\$PATH" >> $BASH_ENV
 
 #################

--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -111,6 +111,7 @@ rustup update
 rustc -Vv
 cargo -V
 
+echo "export RUST_SRC_PATH=$(rustc --print sysroot)/lib/rustlib/src/rust/src" >> $BASH_ENV
 echo "export PATH=${CARGO_PATH}:\$PATH" >> $BASH_ENV
 
 #################

--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -106,6 +106,7 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 CARGO_PATH="${HOME}/.cargo/bin"
 PATH="${CARGO_PATH}:${PATH}"
+rustup toolchain add nightly
 rustup update
 rustc -Vv
 cargo -V

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Next, install the language specific dependencies you need:
 - `sudo apt install golang-go` for Go.
 - `sudo apt install npm` for JavaScript and TypeScript.
 - `sudo apt install mono-devel` for C#.
-- install Cargo and rustc with [rustup][] for Rust.
+- install Cargo, rustc and nightly rust with [rustup][] for Rust.
 - `sudo apt install openjdk-8-jre` for Java.
 
 When you first clone the repository you'll need to update the submodules:

--- a/build.py
+++ b/build.py
@@ -686,7 +686,7 @@ def EnableRustCompleter( args ):
                                'cargo is required for the Rust completer.' )
 
   os.chdir( p.join( DIR_OF_THIRD_PARTY, 'racerd' ) )
-  command_line = [ cargo, 'build' ]
+  command_line = [ cargo, '+nightly' , 'build' ]
   # We don't use the --release flag on CI services because it makes building
   # racerd 2.5x slower and we don't care about the speed of the produced racerd.
   if not OnCiService():

--- a/ci/appveyor/appveyor_install.bat
+++ b/ci/appveyor/appveyor_install.bat
@@ -47,6 +47,7 @@ appveyor DownloadFile https://static.rust-lang.org/rustup/dist/i686-pc-windows-g
 rustup-init.exe -y
 
 set PATH=%USERPROFILE%\.cargo\bin;%PATH%
+rustup toolchain add nightly
 rustup update
 rustc -Vv
 cargo -V

--- a/ci/appveyor/appveyor_install.bat
+++ b/ci/appveyor/appveyor_install.bat
@@ -47,6 +47,7 @@ appveyor DownloadFile https://static.rust-lang.org/rustup/dist/i686-pc-windows-g
 rustup-init.exe -y
 
 set PATH=%USERPROFILE%\.cargo\bin;%PATH%
+rustup component add rust-src
 rustup toolchain add nightly
 rustup update
 rustc -Vv

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -90,10 +90,12 @@ echo -e "import coverage\ncoverage.process_startup()" > \
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 export PATH="${HOME}/.cargo/bin:${PATH}"
+rustup component add rust-src
 rustup toolchain add nightly
 rustup update
 rustc -Vv
 cargo -V
+export RUST_SRC_PATH=$(rustc --print sysroot)/lib/rustlib/src/rust/src
 
 #################################
 # JavaScript and TypeScript setup

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -95,7 +95,6 @@ rustup toolchain add nightly
 rustup update
 rustc -Vv
 cargo -V
-export RUST_SRC_PATH=$(rustc --print sysroot)/lib/rustlib/src/rust/src
 
 #################################
 # JavaScript and TypeScript setup

--- a/ci/travis/travis_install.sh
+++ b/ci/travis/travis_install.sh
@@ -90,6 +90,7 @@ echo -e "import coverage\ncoverage.process_startup()" > \
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 export PATH="${HOME}/.cargo/bin:${PATH}"
+rustup toolchain add nightly
 rustup update
 rustc -Vv
 cargo -V


### PR DESCRIPTION
Hi there!
I know that [ycmd is migrating rust completer to RLS](https://github.com/Valloric/ycmd/issues/1105), but the Racerd version that ycmd currently uses is too old (last update 2 years ago) and doesn't work well under recent Rust versions  (most times no completion pops up after pressing ' . ', not recognizing some Rust 2018 features, etc.). So it's necessary to switch to the most recent Racerd version before we finally migrate to RLS.
  
Since starting from version 2.1, racer needs **nightly rust**, I also added "nightly" in build scripts, test scripts and the documentation.
  
But as was mentioned in the issue above, **Racerd isn't under effective maintenance and its most recent version is still a little bit out of date**. [This pull request there](https://github.com/jwilm/racerd/pull/77) tries to keep it up-to-date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1212)
<!-- Reviewable:end -->
