### PR TITLE
[READY] Do not build quietly by default when running tests

### DIFF
--- a/azure/lint.sh
+++ b/azure/lint.sh
@@ -14,6 +14,6 @@ python_version=$(python -c 'import sys; print( "{}.{}.{}".format( *sys.version_i
 echo "Checking python version (actual ${python_version} vs expected ${YCM_PYTHON_VERSION})"
 test ${python_version} == ${YCM_PYTHON_VERSION}
 
-python build.py --clang-completer --clang-tidy --quiet --no-regex
+python build.py --clang-completer --clang-tidy --no-regex
 
 set +e

--- a/run_tests.py
+++ b/run_tests.py
@@ -172,6 +172,9 @@ def ParseArguments():
                               'manually, then exit.' )
   parser.add_argument( '--no-retry', action = 'store_true',
                        help = 'Disable retry of flaky tests' )
+  parser.add_argument( '--quiet', action = 'store_true',
+                       help = 'Quiet installation mode. Just print overall '
+                              'progress and errors' )
 
   parsed_args, nosetests_args = parser.parse_known_args()
 
@@ -213,8 +216,7 @@ def BuildYcmdLibs( args ):
     build_cmd = [
       sys.executable,
       p.join( DIR_OF_THIS_SCRIPT, 'build.py' ),
-      '--core-tests',
-      '--quiet',
+      '--core-tests'
     ]
 
     for key in COMPLETERS:
@@ -230,6 +232,9 @@ def BuildYcmdLibs( args ):
       # output in a known directory, which is then used by the CI infrastructure
       # to generate the c++ coverage information.
       build_cmd.extend( [ '--enable-coverage', '--build-dir', '.build' ] )
+
+    if args.quiet:
+      build_cmd.append( '--quiet' )
 
     subprocess.check_call( build_cmd )
 


### PR DESCRIPTION
Silencing the output of the build on CIs has the inconvenience that we can't check if the configuration is correct (which compiler, version of Python, etc.). We silenced it because the output was too long and forced us to download the logs to see which tests failed and how. See PR https://github.com/Valloric/ycmd/pull/924. This is no longer an issue on Azure as the length of the output doesn't seem to be limited and its UI makes it convenient to scroll through it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1248)
<!-- Reviewable:end -->
