### PR TITLE
[READY] Add numpydoc to Jedi dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,6 +24,9 @@
 [submodule "third_party/jedi"]
 	path = third_party/jedi_deps/jedi
 	url = https://github.com/davidhalter/jedi
+[submodule "third_party/jedi_deps/numpydoc"]
+	path = third_party/jedi_deps/numpydoc
+	url = https://github.com/numpy/numpydoc
 [submodule "third_party/parso"]
 	path = third_party/jedi_deps/parso
 	url = https://github.com/davidhalter/parso

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -209,6 +209,7 @@ def PythonSysPath( **kwargs ):
                               'regex_{}'.format( major_version ) ),
                       p.join( DIR_OF_THIRD_PARTY, 'frozendict' ),
                       p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'jedi' ),
+                      p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'numpydoc' ),
                       p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'parso' ),
                       p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'requests' ),
                       p.join( DIR_OF_THIRD_PARTY, 'requests_deps',

--- a/run_tests.py
+++ b/run_tests.py
@@ -37,6 +37,7 @@ python_path = [
           'regex_{}'.format( sys.version_info[ 0 ] ) ),
   p.join( DIR_OF_THIRD_PARTY, 'frozendict' ),
   p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'jedi' ),
+  p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'numpydoc' ),
   p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'parso' ),
   p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'certifi' ),
   p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'chardet' ),

--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013-2018 ycmd contributors
+# Copyright (C) 2013-2019 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -68,6 +68,7 @@ def SetUpPythonPath():
                               'regex_{}'.format( sys.version_info[ 0 ] ) ),
                       p.join( DIR_OF_THIRD_PARTY, 'frozendict' ),
                       p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'jedi' ),
+                      p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'numpydoc' ),
                       p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'parso' ),
                       p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'requests' ),
                       p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'chardet' ),

--- a/ycmd/tests/python/get_completions_test.py
+++ b/ycmd/tests/python/get_completions_test.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-# Copyright (C) 2015-2018 ycmd contributors
+# Copyright (C) 2015-2019 ycmd contributors
 #
 # This file is part of ycmd.
 #
@@ -387,3 +387,26 @@ def GetCompletions_PythonInterpreter_ExtraConfData_test( app ):
       'errors': empty()
     } )
   )
+
+
+@SharedYcmd
+def GetCompletions_NumpyDoc_test( app ):
+  RunTest( app, {
+    'description': 'Type hinting is working with docstrings '
+                   'in the Numpy format',
+    'request': {
+      'filetype'  : 'python',
+      'filepath'  : PathToTestFile( 'numpy_docstring.py' ),
+      'line_num'  : 11,
+      'column_num': 18
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completions': contains(
+          CompletionEntryMatcher( 'SomeMethod', 'def SomeMethod()' ),
+        ),
+        'errors': empty()
+      } )
+    }
+  } )

--- a/ycmd/tests/python/testdata/numpy_docstring.py
+++ b/ycmd/tests/python/testdata/numpy_docstring.py
@@ -1,0 +1,11 @@
+class SomeClass():
+    def SomeMethod(self):
+        pass
+
+def some_function(some_param):
+    """
+    Parameters
+    ----------
+    some_param : SomeClass
+    """
+    some_param.sm


### PR DESCRIPTION
[Jedi depends on numpydoc](https://github.com/davidhalter/jedi/blob/8d0c4d3cec4973a2722652bf33f093ac3f1f385a/jedi/evaluate/docstrings.py#L53) to get type hinting from docstrings written in [the Numpy format](https://numpydoc.readthedocs.io/en/latest/). We could tell users to install numpydoc for this use case but it's tricky because we need to tell them to install it for the Python used to build ycmd, not the Python that they are working on. This also defeats the purpose of bundling the Jedi and Parso dependencies in the first place since they could be installed separately as well.

Note that this docstring format is used by other projects than Numpy so we are not adding a dependency just for one Python module.

Fixes https://github.com/Valloric/YouCompleteMe/issues/3361.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1228)
<!-- Reviewable:end -->
