### PR TITLE
Add feature to define LSP settings in g:ycm_language_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ wouldn't usually know about. The value is a list of dictionaries containing:
 - `triggerCharacters`: Override the LSP server's trigger characters for
   completion. This can be useful when the server obnoxiously requests completion
   on every character or for example on whitespace characters.
+- `settings`: optional. Default language server settings. These can be overridden
+  on a per-project basis by the `Settings()` function in `.ycm_extra_conf.py`
+  files (see below).
 
 ```json
 {
@@ -298,7 +301,13 @@ wouldn't usually know about. The value is a list of dictionaries containing:
     "cmdline": [ "/path/to/gopls", "-rpc.trace" ],
     "filetypes": [ "go" ],
     "project_root_files": [ "go.mod" ],
-    "triggerCharacters": [ "." ]
+    "triggerCharacters": [ "." ],
+    "settings": {
+      "gopls": {
+        "usePlaceholders": true,
+        "staticcheck": true
+      }
+    }
   } ]
 }
 ```
@@ -333,6 +342,45 @@ Or, to use an unused  local port, set `port` to `*` and use `${port}` in the
 
 When plugging in a completer in this way, the `kwargs[ 'language' ]` will be set
 to the value of the `name` key, i.e. `gopls` in the above example.
+
+##### Language Server Settings Priority
+
+Language server settings are merged with the following priority (later overrides earlier):
+
+1. Settings from the `settings` key in `language_server` configuration (from Vim `g:ycm_language_server` option)
+2. Settings from the `ls` key returned by the `Settings()` function in
+   `.ycm_extra_conf.py`
+
+This allows you to define default language server settings in your Vim configuration, and override them on a per-project basis using `.ycm_extra_conf.py`. For example:
+
+In your Vim configuration:
+```vim
+let g:ycm_language_server = [
+\ {
+\   'name': 'gopls',
+\   'filetypes': ['go'],
+\   'cmdline': ['/path/to/gopls'],
+\   'settings': {
+\     'hoverKind': 'SynopsisDocumentation',
+\     'gopls': {
+\       'usePlaceholders': true,
+\     },
+\   },
+\ },
+\]
+```
+
+In a project's `.ycm_extra_conf.py`:
+```python
+def Settings( **kwargs ):
+  return {
+    'ls': {
+      'gopls': {
+        'usePlaceholders': false,  # Override the Vim default
+      }
+    }
+  }
+```
 
 A number of LSP completers are currently supported without `language_server`,
 usch as:

--- a/ycmd/completers/language_server/generic_lsp_completer.py
+++ b/ycmd/completers/language_server/generic_lsp_completer.py
@@ -16,6 +16,7 @@
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
 import string
+from copy import deepcopy
 from ycmd import responses, utils
 from ycmd.completers.language_server import language_server_completer
 
@@ -131,6 +132,6 @@ class GenericLSPCompleter( language_server_completer.LanguageServerCompleter ):
 
 
   def DefaultSettings( self, request_data ):
-    settings = super().DefaultSettings( request_data ).copy()
-    return utils.UpdateDict( settings,
-                             self._server_settings.get( 'settings', {} ) )
+    """ Override parent method to provide default
+    settings from server config. Return a copy to avoid mutation. """
+    return deepcopy( self._server_settings.get( 'settings', {} ) )

--- a/ycmd/completers/language_server/generic_lsp_completer.py
+++ b/ycmd/completers/language_server/generic_lsp_completer.py
@@ -132,5 +132,5 @@ class GenericLSPCompleter( language_server_completer.LanguageServerCompleter ):
 
   def DefaultSettings( self, request_data ):
     settings = super().DefaultSettings( request_data ).copy()
-    settings.update( self._server_settings.get( 'settings', {} ) )
-    return settings
+    return utils.UpdateDict( settings,
+                             self._server_settings.get( 'settings', {} ) )

