### PR TITLE
windows fix: undeclared identifier ssiz_t

### DIFF
--- a/cpp/ycm/PythonSupport.cpp
+++ b/cpp/ycm/PythonSupport.cpp
@@ -15,6 +15,11 @@
 // You should have received a copy of the GNU General Public License
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
+#if defined(_MSC_VER)
+    #include <BaseTsd.h>
+    typedef SSIZE_T ssize_t;
+#endif
+
 #include "PythonSupport.h"
 #include "Candidate.h"
 #include "Repository.h"


### PR DESCRIPTION
simple fix for unrecognized type ssize_t on windows

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1597)
<!-- Reviewable:end -->
