### PR TITLE
[READY] Add vimspector config

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -1,0 +1,33 @@
+{
+  "configurations": {
+    "python - launch nosetests": {
+      "adapter": "vscode-python",
+      "configuration": {
+        "name": "Python nosetests",
+        "type": "vscode-python",
+        "request": "launch",
+
+        "cwd": "${workspaceRoot}",
+        "stopOnEntry": true,
+        "console": "integratedTerminal",
+        "justMyCode": false,
+
+        "debugOptions": [],
+
+        "program": "$VIRTUAL_ENV/bin/nosetests",
+        "pythonPath": "${VIRTUAL_ENV}/bin/python",
+        "args": [
+          "-v",
+          "--with-id",
+          "--ignore-files=(^\\.|^setup\\.py$$)",
+          "${Test}"
+        ],
+        "env": {
+          "PYTHONPATH": "${workspaceRoot}/third_party/bottle:${workspaceRoot}/third_party/cregex/regex_${python_version}:${workspaceRoot}/third_party/frozendict:${workspaceRoot}/third_party/jedi_deps/jedi:${workspaceRoot}/third_party/jedi_deps/numpydoc:${workspaceRoot}/third_party/jedi_deps/parso:${workspaceRoot}/third_party/requests_deps/certifi:${workspaceRoot}/third_party/requests_deps/chardet:${workspaceRoot}/third_party/requests_deps/idna:${workspaceRoot}/third_party/requests_deps/requests:${workspaceRoot}/third_party/requests_deps/urllib3/src:${workspaceRoot}/third_party/waitress",
+          "LD_LIBRARY_PATH": "${workspaceRoot}/third_party/clang/lib",
+          "YCM_TEST_NO_RETRY": "1"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This allows debugging of ycmd tests directly using vimspector. I use a
mapping which runs the test under the cursor, so one of the variables it
asks you for it "test" which is essentially arguments to nosetests.

NOTE: It doesn't work on windows, and it requires the use of a
virtualenv at the moment. This is mainly due to a limitation of
vimspector that it only has simple variable replacement in its config.

It's actually possible to set variables based on shell commands so if the use of venv is painful for anyone else who actually uses it I can improve that.

Demo:

![vimspector-YCM-debug-test](https://user-images.githubusercontent.com/10584846/59553273-c1ba9480-8f8a-11e9-8c19-7bf96c22962a.gif)



To use:

 - install Vimspector: https://puremourning.github.io/vimspector-web/. enable the `HUMAN` mappings (or the vs ones if you prefer. or write your own)
 - install the python debugger `cd /path/to/vimspector; ./install_gadget.py --enable-python`
 - open a test file and navigate to place to break, hit `<F9>`
- hit `<F5>`
 - `Test` should be set to either empty (all tests) or nosetest arg such as `ycmd/tests/get_completions.test:<function>`
 - `python_version` should be `2` or `3` - this selects the regex module that gets loaded.

I also have a bunch of mappings and a compiler plugin that lets me do this with a single keystroke.

This can all be improved over time if people use it a lot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1264)
<!-- Reviewable:end -->