--- a/ycmd/completers/language_server/generic_lsp_completer.py
+++ b/ycmd/completers/language_server/generic_lsp_completer.py
@@ -128,3 +128,9 @@ class GenericLSPCompleter( language_server_completer.LanguageServerCompleter ):
   def GetTriggerCharacters( self, server_trigger_characters ):
     return self._server_settings.get( 'triggerCharacters',
                                       server_trigger_characters )
+
+
+  def DefaultSettings( self, request_data ):
+    settings = super().DefaultSettings( request_data ).copy()
+    settings.update( self._server_settings.get( 'settings', {} ) )
+    return settings

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1901,8 +1901,7 @@ class LanguageServerCompleter( Completer ):
 
       # Merge any user-supplied 'ls' settings with the defaults
       if 'ls' in user_settings:
-        merged_ls_settings = utils.UpdateDict( merged_ls_settings,
-                                               user_settings[ 'ls' ] )
+        utils.UpdateDict( merged_ls_settings, user_settings[ 'ls' ] )
 
       user_settings[ 'ls' ] = merged_ls_settings
       self._settings = user_settings

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1901,7 +1901,8 @@ class LanguageServerCompleter( Completer ):
 
       # Merge any user-supplied 'ls' settings with the defaults
       if 'ls' in user_settings:
-        merged_ls_settings.update( user_settings[ 'ls' ] )
+        merged_ls_settings = utils.UpdateDict( merged_ls_settings,
+                                               user_settings[ 'ls' ] )
 
       user_settings[ 'ls' ] = merged_ls_settings
       self._settings = user_settings

--- a/ycmd/tests/language_server/generic_completer_test.py
+++ b/ycmd/tests/language_server/generic_completer_test.py
@@ -736,15 +736,27 @@ class GenericCompleterTest( TestCase ):
 
 
   @IsolatedYcmd( {
-    'global_ycm_extra_conf': PathToTestFile( 'extra_confs',
-                                             'settings_extra_conf.py' ),
+    'global_ycm_extra_conf': PathToTestFile(
+        'extra_confs',
+        'settings_extra_conf_multilayer.py'
+    ),
     'language_server':
       [ { 'name': 'foo',
           'filetypes': [ 'foo' ],
           'cmdline': [ 'node', PATH_TO_GENERIC_COMPLETER, '--stdio' ],
           'settings': {
-            'foo.bar': 'from_vim',
-            'foo.baz': 'only_in_vim'
+            'foo': {
+              'bar': 'from_vim',
+              'baz': 'only_in_vim',
+              'nested': {
+                'key': 'value_from_vim'
+              }
+            },
+              'java': {
+                'rename': {
+                  'enabled': True
+                }
+              }
           } } ] } )
   def test_GenericLSPCompleter_Settings_MergeWithExtraConf( self, app ):
     completer = handlers._server_state.GetFiletypeCompleter( [ 'foo' ] )
@@ -761,7 +773,10 @@ class GenericCompleterTest( TestCase ):
     # Check that settings are merged with extra_conf overriding
     assert_that( completer._settings.get( 'ls', {} ),
                  has_entries( {
-                   'foo.bar': 'from_vim',           # From language_server
-                   'foo.baz': 'only_in_vim',        # From language_server
-                   'java.rename.enabled': False     # From extra_conf (override)
+                   'foo': {
+                     'bar': 'from_vim',
+                     'baz': 'from_conf_file',
+                     'nested': {'key': 'from_conf_file'}
+                   },
+                   'java': {'rename': {'enabled': False}}
                  } ) )

--- a/ycmd/tests/language_server/generic_completer_test.py
+++ b/ycmd/tests/language_server/generic_completer_test.py
@@ -776,7 +776,7 @@ class GenericCompleterTest( TestCase ):
                    'foo': {
                      'bar': 'from_vim',
                      'baz': 'from_conf_file',
-                     'nested': {'key': 'from_conf_file'}
+                     'nested': { 'key': 'from_conf_file' }
                    },
