### PR TITLE
[READY] Support multi-user installation for Java

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -505,8 +505,13 @@ class LanguageServerConnection( threading.Thread ):
             read_bytes += 1
             break
           else:
-            key, value = utils.ToUnicode( line ).split( ':', 1 )
-            headers[ key.strip() ] = value.strip()
+            try:
+              key, value = utils.ToUnicode( line ).split( ':', 1 )
+              headers[ key.strip() ] = value.strip()
+            except Exception:
+              LOGGER.exception( 'Received invalid protocol data from server: '
+                                 + str( line ) )
+              raise
 
         read_bytes += 1
 

--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -32,5 +32,6 @@
   "use_clangd": 1,
   "clangd_binary_path": "",
   "clangd_args": [],
-  "clangd_uses_ycmd_caching": 1
+  "clangd_uses_ycmd_caching": 1,
+  "java_jdtls_workspace_root_path": ""
 }

--- a/ycmd/tests/clangd/get_completions_test.py
+++ b/ycmd/tests/clangd/get_completions_test.py
@@ -35,7 +35,8 @@ from ycmd.tests.test_utils import ( BuildRequest,
                                     CombineRequest,
                                     CompletionEntryMatcher,
                                     WaitUntilCompleterServerReady,
-                                    WindowsOnly )
+                                    WindowsOnly,
+                                    WithRetry )
 from ycmd.utils import ReadFile
 
 
@@ -416,6 +417,7 @@ int main()
 
 @SharedYcmd
 @WindowsOnly
+@WithRetry
 def GetCompletions_ClangCLDriverFlag_SimpleCompletion_test( app ):
   RunTest( app, {
     'description': 'basic completion with --driver-mode=cl',
@@ -444,6 +446,7 @@ def GetCompletions_ClangCLDriverFlag_SimpleCompletion_test( app ):
 
 @SharedYcmd
 @WindowsOnly
+@WithRetry
 def GetCompletions_ClangCLDriverExec_SimpleCompletion_test( app ):
   RunTest( app, {
     'description': 'basic completion with --driver-mode=cl',
@@ -472,6 +475,7 @@ def GetCompletions_ClangCLDriverExec_SimpleCompletion_test( app ):
 
 @SharedYcmd
 @WindowsOnly
+@WithRetry
 def GetCompletions_ClangCLDriverFlag_IncludeStatementCandidate_test( app ):
   RunTest( app, {
     'description': 'Completion inside include statement with CL driver',
@@ -498,6 +502,7 @@ def GetCompletions_ClangCLDriverFlag_IncludeStatementCandidate_test( app ):
 
 @SharedYcmd
 @WindowsOnly
+@WithRetry
 def GetCompletions_ClangCLDriverExec_IncludeStatementCandidate_test( app ):
   RunTest( app, {
     'description': 'Completion inside include statement with CL driver',
@@ -568,6 +573,7 @@ def GetCompletions_UnicodeInLineFilter_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_QuotedInclude_test( app ):
   RunTest( app, {

--- a/ycmd/tests/java/java_completer_test.py
+++ b/ycmd/tests/java/java_completer_test.py
@@ -60,15 +60,22 @@ def ShouldEnableJavaCompleter_NoLauncherJar_test( glob ):
 
 def WorkspaceDirForProject_HashProjectDir_test():
   assert_that(
-    java_completer._WorkspaceDirForProject( os.getcwd(), False ),
-    equal_to( java_completer._WorkspaceDirForProject( os.getcwd(), False ) )
+    java_completer._WorkspaceDirForProject( os.getcwd(),
+                                            os.getcwd(),
+                                            False ),
+    equal_to( java_completer._WorkspaceDirForProject( os.getcwd(),
+                                                      os.getcwd(),
+                                                      False ) )
   )
 
 
 def WorkspaceDirForProject_UniqueDir_test():
   assert_that(
-    java_completer._WorkspaceDirForProject( os.getcwd(), True ),
+    java_completer._WorkspaceDirForProject( os.getcwd(),
+                                            os.getcwd(),
+                                            True ),
     is_not( equal_to( java_completer._WorkspaceDirForProject( os.getcwd(),
+                                                              os.getcwd(),
                                                               True ) ) )
   )
 

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -79,7 +79,8 @@ def Subcommands_DefinedSubcommands_test( app ):
                  'OpenProject',
                  'OrganizeImports',
                  'RefactorRename',
-                 'RestartServer' ] ),
+                 'RestartServer',
+                 'WipeWorkspace' ] ),
        app.post_json( '/defined_subcommands', subcommands_data ).json )
 
 


### PR DESCRIPTION
jdt.ls workspace areas are mutable and written by the server. Putting them
underneath the ycmd installation, even in their own directory makes it
impossible to use a shared installation of ycmd. In order to allow that, we
expose another (hidden) option which moves the workspace root dirdectory
somewhere else, such as the user's home directory.

---

The 'config' directory is a bit of a misnomer. It is really a working area
for eclipse to store things that eclipse feels entitled to store,
that are not specific to a particular project or workspace.
Importantly, the server writes to this directory, which means that in order
to allow installations of ycmd on readonly filesystems (or shared
installations of ycmd), we have to make it somehow unique at least per user,
and possibly per ycmd instance.

To allow this, we let the client specify the workspace root and we always
put the (mutable) config directory under the workspace root path. The config
directory is simply a writable directory with the config.ini in it.

Note that we must re-copy the config when it changes. Otherwise, eclipse
just won't start. As the file is generated part of the jdt.ls build, we just
always copy and overwrite it.

---

Move the config directory inside the workspace, and allow the client to
specify a workspace root directory.  This means that it is possible to
share the ycmd installation across multiple users by moving the mutable
state directories elsewhere.  By default we just move the config dir and
use the old workspace directory.

While we are at it, provide a way to wipe out the re-used workspace.
When use_clean_workspace is False, the workspace can become corrupt, so
we add a command to stop the server, delete the workspace (and
optionally also the config directory), then restart the server.

---

I have been using this change for years at work and it is very stable. Would like to not maintain it in a fork any longer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1262)
<!-- Reviewable:end -->
