### PR TITLE
[READY] Do not reset state at server start in Clangd completer

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -352,10 +352,8 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
 
   def StartServer( self, request_data ):
     with self._server_state_mutex:
-      # Ensure we cleanup all states.
-      self._Reset()
-
       LOGGER.info( 'Starting clangd: %s', self._clangd_command )
+
       self._stderr_file = utils.CreateLogfile( 'clangd_stderr' )
       with utils.OpenForStdHandle( self._stderr_file ) as stderr:
         self._server_handle = utils.SafePopen( self._clangd_command,


### PR DESCRIPTION
Resetting the state at server start is unnecessary (it's already reset at completer initialization and at server shutdown) and even problematic as it prevents passing initialization options to Clangd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1220)
<!-- Reviewable:end -->
