### PR TITLE
[READY] Support LSP declaration, typeDefinition, and implementation

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -282,8 +282,15 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
       'GetTypeImprecise': (
         lambda self, request_data, args: self.GetType( request_data )
       ),
+      # NOTE: these two commands are only kept for backward compatibility with
+      # the libclang completer.
+      'GoToImprecise': (
+        lambda self, request_data, args: self.GoTo( request_data,
+                                                    [ 'Definition' ] )
+      ),
       'GoToInclude': (
-        lambda self, request_data, args: self.GoToDeclaration( request_data )
+        lambda self, request_data, args: self.GoTo( request_data,
+                                                    [ 'Definition' ] )
       ),
       'RestartServer': (
         lambda self, request_data, args: self._RestartServer( request_data )

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -206,42 +206,11 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
     return [ 'java' ]
 
 
-  def GetSubcommandsMap( self ):
+  def GetCustomSubcommands( self ):
     return {
-      # Handled by base class
-      'GoToDeclaration': (
-        lambda self, request_data, args: self.GoToDeclaration( request_data )
-      ),
-      'GoTo': (
-        lambda self, request_data, args: self.GoToDeclaration( request_data )
-      ),
-      'GoToDefinition': (
-        lambda self, request_data, args: self.GoToDeclaration( request_data )
-      ),
-      'GoToReferences': (
-        lambda self, request_data, args: self.GoToReferences( request_data )
-      ),
       'FixIt': (
         lambda self, request_data, args: self.GetCodeActions( request_data,
                                                               args )
-      ),
-      'RefactorRename': (
-        lambda self, request_data, args: self.RefactorRename( request_data,
-                                                              args )
-      ),
-      'Format': (
-        lambda self, request_data, args: self.Format( request_data )
-      ),
-
-      # Handled by us
-      'RestartServer': (
-        lambda self, request_data, args: self._RestartServer( request_data )
-      ),
-      'StopServer': (
-        lambda self, request_data, args: self.Shutdown()
-      ),
-      'OpenProject': (
-        lambda self, request_data, args: self._OpenProject( request_data, args )
       ),
       'GetDoc': (
         lambda self, request_data, args: self.GetDoc( request_data )
@@ -251,6 +220,12 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       ),
       'OrganizeImports': (
         lambda self, request_data, args: self.OrganizeImports( request_data )
+      ),
+      'OpenProject': (
+        lambda self, request_data, args: self._OpenProject( request_data, args )
+      ),
+      'RestartServer': (
+        lambda self, request_data, args: self._RestartServer( request_data )
       ),
     }
 

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -48,53 +48,55 @@ CONNECTION_TIMEOUT         = 5
 # Size of the notification ring buffer
 MAX_QUEUED_MESSAGES = 250
 
+PROVIDERS_MAP = {
+  'definitionProvider': (
+    lambda self, request_data, args: self.GoTo( request_data, [ 'Definition' ] )
+  ),
+  'declarationProvider': (
+    lambda self, request_data, args: self.GoTo( request_data,
+                                                [ 'Declaration' ] )
+  ),
+  ( 'definitionProvider', 'declarationProvider' ): (
+    lambda self, request_data, args: self.GoTo( request_data,
+                                                [ 'Definition',
+                                                  'Declaration' ] )
+  ),
+  'typeDefinitionProvider': (
+    lambda self, request_data, args: self.GoTo( request_data,
+                                                [ 'TypeDefinition' ] )
+  ),
+  'implementationProvider': (
+    lambda self, request_data, args: self.GoTo( request_data,
+                                                [ 'Implementation' ] )
+  ),
+  'referencesProvider': (
+    lambda self, request_data, args: self.GoTo( request_data,
+                                                [ 'References' ] )
+  ),
+  'renameProvider': (
+    lambda self, request_data, args: self.RefactorRename( request_data, args )
+  ),
+  'documentFormattingProvider': (
+    lambda self, request_data, args: self.Format( request_data )
+  )
+}
+
+# Each command is mapped to a list of providers. This allows a command to use
+# another provider if the LSP server doesn't support the main one. For instance,
+# GoToDeclaration is mapped to the same provider as GoToDefinition if there is
+# no declaration provider. A tuple of providers is also allowed for commands
+# like GoTo where it's convenient to jump to the declaration if already on the
+# definition and vice versa.
 DEFAULT_SUBCOMMANDS_MAP = {
-  'GoToDefinition': {
-    'checker': lambda caps: caps.get( 'definitionProvider', False ),
-    'handler': (
-      lambda self, request_data, args: self.GoToDeclaration( request_data )
-    ),
-  },
-  'GoToDeclaration': {
-    'checker': lambda caps: caps.get( 'definitionProvider', False ),
-    'handler': (
-      lambda self, request_data, args: self.GoToDeclaration( request_data )
-    ),
-  },
-  'GoTo': {
-    'checker': lambda caps: caps.get( 'definitionProvider', False ),
-    'handler': (
-      lambda self, request_data, args: self.GoToDeclaration( request_data )
-    ),
-  },
-  'GoToImprecise': {
-    'checker': lambda caps: caps.get( 'definitionProvider', False ),
-    'handler': (
-      lambda self, request_data, args: self.GoToDeclaration( request_data )
-    ),
-  },
-  'GoToReferences': {
-    'checker': lambda caps: caps.get( 'referencesProvider', False ),
-    'handler': (
-      lambda self, request_data, args: self.GoToReferences( request_data )
-    ),
-  },
-  'RefactorRename': {
-    # This can be boolean | RenameOptions. But either way a simple if
-    # works (i.e. if RenameOptions is supplied and nonempty, then boom we have
-    # truthiness).
-    'checker': lambda caps: caps.get( 'renameProvider', False ),
-    'handler': (
-      lambda self, request_data, args: self.RefactorRename( request_data,
-                                                            args )
-    ),
-  },
-  'Format': {
-    'checker': lambda caps: caps.get( 'documentFormattingProvider', False ),
-    'handler': (
-      lambda self, request_data, args: self.Format( request_data )
-    ),
-  }
+  'GoToDefinition':     [ 'definitionProvider' ],
+  'GoToDeclaration':    [ 'declarationProvider', 'definitionProvider' ],
+  'GoTo':               [ ( 'definitionProvider', 'declarationProvider' ),
+                          'definitionProvider' ],
+  'GoToType':           [ 'typeDefinitionProvider' ],
+  'GoToImplementation': [ 'implementationProvider' ],
+  'GoToReferences':     [ 'referencesProvider' ],
+  'RefactorRename':     [ 'renameProvider' ],
+  'Format':             [ 'documentFormattingProvider' ]
 }
 
 
@@ -1043,22 +1045,34 @@ class LanguageServerCompleter( Completer ):
     return self._DiscoverSubcommandSupport( commands )
 
 
-  def _DiscoverSubcommandSupport( self, commands ):
+  def _GetSubcommandProvider( self, provider_list ):
     if not self._server_capabilities:
       LOGGER.warning( "Can't determine subcommands: not initialized yet" )
       capabilities = {}
     else:
       capabilities = self._server_capabilities
 
+    for providers in provider_list:
+      if isinstance( providers, tuple ):
+        if all( capabilities.get( provider ) for provider in providers ):
+          return providers
+      if capabilities.get( providers ):
+        return providers
+    return None
+
+
+  def _DiscoverSubcommandSupport( self, commands ):
     subcommands_map = {}
     for command, handler in iteritems( commands ):
-      if isinstance( handler, dict ):
-        if handler[ 'checker' ]( capabilities ):
-          LOGGER.info( 'Found support for command %s in %s',
+      if isinstance( handler, list ):
+        provider = self._GetSubcommandProvider( handler )
+        if provider:
+          LOGGER.info( 'Found %s support for command %s in %s',
+                        provider,
                         command,
                         self.Language() )
 
-          subcommands_map[ command ] = handler[ 'handler' ]
+          subcommands_map[ command ] = PROVIDERS_MAP[ provider ]
         else:
           LOGGER.info( 'No support for %s command in server for %s',
                         command,
@@ -1610,48 +1624,39 @@ class LanguageServerCompleter( Completer ):
     raise RuntimeError( NO_HOVER_INFORMATION )
 
 
-  def GoToDeclaration( self, request_data ):
-    """Issues the definition request and returns the result as a GoTo
-    response."""
-    if not self.ServerIsReady():
-      raise RuntimeError( 'Server is initializing. Please wait.' )
-
-    self._UpdateServerWithFileContents( request_data )
-
+  def _GoToRequest( self, request_data, handler ):
     request_id = self.GetConnection().NextRequestId()
-    response = self.GetConnection().GetResponse(
+    result = self.GetConnection().GetResponse(
       request_id,
-      lsp.Definition( request_id, request_data ),
-      REQUEST_TIMEOUT_COMMAND )
-
-    if isinstance( response[ 'result' ], list ):
-      return _LocationListToGoTo( request_data, response )
-    elif response[ 'result' ]:
-      position = response[ 'result' ]
-      try:
-        return responses.BuildGoToResponseFromLocation(
-          *_PositionToLocationAndDescription( request_data, position ) )
-      except KeyError:
-        raise RuntimeError( 'Cannot jump to location' )
-    else:
+      getattr( lsp, handler )( request_id, request_data ),
+      REQUEST_TIMEOUT_COMMAND )[ 'result' ]
+    if not result:
       raise RuntimeError( 'Cannot jump to location' )
+    if not isinstance( result, list ):
+      return [ result ]
+    return result
 
 
-  def GoToReferences( self, request_data ):
-    """Issues the references request and returns the result as a GoTo
-    response."""
+  def GoTo( self, request_data, handlers ):
+    """Issues a GoTo request for each handler in |handlers| until it returns
+    multiple locations or a location the cursor does not belong since the user
+    wants to jump somewhere else. If that's the last handler, the location is
+    returned anyway."""
     if not self.ServerIsReady():
       raise RuntimeError( 'Server is initializing. Please wait.' )
 
     self._UpdateServerWithFileContents( request_data )
 
-    request_id = self.GetConnection().NextRequestId()
-    response = self.GetConnection().GetResponse(
-      request_id,
-      lsp.References( request_id, request_data ),
-      REQUEST_TIMEOUT_COMMAND )
+    if len( handlers ) == 1:
+      result = self._GoToRequest( request_data, handlers[ 0 ] )
+    else:
+      for handler in handlers:
+        result = self._GoToRequest( request_data, handler )
+        if len( result ) > 1 or not _CursorInsideLocation( request_data,
+                                                           result[ 0 ] ):
+          break
 
-    return _LocationListToGoTo( request_data, response )
+    return _LocationListToGoTo( request_data, result )
 
 
   def GetCodeActions( self, request_data, args ):
@@ -2043,24 +2048,17 @@ def _GetCompletionItemStartCodepointOrReject( text_edit, request_data ):
   return start_codepoint
 
 
-def _LocationListToGoTo( request_data, response ):
+def _LocationListToGoTo( request_data, positions ):
   """Convert a LSP list of locations to a ycmd GoTo response."""
-  if not response:
-    raise RuntimeError( 'Cannot jump to location' )
-
   try:
-    if len( response[ 'result' ] ) > 1:
-      positions = response[ 'result' ]
+    if len( positions ) > 1:
       return [
         responses.BuildGoToResponseFromLocation(
-          *_PositionToLocationAndDescription( request_data,
-                                              position ) )
+          *_PositionToLocationAndDescription( request_data, position ) )
         for position in positions
       ]
-    else:
-      position = response[ 'result' ][ 0 ]
-      return responses.BuildGoToResponseFromLocation(
-        *_PositionToLocationAndDescription( request_data, position ) )
+    return responses.BuildGoToResponseFromLocation(
+      *_PositionToLocationAndDescription( request_data, positions[ 0 ] ) )
   except ( IndexError, KeyError ):
     raise RuntimeError( 'Cannot jump to location' )
 
@@ -2087,28 +2085,63 @@ def _PositionToLocationAndDescription( request_data, position ):
                                        position[ 'range' ][ 'start' ] )
 
 
-def _BuildLocationAndDescription( filename, file_contents, loc ):
+def _LspToYcmdLocation( file_contents, location ):
+  """Converts a LSP location to a ycmd one. Returns a tuple of (
+     - the contents of the line of |location|
+     - the line number of |location|
+     - the byte offset converted from the UTF-16 offset of |location|
+  )"""
+  line_num = location[ 'line' ] + 1
+  try:
+    line_value = file_contents[ location[ 'line' ] ]
+    return line_value, line_num, utils.CodepointOffsetToByteOffset(
+      line_value,
+      lsp.UTF16CodeUnitsToCodepoints( line_value,
+                                      location[ 'character' ] + 1 ) )
+  except IndexError:
+    # This can happen when there are stale diagnostics in OnFileReadyToParse,
+    # just return the value as-is.
+    return '', line_num, location[ 'character' ] + 1
+
+
+def _CursorInsideLocation( request_data, location ):
+  try:
+    filepath = lsp.UriToFilePath( location[ 'uri' ] )
+  except lsp.InvalidUriException:
+    LOGGER.debug( 'Invalid URI, assume cursor is not inside the location' )
+    return False
+
+  if request_data[ 'filepath' ] != filepath:
+    return False
+
+  line = request_data[ 'line_num' ]
+  column = request_data[ 'column_num' ]
+  file_contents = GetFileLines( request_data, filepath )
+  lsp_range = location[ 'range' ]
+
+  _, start_line, start_column = _LspToYcmdLocation( file_contents,
+                                                    lsp_range[ 'start' ] )
+  if ( line < start_line or
+       ( line == start_line and column < start_column ) ):
+    return False
+
+  _, end_line, end_column = _LspToYcmdLocation( file_contents,
+                                                lsp_range[ 'end' ] )
+  if ( line > end_line or
+       ( line == end_line and column > end_column ) ):
+    return False
+
+  return True
+
+
+def _BuildLocationAndDescription( filename, file_contents, location ):
   """Returns a tuple of (
     - ycmd Location for the supplied filename and LSP location
     - contents of the line at that location
   )
   Importantly, converts from LSP Unicode offset to ycmd byte offset."""
-
-  try:
-    line_value = file_contents[ loc[ 'line' ] ]
-    column = utils.CodepointOffsetToByteOffset(
-      line_value,
-      lsp.UTF16CodeUnitsToCodepoints( line_value, loc[ 'character' ] + 1 ) )
-  except IndexError:
-    # This can happen when there are stale diagnostics in OnFileReadyToParse,
-    # just return the value as-is.
-    line_value = ""
-    column = loc[ 'character' ] + 1
-
-  return ( responses.Location( loc[ 'line' ] + 1,
-                               column,
-                               filename = filename ),
-           line_value )
+  line_value, line, column = _LspToYcmdLocation( file_contents, location )
+  return responses.Location( line, column, filename = filename ), line_value
 
 
 def _BuildRange( contents, filename, r ):

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -347,6 +347,25 @@ def Definition( request_id, request_data ):
                        BuildTextDocumentPositionParams( request_data ) )
 
 