-                   'java': {'rename': {'enabled': False}}
+                   'java': { 'rename': { 'enabled': False } }
                  } ) )

--- a/ycmd/tests/language_server/generic_completer_test.py
+++ b/ycmd/tests/language_server/generic_completer_test.py
@@ -705,3 +705,63 @@ class GenericCompleterTest( TestCase ):
         } )
       ) } )
     ) )
+
+
+  @IsolatedYcmd( {
+    'language_server':
+      [ { 'name': 'foo',
+          'filetypes': [ 'foo' ],
+          'cmdline': [ 'node', PATH_TO_GENERIC_COMPLETER, '--stdio' ],
+          'settings': {
+            'foo.bar': 'from_vim',
+            'foo.baz': 'only_in_vim'
+          } } ] } )
+  def test_GenericLSPCompleter_Settings_FromLanguageServer( self, app ):
+    completer = handlers._server_state.GetFiletypeCompleter( [ 'foo' ] )
+    request = BuildRequest( filepath = TEST_FILE,
+                            filetype = 'foo',
+                            line_num = 1,
+                            column_num = 1,
+                            contents = 'test',
+                            event_name = 'FileReadyToParse' )
+    app.post_json( '/event_notification', request )
+    WaitUntilCompleterServerReady( app, 'foo' )
+
+    # Check that settings from language_server config are used
+    assert_that( completer._settings.get( 'ls', {} ),
+                 has_entries( {
+                   'foo.bar': 'from_vim',
+                   'foo.baz': 'only_in_vim'
+                 } ) )
+
+
+  @IsolatedYcmd( {
+    'global_ycm_extra_conf': PathToTestFile( 'extra_confs',
+                                             'settings_extra_conf.py' ),
+    'language_server':
+      [ { 'name': 'foo',
+          'filetypes': [ 'foo' ],
+          'cmdline': [ 'node', PATH_TO_GENERIC_COMPLETER, '--stdio' ],
+          'settings': {
+            'foo.bar': 'from_vim',
+            'foo.baz': 'only_in_vim'
+          } } ] } )
+  def test_GenericLSPCompleter_Settings_MergeWithExtraConf( self, app ):
+    completer = handlers._server_state.GetFiletypeCompleter( [ 'foo' ] )
+    filepath = PathToTestFile( 'extra_confs', 'foo' )
+    request = BuildRequest( filepath = filepath,
+                            filetype = 'foo',
+                            line_num = 1,
+                            column_num = 1,
+                            contents = 'test',
+                            event_name = 'FileReadyToParse' )
+    app.post_json( '/event_notification', request )
+    WaitUntilCompleterServerReady( app, 'foo' )
+
+    # Check that settings are merged with extra_conf overriding
+    assert_that( completer._settings.get( 'ls', {} ),
+                 has_entries( {
+                   'foo.bar': 'from_vim',           # From language_server
+                   'foo.baz': 'only_in_vim',        # From language_server
+                   'java.rename.enabled': False     # From extra_conf (override)
+                 } ) )

--- a/ycmd/tests/language_server/testdata/extra_confs/settings_extra_conf_multilayer.py
+++ b/ycmd/tests/language_server/testdata/extra_confs/settings_extra_conf_multilayer.py
@@ -1,0 +1,7 @@
+def Settings(**kwargs):
+    return {
+        "ls": {
+            "java": {"rename": {"enabled": False}},
+            "foo": {"baz": "from_conf_file", "nested": {"key": "from_conf_file"}},
+        }
+    }


### PR DESCRIPTION
In https://github.com/ycm-core/YouCompleteMe/issues/4272, I asked if it's possible to define global LSP settings in `.vimrc`

Here's the patch that adds this feature, so the `settings` option will be global with overrides from `.ycm_extra_conf.py`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1809)
<!-- Reviewable:end -->
