### PR TITLE
Use tsserver to drive vue-typescript-plugin (fix Vue file completion)

### DIFF
--- a/third_party/tsserver/package.json
+++ b/third_party/tsserver/package.json
@@ -1,6 +1,8 @@
 {
   "description": "ycmd tsserver runtime area with required typescript version and plugins",
   "dependencies": {
-    "typescript": "5.7.2"
+    "@vue/language-server": "^3.0.7",
+    "@vue/typescript-plugin": "^3.0.7",
+    "typescript": "^5.9.2"
   }
 }

--- a/ycmd/completers/vue/hook.py
+++ b/ycmd/completers/vue/hook.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2020 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from ycmd.completers.typescript.typescript_completer import (
+    ShouldEnableTypeScriptCompleter, TypeScriptCompleter )
+
+
+def GetCompleter( user_options ):
+  if not ShouldEnableTypeScriptCompleter( user_options ):
+    return None
+
+  return TypeScriptCompleter( user_options )


### PR DESCRIPTION
Everything in the title ; as it currently is, completion in `*.vue` files is not working - not at all out of the box, and very broken if trying to use modern `vue-language-server` the same way one used to use `volar` or `vls` - I'm not 100% sure but despite it being the same project as `volar`/`vls` (or a fork), I suspect it really expects to be driven through `tsserver` nowadays - this seems to work perfectly without the user even needing to change anything in their `.vimrc`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1791)
<!-- Reviewable:end -->

EDIT: I'm sure in an ideal world there would be a fully separate `build.py` argument for Vue, so that we wouldn't need to "pollute" the `tsserver/package.json` file with Vue-specific stuff, but I figured it might be overkill and doesn't make a whole lot of difference anyway (~4MB in `node_modules`).