### PR TITLE
[READY] Clangd GetType response bugfix

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -229,7 +229,8 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
 
 
   def GetType( self, request_data ):
-    return self.GetHoverResponse( request_data )[ 'value' ]
+    hover_response = self.GetHoverResponse( request_data )
+    return responses.BuildDisplayMessageResponse( hover_response[ 'value' ] )
 
 
   def _GetTriggerCharacters( self, server_trigger_characters ):

--- a/ycmd/tests/clangd/subcommands_test.py
+++ b/ycmd/tests/clangd/subcommands_test.py
@@ -247,7 +247,7 @@ def RunGetSemanticTest( app, filepath, filetype, test, command,
   request.update( args )
 
   test = { 'request': request, 'route': '/run_completer_command' }
-  response = RunAfterInitialized( app, test )
+  response = RunAfterInitialized( app, test )[ 'message' ]
 
   pprint( response )
   if matches_regexp:


### PR DESCRIPTION
Right now, clangd completer returns a string as a `GetType` response instead of `{ 'message': $STRING }`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1232)
<!-- Reviewable:end -->
