### PR TITLE
[READY] Use the right application in Java and Tern tests

### DIFF
--- a/ycmd/tests/java/__init__.py
+++ b/ycmd/tests/java/__init__.py
@@ -74,7 +74,7 @@ def StartJavaCompleterServerInDirectory( app, directory ):
                    filepath = os.path.join( directory, 'test.java' ),
                    event_name = 'FileReadyToParse',
                    filetype = 'java' ) )
-  WaitUntilCompleterServerReady( shared_app, 'java', SERVER_STARTUP_TIMEOUT )
+  WaitUntilCompleterServerReady( app, 'java', SERVER_STARTUP_TIMEOUT )
 
 
 def SharedYcmd( test ):

--- a/ycmd/tests/tern/__init__.py
+++ b/ycmd/tests/tern/__init__.py
@@ -62,7 +62,7 @@ def StartJavaScriptCompleterServerInDirectory( app, directory ):
                    filepath = os.path.join( directory, 'test.js' ),
                    event_name = 'FileReadyToParse',
                    filetype = 'javascript' ) )
-  WaitUntilCompleterServerReady( shared_app, 'javascript' )
+  WaitUntilCompleterServerReady( app, 'javascript' )
 
 
 def SharedYcmd( test ):


### PR DESCRIPTION
The shared application is used when waiting for the server to be ready instead of the one passed to the `Start*CompleterServerInDirectory` functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1227)
<!-- Reviewable:end -->
