### PR TITLE
Fix typo, add `language_server` anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ def Settings( **kwargs ):
              'config_sections': { 'section0': {} }
 ```
 
+##### `language_server` configuration
+
 In addition, ycmd can use any language server, given a file type and a command
 line. A user option `language_server` can be used to plug in a LSP server ycmd
 wouldn't usually know about. The value is a list of dictionaries containing:
@@ -278,11 +280,11 @@ wouldn't usually know about. The value is a list of dictionaries containing:
 - `cmdline`: the list representing the command line to execute the server
   (optional; mandatory if port not specified)
 - `port`: optional. If specified, a TCP connection is used to this port. If set
-  to `*`, an unused locall port is selected and made availble in the `cmdline`
+  to `*`, an unused local port is selected and made available in the `cmdline`
   as `${port}` (see below examples).
 - `filetypes`: list of supported filetypes.
 - `project_root_files`: Tells ycmd which files indicate project root.
-- `capabilities'`: Overrides the default LSP capabilities of ycmd.
+- `capabilities`: Overrides the default LSP capabilities of ycmd.
   - If you enable `workspace/configuration` support, check the extra conf
     details, relevant to LSP servers.
 - `additional_workspace_dirs`: Specifies statically known workspaces that should


### PR DESCRIPTION
A tiny follow-up for #1809 

Currently, `g:ycm_language_server` has two places that describe its keys. I am going to replace one in the YouCompleteMe repository by cross-referencing here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1811)
<!-- Reviewable:end -->
