### PR TITLE
Python 3.12 is required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
 
     - name: Install Go
       if: matrix.benchmark == false

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ tests][test-setup].**
 
 This is all for Ubuntu Linux. Details on getting ycmd running on other OS's can
 be found in [YCM's instructions][ycm-install] (ignore the Vim-specific parts).
-Note that **ycmd runs on Python 3.8.0+.**
+Note that **ycmd runs on Python 3.12.0+.**
 
 First, install the minimal dependencies:
 ```

--- a/build.py
+++ b/build.py
@@ -39,8 +39,8 @@ IS_MSYS = 'MSYS' == os.environ.get( 'MSYSTEM' )
 IS_64BIT = sys.maxsize > 2**32
 PY_MAJOR, PY_MINOR = sys.version_info[ 0 : 2 ]
 PY_VERSION = sys.version_info[ 0 : 3 ]
-if PY_VERSION < ( 3, 8, 0 ):
-  sys.exit( 'ycmd requires Python >= 3.8.0; '
+if PY_VERSION < ( 3, 12, 0 ):
+  sys.exit( 'ycmd requires Python >= 3.12.0; '
             'your version of Python is ' + sys.version +
             '\nHint: Try running python3 ' + ' '.join( sys.argv ) )
 

--- a/examples/example_client.py
+++ b/examples/example_client.py
@@ -17,8 +17,8 @@
 import sys
 
 PY_VERSION = sys.version_info[ 0 : 3 ]
-if PY_VERSION < ( 3, 8, 0 ):
-  sys.exit( 'ycmd requires Python >= 3.8.0; '
+if PY_VERSION < ( 3, 12, 0 ):
+  sys.exit( 'ycmd requires Python >= 3.12.0; '
             'your version of Python is ' + sys.version +
             '\nHint: Try running python3 ' + ' '.join( sys.argv ) )
 

--- a/ycmd/__main__.py
+++ b/ycmd/__main__.py
@@ -27,7 +27,7 @@ if 'YCMD_DEBUGPY_PORT' in os.environ:
     pass
 
 PY_VERSION = sys.version_info[ 0 : 3 ]
-if PY_VERSION < ( 3, 8, 0 ):
+if PY_VERSION < ( 3, 12, 0 ):
   sys.exit( 8 )
 
 ROOT_DIR = os.path.abspath( os.path.join( os.path.dirname( __file__ ), '..' ) )


### PR DESCRIPTION
Python 3.8 was EOL a long time ago. Python 3.12 is 2 years old.

Closes #1782

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1807)
<!-- Reviewable:end -->
