### PR TITLE
[READY] Use absl::flat_hash_map instead of std maps

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,3 +51,6 @@
 [submodule "third_party/idna"]
 	path = third_party/requests_deps/idna
 	url = https://github.com/kjd/idna
+[submodule "cpp/abseil"]
+	path = cpp/abseil
+	url = https://github.com/abseil/abseil-cpp

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -60,6 +60,8 @@ flags = [
 '-x',
 'c++',
 '-isystem',
+'cpp/abseil',
+'-isystem',
 'cpp/pybind11',
 '-isystem',
 'cpp/whereami',

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -29,6 +29,10 @@ project( YouCompleteMe )
 file( STRINGS "../CORE_VERSION" YCMD_CORE_VERSION )
 add_definitions( -DYCMD_CORE_VERSION=${YCMD_CORE_VERSION} )
 
+if ( MSVC )
+  add_definitions( -DNOMINMAX )
+endif()
+
 option( UNIVERSAL "Build universal mac binary" OFF )
 
 if ( CMAKE_GENERATOR STREQUAL Xcode )
@@ -188,7 +192,7 @@ endif()
 # number of sections that an object file can hold. This is needed for storing
 # the Unicode table. Also, force MSVC to treat source files as UTF-8 encoded.
 if ( MSVC )
-  add_definitions( /DUNICODE /D_UNICODE /Zc:wchar_t- )
+  add_definitions( /DUNICODE /D_UNICODE )
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /bigobj /utf-8" )
 endif()
 
@@ -265,4 +269,8 @@ if (NOT USE_SYSTEM_BOOST)
   add_subdirectory( BoostParts )
 endif()
 
+# This adds -fPIC to everything
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+
+add_subdirectory( abseil )
 add_subdirectory( ycm )

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -200,6 +200,7 @@ else()
 endif()
 
 set( PYBIND11_INCLUDES_DIR "${CMAKE_SOURCE_DIR}/pybind11" )
+set( ABSEIL_INCLUDES_DIR "${CMAKE_SOURCE_DIR}/abseil" )
 
 file( GLOB_RECURSE SERVER_SOURCES *.h *.cpp )
 
@@ -237,6 +238,7 @@ include_directories(
   SYSTEM
   ${Boost_INCLUDE_DIR}
   ${PYBIND11_INCLUDES_DIR}
+  ${ABSEIL_INCLUDES_DIR}
   ${PYTHON_INCLUDE_DIRS}
   ${CLANG_INCLUDES_DIR}
   )
@@ -332,6 +334,9 @@ endif()
 
 target_link_libraries( ${PROJECT_NAME}
                        ${Boost_LIBRARIES}
+                       absl::hash
+                       absl::flat_hash_map
+                       absl::flat_hash_set
                        ${PYTHON_LIBRARIES}
                        ${LIBCLANG_TARGET}
                        ${EXTRA_LIBS}

--- a/cpp/ycm/CandidateRepository.h
+++ b/cpp/ycm/CandidateRepository.h
@@ -26,10 +26,12 @@
 #include <unordered_map>
 #include <vector>
 
+#include <absl/container/flat_hash_map.h>
+
 namespace YouCompleteMe {
 
-using CandidateHolder = std::unordered_map< std::string,
-                                            std::unique_ptr< Candidate > >;
+using CandidateHolder = absl::flat_hash_map< std::string,
+                                             std::unique_ptr< Candidate > >;
 
 
 // This singleton stores already built Candidate objects for candidate strings

--- a/cpp/ycm/CharacterRepository.h
+++ b/cpp/ycm/CharacterRepository.h
@@ -20,16 +20,16 @@
 
 #include "Character.h"
 
+#include <absl/container/flat_hash_map.h>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace YouCompleteMe {
 
-using CharacterHolder = std::unordered_map< std::string,
-                                            std::unique_ptr< Character > >;
+using CharacterHolder = absl::flat_hash_map< std::string,
+                                             std::unique_ptr< Character > >;
 
 
 // This singleton stores already built Character objects for character strings

--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -23,15 +23,16 @@
 #include "UnsavedFile.h"
 #include "Utils.h"
 
-#include <unordered_map>
+#include <absl/container/flat_hash_map.h>
 #include <utility>
-
-using std::unordered_map;
 
 namespace YouCompleteMe {
 namespace {
 
 DiagnosticKind DiagnosticSeverityToType( CXDiagnosticSeverity severity ) {
+#ifdef ERROR
+#undef ERROR
+#endif
   switch ( severity ) {
     case CXDiagnostic_Ignored:
     case CXDiagnostic_Note:
@@ -213,7 +214,7 @@ std::vector< CompletionData > ToCompletionDataVector(
   }
 
   completions.reserve( results->NumResults );
-  unordered_map< std::string, size_t > seen_data;
+  absl::flat_hash_map< std::string, size_t > seen_data;
 
   for ( size_t i = 0; i < results->NumResults; ++i ) {
     CXCompletionResult result = results->Results[ i ];

--- a/cpp/ycm/ClangCompleter/Diagnostic.h
+++ b/cpp/ycm/ClangCompleter/Diagnostic.h
@@ -22,6 +22,10 @@
 
 namespace YouCompleteMe {
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 enum class DiagnosticKind {
   INFORMATION = 0,
   ERROR,

--- a/cpp/ycm/ClangCompleter/TranslationUnitStore.h
+++ b/cpp/ycm/ClangCompleter/TranslationUnitStore.h
@@ -21,10 +21,10 @@
 #include "TranslationUnit.h"
 #include "UnsavedFile.h"
 
+#include <absl/container/flat_hash_map.h>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 using CXIndex = void*;
@@ -68,9 +68,9 @@ private:
 
 
   using TranslationUnitForFilename =
-    std::unordered_map< std::string, std::shared_ptr< TranslationUnit > >;
+    absl::flat_hash_map< std::string, std::shared_ptr< TranslationUnit > >;
 
-  using FlagsHashForFilename = std::unordered_map< std::string, std::size_t >;
+  using FlagsHashForFilename = absl::flat_hash_map< std::string, std::size_t >;
 
   CXIndex clang_index_;
   TranslationUnitForFilename filename_to_translation_unit_;

--- a/cpp/ycm/CodePointRepository.h
+++ b/cpp/ycm/CodePointRepository.h
@@ -20,16 +20,16 @@
 
 #include "CodePoint.h"
 
+#include <absl/container/flat_hash_map.h>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace YouCompleteMe {
 
-using CodePointHolder = std::unordered_map< std::string,
-                                            std::unique_ptr< CodePoint > >;
+using CodePointHolder = absl::flat_hash_map< std::string,
+                                             std::unique_ptr< CodePoint > >;
 
 
 // This singleton stores already built CodePoint objects for code points that

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -18,12 +18,10 @@
 #ifndef IDENTIFIERDATABASE_H_ZESX3CVR
 #define IDENTIFIERDATABASE_H_ZESX3CVR
 
-#include <map>
+#include <absl/container/flat_hash_map.h>
 #include <memory>
 #include <mutex>
-#include <set>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace YouCompleteMe {
@@ -34,11 +32,11 @@ class CandidateRepository;
 
 
 // filepath -> identifiers
-using FilepathToIdentifiers = std::map< std::string,
+using FilepathToIdentifiers = absl::flat_hash_map< std::string,
                                         std::vector< std::string > >;
 
 // filetype -> (filepath -> identifiers)
-using FiletypeIdentifierMap = std::map< std::string, FilepathToIdentifiers >;
+using FiletypeIdentifierMap = absl::flat_hash_map< std::string, FilepathToIdentifiers >;
 
 
 // This class stores the database of identifiers the identifier completer has
@@ -84,12 +82,12 @@ private:
 
   // filepath -> *( *candidate )
   using FilepathToCandidates =
-    std::unordered_map < std::string,
-                         std::shared_ptr< std::set< const Candidate * > > >;
+    absl::flat_hash_map < std::string,
+                          std::unique_ptr< std::set< const Candidate * > > >;
 
   // filetype -> *( filepath -> *( *candidate ) )
   using FiletypeCandidateMap =
-    std::unordered_map < std::string, std::shared_ptr< FilepathToCandidates > >;
+    absl::flat_hash_map < std::string, FilepathToCandidates >;
 
 
   CandidateRepository &candidate_repository_;

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -18,8 +18,8 @@
 #include "IdentifierUtils.h"
 #include "Utils.h"
 
+#include <absl/container/flat_hash_map.h>
 #include <boost/regex.hpp>
-#include <unordered_map>
 
 namespace YouCompleteMe {
 
@@ -58,9 +58,9 @@ struct StringEqualityComparer :
 //   :e $VIMRUNTIME/filetype.vim
 // This is a map of const char* and not std::string to prevent issues with
 // static initialization.
-const std::unordered_map < const char *,
+const absl::flat_hash_map < const char *,
       const char *,
-      std::hash< std::string >,
+      absl::Hash< std::string >,
       StringEqualityComparer > LANG_TO_FILETYPE = {
         { "Ada"                 , "ada"                 },
         { "AnsiblePlaybook"     , "ansibleplaybook"     },


### PR DESCRIPTION
This is finally ready and it finally works. It replaces `std::map` and `std::unordered_map` with `absl::flat_hash_map` and similarly for sets\*.

The basic difference compared to STL associative containers are "flat" storage of values (using contiguous arrays) and as the result,  no pointer stability (though we don't rely on pointer stability).

The reason for this change is performance. The benchmarks can be found [here](https://gist.github.com/bstaletic/7d3e31db7fc8d40a12787fab09ff092f).

\* You will notice in `IdentiferDatabase` there's one `std::set` left. The reason for that is that, for some reason, using a flat set there completely destroys performance. I have tried many implementations of sets and result was always the same, so I think we have to keep `std::set` there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1226)
<!-- Reviewable:end -->
