### PR TITLE
[READY] Include settings in debug info for LSP

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -25,6 +25,7 @@ from builtins import *  # noqa
 from future.utils import iteritems, iterkeys
 import abc
 import collections
+import json
 import logging
 import os
 import queue
@@ -1805,7 +1806,10 @@ class LanguageServerCompleter( Completer ):
     return [ responses.DebugInfoItem( 'Server State',
                                       ServerStateDescription() ),
              responses.DebugInfoItem( 'Project Directory',
-                                      self._project_directory ) ]
+                                      self._project_directory ),
+             responses.DebugInfoItem( 'Settings',
+                                      json.dumps( self._settings,
+                                                  indent = 2 ) ) ]
 
 
 def _CompletionItemToCompletionData( insertion_text, item, fixits ):

--- a/ycmd/tests/clangd/debug_info_test.py
+++ b/ycmd/tests/clangd/debug_info_test.py
@@ -51,6 +51,10 @@ def DebugInfo_NotInitialized_test( app ):
             'key': 'Project Directory',
             'value': None,
           } ),
+          has_entries( {
+            'key': 'Settings',
+            'value': '{}',
+          } ),
         ),
       } ) ),
       'items': empty(),
@@ -79,6 +83,10 @@ def DebugInfo_Initialized_test( app ):
           has_entries( {
             'key': 'Project Directory',
             'value': PathToTestFile(),
+          } ),
+          has_entries( {
+            'key': 'Settings',
+            'value': '{}',
           } ),
         ),
       } ) ),


### PR DESCRIPTION
This is useful to check that we actually read the settings.

It's equivalent to listing the flags in the libclang completer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1223)
<!-- Reviewable:end -->
