### PR TITLE
[READY] Fix off-by-one error in LSP Initialize request

### DIFF
--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -249,7 +249,7 @@ def Initialize( request_id, project_directory, settings ):
         'completion': {
           'completionItemKind': {
             # ITEM_KIND list is 1-based.
-            'valueSet': list( range( 1, len( ITEM_KIND ) + 1 ) ),
+            'valueSet': list( range( 1, len( ITEM_KIND ) ) ),
           }
         }
       }


### PR DESCRIPTION
- LSP `completionItemKind` has values 1 through 25
- Our `ITEM_KIND` is a python list that has `None` as element 0.
- `len( ITEM_KIND ) + 1 == 27`
- `list( range( 1, len( ITEM_KIND ) + 1 ) ) == [ 1 ... 26 ]`
- We shouldn't add 1, because `ITEM_KIND[0] is None`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1214)
<!-- Reviewable:end -->
