### PR TITLE
[READY] Make repackaged LLVM work on Ubuntu18.04 and newer

### DIFF
--- a/build.py
+++ b/build.py
@@ -1016,32 +1016,32 @@ def GetClangdTarget():
   if OnWindows():
     return [
       ( 'clangd-{version}-win64',
-        '413b1d86af75637d5381e6b6613b41e60756ad411d7a22644d1a9d7b1b3b69df' ),
+        '5f4f8612af3f10bb52fd97d6196ac1653802f04f179d2069cf2c1fa861e167b5' ),
       ( 'clangd-{version}-win32',
-        '232157d85a6277976127f07a204e4c43d2c91c35cc4b6620a0d03b8490ebd67c' ) ]
+        '1554db0f7e7a8b1e98746aa2e9f650d753cfbdc4ad5892d4b94725b7701bc635' ) ]
   if OnMac():
     return [
       ( 'clangd-{version}-x86_64-apple-darwin',
-        'aa8c8bc45ff290f146cc520d4b505adf3b68145b226fe60a2ee80af344ef90c6' ) ]
+        '07f8ee76b47a021c1dc646339a0de564682ed3eb38c9af7c621a13462b372234' ) ]
   if OnFreeBSD():
     return [
       ( 'clangd-{version}-amd64-unknown-freebsd13',
-        '562dd61bba882e542eea4974dee8368c5d16db90ba792870465df30ed86d7679' ),
+        'eba47cc50bea3bebd5f8a8d1c8890dd1d93bf5c7759306f56ea6edb7ee9df23e' ),
       ( 'clangd-{version}-i386-unknown-freebsd13',
-        'e3a660c422cc8f2aa04f20ef4e75a228129354a974a66e44c23facac81a82ca3' ) ]
+        'b5c9e316be51a09cb72a0eec865d990877ce1312aff1612b776735a920aeac05' ) ]
   if OnAArch64():
     return [
       ( 'clangd-{version}-aarch64-linux-gnu',
-        'dd14bd1114e0b5a2a4064b586216ffdbc292959876afb08cd796c575c69b1d69' ) ]
+        'e4696956476680522f388e1650cd088d6c299ae71c371c397b5cec492b9ced4c' ) ]
   if OnArm():
     return [
       None, # First list index is for 64bit archives. ARMv7 is 32bit only.
       ( 'clangd-{version}-armv7a-linux-gnueabihf',
-        '6fb30244ab3d83712742824a49cf1b86e96d87acafb76ce7fe5ee77b976e4776' ) ]
+        'e2e8aa20b7b4d9b3c0955211f42950120d650a4fb4bef3e4140bdf147b903e8e' ) ]
   if OnX86_64():
     return [
       ( 'clangd-{version}-x86_64-unknown-linux-gnu',
-        '923e1d84e485665312db8f41a2eb9da75c3291ac77d098e27827dd594de224d9' ) ]
+        '5fc913b474a142a1796a598167a1227552eb4346b5f500a0594c876165f408ad' ) ]
   sys.exit( CLANGD_BINARIES_ERROR_MESSAGE.format( version = CLANGD_VERSION,
                                                   platform = 'this system' ) )
 

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -35,42 +35,42 @@ if ( USE_CLANG_COMPLETER AND
   if ( APPLE )
     set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-x86_64-apple-darwin" )
     set( LIBCLANG_SHA256
-         "61f8a3f93a2cfe809332ee9e7b8b3716d3f31009f1f0e32170ffd10051636233" )
+         "446c92d0202213eb121df3471c8d71d2f36089b75b9834777ce76bd52286cf93" )
   elseif ( WIN32 )
     if( 64_BIT_PLATFORM )
       set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-win64" )
       set( LIBCLANG_SHA256
-           "071d576d8d0d995c5f6fe2280ab6c63d16636208c9da82a60ac553ceb444428a" )
+           "7a287d4c3ed1d1c622c9139c2cd4ae1cf4c0284f75dce8437e84c752c086b03e" )
     else()
       set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-win32" )
       set( LIBCLANG_SHA256
-           "beb685861b28f98615dd8fe1846dce56ee1c70765a514109de9276a5cb3aa69a" )
+           "d29863e3f8eb4ec51b65a775fd892fa9f2363a3867f7c563764b56b49a912687" )
     endif()
   elseif ( SYSTEM_IS_FREEBSD )
     if ( 64_BIT_PLATFORM )
       set( LIBCLANG_DIRNAME
            "libclang-${CLANG_VERSION}-amd64-unknown-freebsd13" )
       set( LIBCLANG_SHA256
-           "f277b299c395a34cfc44f6e0f802f1818ccff1a7c79bc03d775393dbed45279d" )
+           "6c0fb9d635ff236a5380611f53fadf36881343bf81920f670a3a64a015d9d983" )
     else()
       set( LIBCLANG_DIRNAME
            "libclang-${CLANG_VERSION}-i386-unknown-freebsd13" )
       set( LIBCLANG_SHA256
-           "61df6d6a50c7f5f9480404e3ae6ef2c206075209c1b34f3775caeed1caa9b0df" )
+           "93ec1557a640f35a24b2ffe3477316213977e2cac1a6233f590d92af723fc9ae" )
     endif()
   elseif ( CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*)" )
     set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-aarch64-linux-gnu" )
     set( LIBCLANG_SHA256
-         "a01151de5f4dedb2a7c497e7a860442ab376b4bb1cb7226158cc138c7cd1f155" )
+         "f486faa2958a8e5310c4b8ca69f8e20bac06994b902147ee3f3b1f0f2fe7ddd6" )
   elseif ( CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)" )
     set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-armv7a-linux-gnueabihf" )
     set( LIBCLANG_SHA256
-         "ecd2f0d93b8bd05e05726e85722af14643b09f2feaa331a2b2a3804cef797884" )
+         "418349b5704010330dbd712c8cceb39f9b41dec33cdc2b6834c43493b1a1ce14" )
   elseif ( CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64)" )
     set( LIBCLANG_DIRNAME
          "libclang-${CLANG_VERSION}-x86_64-unknown-linux-gnu" )
     set( LIBCLANG_SHA256
-         "8ddd9d3dbc26e2eea572f3fa36f279f8247e2c4c65529872fe52a21321424b68" )
+         "d783ac9d4f918d1bd33a690e06484968735e55ddbdd59ac466ebc852df40aafa" )
   else()
     message( FATAL_ERROR
       "No prebuilt Clang ${CLANG_VERSION} binaries for this system. "


### PR DESCRIPTION
Updated checksums after getting ycm-core/llvm to work with Ubuntu 18.04 container. This way, we make the archives work for Ubuntu 18.04+ and Ubuntu 18.04 is still supported (by Canonical).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1600)
<!-- Reviewable:end -->
