### PR TITLE
Apply retry outside of SharedYcmd

### DIFF
--- a/ycmd/tests/clangd/get_completions_test.py
+++ b/ycmd/tests/clangd/get_completions_test.py
@@ -758,7 +758,7 @@ def GetCompletions_BracketInclude_AtDirectorySeparator_test( app ):
 
 
 @WithRetry
-@SharedYcmd
+@IsolatedYcmd()
 def GetCompletions_cuda_test( app ):
   RunTest( app, {
     'description': 'Completion of CUDA files',
@@ -775,7 +775,7 @@ def GetCompletions_cuda_test( app ):
         'completion_start_column': 29,
         'completions': contains(
           CompletionEntryMatcher( 'do_something', 'void',
-              { 'menu_text': ' do_something(float *a)' } ),
+              { 'menu_text': 'do_something(float *a)' } ),
         ),
         'errors': empty(),
       } )

--- a/ycmd/tests/clangd/get_completions_test.py
+++ b/ycmd/tests/clangd/get_completions_test.py
@@ -141,6 +141,7 @@ def GetCompletions_NotForced_NoYcmdCaching_test( app ):
 
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_ForcedWithNoTrigger_test( app ):
   RunTest( app, {
@@ -190,6 +191,7 @@ def GetCompletions_Fallback_NoSuggestions_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_Fallback_NoSuggestions_MinimumCharaceters_test( app ):
   # TESTCASE1 (general_fallback/lang_cpp.cc)
@@ -214,6 +216,7 @@ def GetCompletions_Fallback_NoSuggestions_MinimumCharaceters_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_Fallback_Suggestions_test( app ):
   # TESTCASE1 (general_fallback/lang_c.c)
@@ -237,6 +240,7 @@ def GetCompletions_Fallback_Suggestions_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_Fallback_Exception_test( app ):
   # TESTCASE4 (general_fallback/lang_c.c)
@@ -263,6 +267,7 @@ def GetCompletions_Fallback_Exception_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_Forced_NoFallback_test( app ):
   # TESTCASE2 (general_fallback/lang_c.c)
@@ -282,6 +287,7 @@ def GetCompletions_Forced_NoFallback_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_FilteredNoResults_Fallback_test( app ):
   # no errors because the semantic completer returned results, but they
@@ -350,6 +356,7 @@ int main()
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_ForceSemantic_YcmdCache_test( app ):
   RunTest( app, {
@@ -415,9 +422,9 @@ int main()
   } )
 
 
-@SharedYcmd
 @WindowsOnly
 @WithRetry
+@SharedYcmd
 def GetCompletions_ClangCLDriverFlag_SimpleCompletion_test( app ):
   RunTest( app, {
     'description': 'basic completion with --driver-mode=cl',
@@ -444,9 +451,9 @@ def GetCompletions_ClangCLDriverFlag_SimpleCompletion_test( app ):
   } )
 
 
-@SharedYcmd
 @WindowsOnly
 @WithRetry
+@SharedYcmd
 def GetCompletions_ClangCLDriverExec_SimpleCompletion_test( app ):
   RunTest( app, {
     'description': 'basic completion with --driver-mode=cl',
@@ -473,9 +480,9 @@ def GetCompletions_ClangCLDriverExec_SimpleCompletion_test( app ):
   } )
 
 
-@SharedYcmd
 @WindowsOnly
 @WithRetry
+@SharedYcmd
 def GetCompletions_ClangCLDriverFlag_IncludeStatementCandidate_test( app ):
   RunTest( app, {
     'description': 'Completion inside include statement with CL driver',
@@ -500,9 +507,9 @@ def GetCompletions_ClangCLDriverFlag_IncludeStatementCandidate_test( app ):
   } )
 
 
-@SharedYcmd
 @WindowsOnly
 @WithRetry
+@SharedYcmd
 def GetCompletions_ClangCLDriverExec_IncludeStatementCandidate_test( app ):
   RunTest( app, {
     'description': 'Completion inside include statement with CL driver',
@@ -527,6 +534,7 @@ def GetCompletions_ClangCLDriverExec_IncludeStatementCandidate_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_UnicodeInLine_test( app ):
   RunTest( app, {
@@ -550,6 +558,7 @@ def GetCompletions_UnicodeInLine_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_UnicodeInLineFilter_test( app ):
   RunTest( app, {
@@ -602,6 +611,7 @@ def GetCompletions_QuotedInclude_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_QuotedInclude_AfterDirectorySeparator_test( app ):
   RunTest( app, {
@@ -625,6 +635,7 @@ def GetCompletions_QuotedInclude_AfterDirectorySeparator_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_QuotedInclude_AfterDot_test( app ):
   RunTest( app, {
@@ -649,6 +660,7 @@ def GetCompletions_QuotedInclude_AfterDot_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_QuotedInclude_AfterSpace_test( app ):
   RunTest( app, {
@@ -672,6 +684,7 @@ def GetCompletions_QuotedInclude_AfterSpace_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_QuotedInclude_Invalid_test( app ):
   RunTest( app, {
@@ -693,6 +706,7 @@ def GetCompletions_QuotedInclude_Invalid_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_BracketInclude_test( app ):
   RunTest( app, {
@@ -717,6 +731,7 @@ def GetCompletions_BracketInclude_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_BracketInclude_AtDirectorySeparator_test( app ):
   RunTest( app, {
@@ -742,6 +757,7 @@ def GetCompletions_BracketInclude_AtDirectorySeparator_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_cuda_test( app ):
   RunTest( app, {
@@ -759,7 +775,7 @@ def GetCompletions_cuda_test( app ):
         'completion_start_column': 29,
         'completions': contains(
           CompletionEntryMatcher( 'do_something', 'void',
-              { 'menu_text': 'do_something(float *a)' } ),
+              { 'menu_text': ' do_something(float *a)' } ),
         ),
         'errors': empty(),
       } )
@@ -792,6 +808,7 @@ def GetCompletions_WithHeaderInsertionDecorators_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_ServerTriggers_Ignored_test( app ):
   RunTest( app, {


### PR DESCRIPTION
This is so that the completion cache is cleared on each test, rather than repeatedly returning the wrong value from the cache.

SharedYcmd clears the cache for this exact reason, so adding WithRety _after_ SharedYcmd meant that the test just took longer to flake. Now it retries properly (maximally).

For the record: @WithRetry should always be the first decorator added, after any decorator that skips the test. So:

1. Skip decorators
2. Retry decorators
3. ycmd instance decorators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1269)
<!-- Reviewable:end -->
