### PR TITLE
[READY] Simplify creation of LSP clients

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -65,16 +65,23 @@ def RunFlake8():
   subprocess.check_call( args )
 
 
+# Newer completers follow a standard convention of:
+#  - build: --<completer>-completer
+#  - test directory: ycmd/tests/<completer>
+#  - no aliases.
+SIMPLE_COMPLETERS = [
+  'clangd',
+]
+
+# More complex or legacy cases can specify all of:
+#  - build: flags to add to build.py to include this completer
+#  - test: flags to add to run_tests.py when _not_ testing this completer
+#  - aliases?: list of completer aliases for the --completers option
 COMPLETERS = {
   'cfamily': {
     'build': [ '--clang-completer' ],
     'test': [ '--exclude-dir=ycmd/tests/clang' ],
     'aliases': [ 'c', 'cpp', 'c++', 'objc', 'clang', ]
-  },
-  'clangd': {
-    'build': [ '--clangd-completer' ],
-    'test': [ '--exclude-dir=ycmd/tests/clangd' ],
-    'aliases': []
   },
   'cs': {
     'build': [ '--cs-completer' ],
@@ -113,6 +120,13 @@ COMPLETERS = {
     'aliases': [ 'jdt' ],
   },
 }
+
+# Add in the simple completers
+for completer in SIMPLE_COMPLETERS:
+  COMPLETERS[ completer ] = {
+    'build': [ '--{}-completer'.format( completer ) ],
+    'test': [ '--exclude-dir=ycmd/tests/{}'.format( completer ) ],
+  }
 
 
 def CompleterType( value ):

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1332,6 +1332,11 @@ class LanguageServerCompleter( Completer ):
   def _UpdateDirtyFilesUnderLock( self, request_data ):
     for file_name, file_data in iteritems( request_data[ 'file_data' ] ):
       if not self._AnySupportedFileType( file_data[ 'filetypes' ] ):
+        LOGGER.debug( 'Not updating file %s, it is not a supported filetype: '
+                       '%s not in %s',
+                       file_name,
+                       file_data[ 'filetypes' ],
+                       self.SupportedFiletypes() )
         continue
 
       file_state = self._server_file_state[ file_name ]

--- a/ycmd/completers/language_server/simple_language_server_completer.py
+++ b/ycmd/completers/language_server/simple_language_server_completer.py
@@ -1,0 +1,184 @@
+# Copyright (C) 2018 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
+from builtins import *  # noqa
+
+from ycmd.completers.language_server import language_server_completer as lsc
+
+from ycmd import responses, utils
+from ycmd.utils import LOGGER
+
+import threading
+import abc
+import subprocess
+
+
+class SimpleLSPCompleter( lsc.LanguageServerCompleter ):
+  @abc.abstractmethod
+  def GetServerName( self ):
+    pass
+
+
+  @abc.abstractmethod
+  def GetCommandLine( self ):
+    pass
+
+
+  def GetCustomSubcommands( self ):
+    return {}
+
+
+  def __init__( self, user_options ):
+    super( SimpleLSPCompleter, self ).__init__( user_options )
+
+    self._server_state_mutex = threading.RLock()
+    self._server_keep_logfiles = user_options[ 'server_keep_logfiles' ]
+    self._stderr_file = None
+
+    self._Reset()
+
+
+  def _Reset( self ):
+    with self._server_state_mutex:
+      self.ServerReset()
+      self._connection = None
+      self._server_handle = None
+      if not self._server_keep_logfiles and self._stderr_file:
+        utils.RemoveIfExists( self._stderr_file )
+        self._stderr_file = None
+
+
+  def GetConnection( self ):
+    with self._server_state_mutex:
+      return self._connection
+
+
+  def DebugInfo( self, request_data ):
+    with self._server_state_mutex:
+      server = responses.DebugInfoServer( name = self.GetServerName(),
+                                          handle = self._server_handle,
+                                          executable = self.GetCommandLine(),
+                                          logfiles = [ self._stderr_file ],
+                                          extras = self.CommonDebugItems() )
+
+    return responses.BuildDebugInfoResponse( name = self.Language(),
+                                             servers = [ server ] )
+
+
+  def Language( self ):
+    return self.GetServerName()
+
+
+  def ServerIsHealthy( self ):
+    with self._server_state_mutex:
+      return utils.ProcessIsRunning( self._server_handle )
+
+
+  def StartServer( self, request_data ):
+    with self._server_state_mutex:
+      LOGGER.info( 'Starting %s: %s',
+                   self.GetServerName(),
+                   self.GetCommandLine() )
+
+      self._stderr_file = utils.CreateLogfile( '{}_stderr'.format(
+        utils.MakeSafeFileNameString( self.GetServerName() ) ) )
+
+      with utils.OpenForStdHandle( self._stderr_file ) as stderr:
+        self._server_handle = utils.SafePopen( self.GetCommandLine(),
+                                               stdin = subprocess.PIPE,
+                                               stdout = subprocess.PIPE,
+                                               stderr = stderr )
+
+      self._connection = (
+        lsc.StandardIOLanguageServerConnection(
+          self._server_handle.stdin,
+          self._server_handle.stdout,
+          self.GetDefaultNotificationHandler() )
+      )
+
+      self._connection.Start()
+
+      try:
+        self._connection.AwaitServerConnection()
+      except lsc.LanguageServerConnectionTimeout:
+        LOGGER.error( '%s failed to start, or did not connect successfully',
+                      self.GetServerName() )
+        self.Shutdown()
+        return False
+
+    LOGGER.info( '%s started', self.GetServerName() )
+
+    return True
+
+
+  def Shutdown( self ):
+    with self._server_state_mutex:
+      LOGGER.info( 'Shutting down %s...', self.GetServerName() )
+
+      # Tell the connection to expect the server to disconnect
+      if self._connection:
+        self._connection.Stop()
+
+      if not self.ServerIsHealthy():
+        LOGGER.info( '%s is not running', self.GetServerName() )
+        self._Reset()
+        return
+
+      LOGGER.info( 'Stopping %s with PID %s',
+                   self.GetServerName(),
+                   self._server_handle.pid )
+
+      try:
+        self.ShutdownServer()
+
+        # By this point, the server should have shut down and terminated. To
+        # ensure that isn't blocked, we close all of our connections and wait
+        # for the process to exit.
+        #
+        # If, after a small delay, the server has not shut down we do NOT kill
+        # it; we expect that it will shut itself down eventually. This is
+        # predominantly due to strange process behaviour on Windows.
+        if self._connection:
+          self._connection.Close()
+
+        utils.WaitUntilProcessIsTerminated( self._server_handle,
+                                            timeout = 15 )
+
+        LOGGER.info( '%s stopped', self.GetServerName() )
+      except Exception:
+        LOGGER.exception( 'Error while stopping %s', self.GetServerName() )
+        # We leave the process running. Hopefully it will eventually die of its
+        # own accord.
+
+      # Tidy up our internal state, even if the completer server didn't close
+      # down cleanly.
+      self._Reset()
+
+
+  def _RestartServer( self, request_data ):
+    with self._server_state_mutex:
+      self.Shutdown()
+      self._StartAndInitializeServer( request_data )
+
+
+  def HandleServerCommand( self, request_data, command ):
+    return None

--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -745,3 +745,17 @@ def GetClangResourceDir_NotFound_test( *args ):
     calling( utils.GetClangResourceDir ),
     raises( RuntimeError, 'Cannot find Clang resource directory' )
   )
