### PR TITLE
[READY] Automatically detect codeAction support

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -242,10 +242,6 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
 
   def GetCustomSubcommands( self ):
     return {
-      'FixIt': (
-        lambda self, request_data, args: self.GetCodeActions( request_data,
-                                                              args )
-      ),
       'GetType': (
         # In addition to type information we show declaration.
         lambda self, request_data, args: self.GetType( request_data )

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -208,10 +208,6 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
 
   def GetCustomSubcommands( self ):
     return {
-      'FixIt': (
-        lambda self, request_data, args: self.GetCodeActions( request_data,
-                                                              args )
-      ),
       'GetDoc': (
         lambda self, request_data, args: self.GetDoc( request_data )
       ),

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -74,6 +74,9 @@ PROVIDERS_MAP = {
     lambda self, request_data, args: self.GoTo( request_data,
                                                 [ 'References' ] )
   ),
+  'codeActionProvider': (
+    lambda self, request_data, args: self.GetCodeActions( request_data, args )
+  ),
   'renameProvider': (
     lambda self, request_data, args: self.RefactorRename( request_data, args )
   ),
@@ -97,6 +100,7 @@ DEFAULT_SUBCOMMANDS_MAP = {
   'GoToImplementation': [ 'implementationProvider' ],
   'GoToReferences':     [ 'referencesProvider' ],
   'RefactorRename':     [ 'renameProvider' ],
+  'FixIt':              [ 'codeActionProvider' ],
   'Format':             [ 'documentFormattingProvider' ]
 }
 
@@ -706,9 +710,9 @@ class LanguageServerCompleter( Completer ):
     pass # pragma: no cover
 
 
-  @abc.abstractmethod
   def HandleServerCommand( self, request_data, command ):
-    pass # pragma: no cover
+    raise RuntimeError( 'HandleServerCommand not '
+                        'implemented for the current filetype' )
 
 
   def __init__( self, user_options ):

--- a/ycmd/completers/language_server/simple_language_server_completer.py
+++ b/ycmd/completers/language_server/simple_language_server_completer.py
@@ -178,7 +178,3 @@ class SimpleLSPCompleter( lsc.LanguageServerCompleter ):
     with self._server_state_mutex:
       self.Shutdown()
       self._StartAndInitializeServer( request_data )
-
-
-  def HandleServerCommand( self, request_data, command ):
-    return None

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -1252,3 +1252,27 @@ def LanguageServerCompleter_OnFileReadyToParse_InvalidURI_test():
                     uri_to_filepath:
       assert_that( completer.OnFileReadyToParse( request_data ), diagnostics )
       uri_to_filepath.assert_called()
+
+
+def LanguageServerCompleter_FixIt_NoHandleServerCommandImplemented_test():
+  completer = MockCompleter()
+
+  completer._server_capabilities = {
+    'codeActionProvider':     True
+  }
+
+  request_data = RequestWrap( BuildRequest() )
+
+  @patch.object( completer, 'ServerIsReady', return_value = True )
+  def Test( exception, message, *args ):
+    with patch.object( completer.GetConnection(),
+                       'GetResponse',
+                       side_effect = [ { 'result': [ 'whatever' ] } ] ):
+      assert_that(
+        calling( completer.OnUserCommand ).with_args( [ 'FixIt' ],
+                                                      request_data ),
+        raises( exception, message )
+      )
+
+  yield Test, RuntimeError, ( 'HandleServerCommand not '
+                              'implemented for the current filetype' )


### PR DESCRIPTION
This PR lets us automatically detect `codeAction` support.

Additionally, the change to `LanguageServerCompleter.HandleServerCommand()` was needed because:

> Because of the `GenericLSPCompleter`. If we tell users "`try g:ycm_language_server`" and the server reports `codeActionProvider`, then, because of return None in `SimpleLSPCompleter`, it would just silently fail.
With this change, users (and we) will get a message "hey, for this completer you don't have a proper `HandleServerCommand`".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1252)
<!-- Reviewable:end -->
