### PR TITLE
Document unittest_args in run_tests.py --help

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -115,7 +115,11 @@ def CompleterType( value ):
 
 
 def ParseArguments():
-  parser = argparse.ArgumentParser()
+  description = '''
+    Unknown arguments are passed to unittest module, e.g. to select test cases.
+    See `python -m unittest --help` for more details.
+  '''
+  parser = argparse.ArgumentParser( description=description )
   group = parser.add_mutually_exclusive_group()
   group.add_argument( '--no-clang-completer', action = 'store_true',
                        help = argparse.SUPPRESS ) # deprecated


### PR DESCRIPTION
Adds a line of help after usage to document `run_tests.py` passing unknown arguments to `unittest`.

```diff
 > ./run_tests.py --help
 usage: run_tests.py [-h] [--no-completers [{cfamily,cs,javascript,typescript,python,java,clangd,rust,go} ...] | --completers 
[{cfamily,cs,javascript,typescript,python,java,clangd,rust,go} ...]] [--skip-build]
                     [--msvc {15,16,17}] [--coverage] [--no-flake8] [--dump-path] [--no-retry] [--quiet] [--valgrind]
 
+Unknown arguments are passed to unittest module, e.g. to select test cases. See `python -m unittest --help` for more details.
 
 options:
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1761)
<!-- Reviewable:end -->