+def Declaration( request_id, request_data ):
+  return BuildRequest( request_id,
+                       'textDocument/declaration',
+                       BuildTextDocumentPositionParams( request_data ) )
+
+
+def TypeDefinition( request_id, request_data ):
+  return BuildRequest( request_id,
+                       'textDocument/typeDefinition',
+                       BuildTextDocumentPositionParams( request_data ) )
+
+
+
+def Implementation( request_id, request_data ):
+  return BuildRequest( request_id,
+                       'textDocument/implementation',
+                       BuildTextDocumentPositionParams( request_data ) )
+
+
 def CodeAction( request_id, request_data, best_match_range, diagnostics ):
   return BuildRequest( request_id, 'textDocument/codeAction', {
     'textDocument': {

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -73,7 +73,9 @@ def Subcommands_DefinedSubcommands_test( app ):
                  'GoTo',
                  'GetDoc',
                  'GetType',
+                 'GoToImplementation',
                  'GoToReferences',
+                 'GoToType',
                  'OpenProject',
                  'OrganizeImports',
                  'RefactorRename',
@@ -1447,11 +1449,11 @@ def Subcommands_GoTo_test():
     # Member function local variable
     { 'request': { 'line': 28, 'col': 5, 'filepath': filepath },
       'response': { 'line_num': 27, 'column_num': 18, 'filepath': filepath },
-      'description': 'GoTo works for memeber local variable' },
+      'description': 'GoTo works for member local variable' },
     # Member variable
     { 'request': { 'line': 22, 'col': 7, 'filepath': filepath },
       'response': { 'line_num': 8, 'column_num': 16, 'filepath': filepath },
-      'description': 'GoTo works for memeber variable' },
+      'description': 'GoTo works for member variable' },
     # Method
     { 'request': { 'line': 28, 'col': 7, 'filepath': filepath },
       'response': { 'line_num': 21, 'column_num': 16, 'filepath': filepath },
@@ -1496,6 +1498,70 @@ def Subcommands_GoTo_test():
               test[ 'request' ][ 'col' ],
               command,
               has_entries( test[ 'response' ] ) )
+
+
+def Subcommands_GoToType_test():
+  launcher_file = PathToTestFile( 'simple_eclipse_project',
+                                  'src',
+                                  'com',
+                                  'test',
+                                  'TestLauncher.java' )
+  tset_file = PathToTestFile( 'simple_eclipse_project',
+                              'src',
+                              'com',
+                              'youcompleteme',
+                              'testing',
+                              'Tset.java' )
+
+  tests = [
+    # Member function local variable
+    { 'request': { 'line': 28, 'col': 5, 'filepath': launcher_file },
+      'response': { 'line_num': 6, 'column_num': 7, 'filepath': launcher_file },
+      'description': 'GoToType works for member local variable' },
+    # Member variable
+    { 'request': { 'line': 22, 'col': 7, 'filepath': launcher_file },
+      'response': { 'line_num': 6, 'column_num': 14, 'filepath': tset_file },
+      'description': 'GoToType works for member variable' },
+  ]
+
+  for test in tests:
+    yield ( RunGoToTest,
+            test[ 'description' ],
+            test[ 'request' ][ 'filepath' ],
+            test[ 'request' ][ 'line' ],
+            test[ 'request' ][ 'col' ],
+            'GoToType',
+            has_entries( test[ 'response' ] ) )
+
+
+def Subcommands_GoToImplementation_test():
+  filepath = PathToTestFile( 'simple_eclipse_project',
+                             'src',
+                             'com',
+                             'test',
+                             'TestLauncher.java' )
+
+  tests = [
+    # Interface
+    { 'request': { 'line': 17, 'col': 25, 'filepath': filepath },
+      'response': { 'line_num': 28, 'column_num': 16, 'filepath': filepath },
+      'description': 'GoToImplementation on interface '
+                     'jumps to its implementation' },
+    # Interface reference
+    { 'request': { 'line': 21, 'col': 30, 'filepath': filepath },
+      'response': { 'line_num': 28, 'column_num': 16, 'filepath': filepath },
+      'description': 'GoToImplementation on interface reference '
+                     'jumpts to its implementation' },
+  ]
+
+  for test in tests:
+    yield ( RunGoToTest,
+            test[ 'description' ],
+            test[ 'request' ][ 'filepath' ],
+            test[ 'request' ][ 'line' ],
+            test[ 'request' ][ 'col' ],
+            'GoToImplementation',
+            has_entries( test[ 'response' ] ) )
 
 
 @WithRetry


### PR DESCRIPTION
This PR adds the `GoToType` and `GoToImplementation` commands to the LSP completer. They are respectively mapped to the [`textDocument/typeDefinition`](https://microsoft.github.io/language-server-protocol/specification#textDocument_typeDefinition) and [`textDocument/implementation`](https://microsoft.github.io/language-server-protocol/specification#textDocument_implementation) LSP endpoints. It also updates the `GoToDeclaration` command to be mapped to the [`textDocument/declaration`](https://microsoft.github.io/language-server-protocol/specification#textDocument_declaration) endpoint if the LSP server supports it; otherwise, the command is mapped to [`textDocument/definition`](https://microsoft.github.io/language-server-protocol/specification#textDocument_definition) as before. Finally, it changes the `GoTo` command to jump to the declaration if the cursor is already on a definition and vice versa if the LSP server supports declaration.

Closes https://github.com/Valloric/ycmd/issues/1190.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1216)
<!-- Reviewable:end -->
