### PR TITLE
[READY] Fix clang-tidy 8 warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,6 +52,8 @@ CheckOptions:
     value:           '1'
   - key:             performance-type-promotion-in-math-fn.IncludeStyle
     value:           llvm
+  - key:             performance-unnecessary-value-param.AllowedTypes
+    value:           '^object$'
   - key:             performance-unnecessary-value-param.IncludeStyle
     value:           llvm
   - key:             readability-braces-around-statements.ShortStatementLines

--- a/cpp/ycm/CodePoint.cpp
+++ b/cpp/ycm/CodePoint.cpp
@@ -92,15 +92,15 @@ CodePoint::CodePoint( const std::string &code_point )
 
 
 CodePoint::CodePoint( RawCodePoint&& code_point )
-  : normal_( std::move( code_point.normal ) ),
-    folded_case_( std::move( code_point.folded_case ) ),
-    swapped_case_( std::move( code_point.swapped_case ) ),
-    is_letter_( std::move( code_point.is_letter ) ),
-    is_punctuation_( std::move( code_point.is_punctuation ) ),
-    is_uppercase_( std::move( code_point.is_uppercase ) ),
-    break_property_( std::move(
-      static_cast< BreakProperty >( code_point.break_property ) ) ),
-    combining_class_( std::move( code_point.combining_class ) ) {
+  : normal_( code_point.normal ),
+    folded_case_( code_point.folded_case ),
+    swapped_case_( code_point.swapped_case ),
+    is_letter_( code_point.is_letter ),
+    is_punctuation_( code_point.is_punctuation ),
+    is_uppercase_( code_point.is_uppercase ),
+    break_property_(
+      static_cast< BreakProperty >( code_point.break_property ) ),
+    combining_class_( code_point.combining_class ) {
 }
 
 


### PR DESCRIPTION
- `std::move()` for trivially copiable types is useless.
- `pybind11::object` should be allowed to be passed by vaue.

Fixes https://github.com/Valloric/YouCompleteMe/issues/3401
Fixes #1231

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1246)
<!-- Reviewable:end -->
