### PR TITLE
[READY] Allow newer coverage version

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,9 @@ coverage:
   - .*/pybind11/.*
   - .*/whereami/.*
 
+fixes:
+  - "utils.py::ycmd/utils.py"
+
 comment:
   layout: "header, diff, changes, uncovered"
   behavior: default  # update if exists else create new

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -12,7 +12,4 @@ unittest2             >= 1.1.0
 psutil                >= 3.3.0, != 5.0.1
 # This needs to be kept in sync with submodule checkout in third_party
 future                == 0.15.2
-# coverage.py 4.4 removed the path from the filename attribute in its reports.
-# This leads to incorrect coverage from codecov as it relies on this attribute
-# to find the source file.
-coverage              >= 4.2, < 4.4
+coverage              >= 4.2


### PR DESCRIPTION
There's still the problem with paths, but codecov has ["Fixing Paths"](https://docs.codecov.io/docs/fixing-paths) section in the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1236)
<!-- Reviewable:end -->