+
+
+def MakeSafeFileNameString_test():
+  tests = (
+    ( 'this is a test 0123 -x', 'this_is_a_test_0123__x' ),
+    ( 'This Is A Test 0123 -x', 'this_is_a_test_0123__x' ),
+    ( 'T˙^ß ^ß å †´ß† 0123 -x', 't______________0123__x' ),
+    ( 'contains/slashes',       'contains_slashes' ),
+    ( 'contains/newline/\n',    'contains_newline__' ),
+    ( '',                       '' ),
+  )
+  for t in tests:
+    assert_that( utils.MakeSafeFileNameString( t[ 0 ] ),
+                 equal_to( t[ 1 ] ) )

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -138,6 +138,17 @@ def OpenForStdHandle( filepath ):
   return open( filepath, mode = 'w', buffering = 1 )
 
 
+def MakeSafeFileNameString( s ):
+  """Return a representation of |s| that is safe for use in a file name.
+  Explicitly, returns s converted to lowercase with all non alphanumeric
+  characters replaced with '_'."""
+  def is_ascii( c ):
+    return ord( c ) < 128
+
+  return "".join( c if c.isalnum() and is_ascii( c ) else '_'
+                  for c in ToUnicode( s ).lower() )
+
+
 def CreateLogfile( prefix = '' ):
   with tempfile.NamedTemporaryFile( prefix = prefix,
                                     suffix = '.log',


### PR DESCRIPTION
Pull out the common tasks for a stdio-based languate server into
SimpleLSPCompleter, and make the Clangd completer inherit from this.

The simple language server completer attempts to minimize the amount of
work required to add a completer using LSP by automatically detecting
the supported subcommands and managing the server instance.

Now, you just need to:

- update build.py to build the server
- create the <ft> package (__init__.py, hook.py, ft_completer.py)
- write the hook and ShouldEnableFTCompleter
- derive a class from SimpleLSPCompleter and implement 3 methods:
  - SupportedFileTypes
  - GetServerName
  - GetCommandLine
  - (optional) GetCustomSubcommnds
- override any other methods on the LanguageServerCompleter API as
  required

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1222)
<!-- Reviewable:end -->
