### PR TITLE
[WIP] Go completer: find root go.mod

### DIFF
--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -63,7 +63,7 @@ class GoCompleter( simple_language_server_completer.SimpleLSPCompleter ):
     return 'gopls'
 
 
-  def _GetProjectDirectory( self, request_data, extra_conf_dir ):
+  def GetProjectDirectory( self, request_data, extra_conf_dir ):
     # Without LSP workspaces support, GOPLS relies on the rootUri to detect a
     # project.
     # TODO: add support for LSP workspaces to allow users to change project
@@ -71,8 +71,8 @@ class GoCompleter( simple_language_server_completer.SimpleLSPCompleter ):
     for folder in utils.PathsToAllParentFolders( request_data[ 'filepath' ] ):
       if os.path.isfile( os.path.join( folder, 'go.mod' ) ):
         return folder
-    return super( GoCompleter, self )._GetProjectDirectory( request_data,
-                                                            extra_conf_dir )
+    return super( GoCompleter, self ).GetProjectDirectory( request_data,
+                                                           extra_conf_dir )
 
 
   def GetCommandLine( self ):


### PR DESCRIPTION
Rust completer renamed GetProjectDirectory to _GetProjectDirectory,
which I didn't notice when rebasing after merging the Rust completer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1257)
<!-- Reviewable:end -->
