### PR TITLE
[READY] Improve Clangd completer logging

### DIFF
--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -340,10 +340,9 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
 
 
   def _CleanUp( self ):
-    if not self._server_keep_logfiles:
-      if self._server_stderr:
-        utils.RemoveIfExists( self._server_stderr )
-        self._server_stderr = None
+    if not self._server_keep_logfiles and self._server_stderr:
+      utils.RemoveIfExists( self._server_stderr )
+      self._server_stderr = None
 
     if self._workspace_path and self._use_clean_workspace:
       try:


### PR DESCRIPTION
This avoids having to add `'-verbose=log'` to the `clangd_args` option in addition to set the `log_level` option to `'debug'` to get maximum log verbosity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1213)
<!-- Reviewable:end -->
