### PR TITLE
[READY] Do not ignore extra conf twice in Clangd tests

### DIFF
--- a/ycmd/tests/clangd/__init__.py
+++ b/ycmd/tests/clangd/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 ycmd contributors
+# Copyright (C) 2018-2019 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -100,13 +100,12 @@ def IsolatedYcmd( custom_options = {} ):
   def Decorator( test ):
     @functools.wraps( test )
     def Wrapper( *args, **kwargs ):
-      with IgnoreExtraConfOutsideTestsFolder():
-        with IsolatedApp( custom_options ) as app:
-          clangd_completer.CLANGD_COMMAND = clangd_completer.NOT_CACHED
-          try:
-            test( app, *args, **kwargs )
-          finally:
-            StopCompleterServer( app, 'cpp' )
+      with IsolatedApp( custom_options ) as app:
+        clangd_completer.CLANGD_COMMAND = clangd_completer.NOT_CACHED
+        try:
+          test( app, *args, **kwargs )
+        finally:
+          StopCompleterServer( app, 'cpp' )
     return Wrapper
   return Decorator
 


### PR DESCRIPTION
[Extra confs are already ignored in `IsolatedApp`](https://github.com/Valloric/ycmd/blob/c04647006ba5b1d2dc3053a01e5a966515cf1f59/ycmd/tests/test_utils.py#L241).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1225)
<!-- Reviewable:end -->
