### PR TITLE
Allow maintainer to manually merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,3 +8,20 @@ pull_request_rules:
       merge:
         method: merge
         strict: smart
+      comment:
+        message: Thanks for sending a PR!
+  - name: Manual merge on Azure Pipelines and Maintainer Override
+    conditions:
+      - base=master
+      - status-success=Valloric.ycmd
+
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+
+      - label="Ship It!"
+    actions:
+      merge:
+        method: merge
+        strict: smart
+      comment:
+        message: Thanks for sending a PR!


### PR DESCRIPTION
This allows adding a "Ship It!" label to the PR to allow mergify to
merge it even if the Reviewable is not happy, but assuming there is at
least 1 approving review and no outstanding blocking comments.

This allows maintainers to agree to merge something with essentially
only 1 LGTM, but without always automatically merging based on that. 2
LGTMs is still a good rule for a lot of things, but is cumbersome for
smaller or more urgent PRs.

I've already created the label on Valloric/ycmd repo. Will push this change to YouCompleteMe repo too later.

Tested on my fork:

<img width="720" alt="Screenshot 2019-06-02 at 14 57 20" src="https://user-images.githubusercontent.com/10584846/58762310-bc028f00-8546-11e9-8c9c-7a6dbeae4465.png">

Removing the label, it updates about 1 minute later to not be ticked (pass).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1256)
<!-- Reviewable:end -->
