### PR TITLE
[READY] Ignore dirty gopls repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,4 @@
 [submodule "third_party/go/src/golang.org/x/tools"]
 	path = third_party/go/src/golang.org/x/tools
 	url = https://go.googlesource.com/tools
+	ignore = dirty


### PR DESCRIPTION
After building, it has the gopls binary in there, but the repo doesn't have a .gitignore.

So we ignore it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1265)
<!-- Reviewable:end -->
