### PR TITLE
[READY] Set specific gcc, clang and clang-tidy versions in CI

### DIFF
--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -6,8 +6,13 @@ set -e
 #
 
 if [ "${YCM_COMPILER}" == "clang" ]; then
-  sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
-  sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
+  sudo apt-get install clang-3.5
+  sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-3.5 100
+  sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.5 100
+else
+  sudo apt-get install gcc-4.8 g++-4.8
+  sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.8 100
+  sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-4.8 100
 fi
 
 if [ "${YCM_CLANG_TIDY}" ]; then

--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -10,6 +10,14 @@ if [ "${YCM_COMPILER}" == "clang" ]; then
   sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
 fi
 
+if [ "${YCM_CLANG_TIDY}" ]; then
+  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+  sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
+  sudo apt-get update
+  sudo apt-get install -y clang-tidy-8
+  sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-8 100
+fi
+
 #
 # Go setup
 #

--- a/build.py
+++ b/build.py
@@ -424,7 +424,8 @@ def ParseArguments():
                        help = "Don't build the regex module" )
   parser.add_argument( '--clang-tidy',
                        action = 'store_true',
-                       help = 'Run clang-tidy static analysis' )
+                       help = 'For developers: Run clang-tidy static analysis'
+                              'on the ycm_core\'s code itself.' )
   parser.add_argument( '--core-tests', nargs = '?', const = '*',
                        help = 'Run core tests and optionally filter them.' )
 

--- a/build.py
+++ b/build.py
@@ -425,7 +425,7 @@ def ParseArguments():
   parser.add_argument( '--clang-tidy',
                        action = 'store_true',
                        help = 'For developers: Run clang-tidy static analysis'
-                              'on the ycm_core\'s code itself.' )
+                              'on the ycm_core code itself.' )
   parser.add_argument( '--core-tests', nargs = '?', const = '*',
                        help = 'Run core tests and optionally filter them.' )
 


### PR DESCRIPTION
Instead of running Ubuntu 16.04 default toolchains, this PR tries to use the oldest ones that we support. That means gcc-4.8 and clang-3.5 (we support 3.3, but it's too old and unavailable). This PR also installs the latest clang-tidy, so issues like https://github.com/Valloric/YouCompleteMe/issues/3401 won't come up again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1247)
<!-- Reviewable:end -->
