### PR TITLE
Fix %-encoding in UriToFilePath

### DIFF
--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
 import collections
 import os
 import json
@@ -761,14 +762,18 @@ def UriToFilePath( uri ):
   if parsed_uri.scheme != 'file':
     raise InvalidUriException( uri )
 
-  # url2pathname doesn't work as expected when uri.path is percent-encoded and
-  # is a windows path for ex:
-  # url2pathname('/C%3a/') == 'C:\\C:'
-  # whereas
-  # url2pathname('/C:/') == 'C:\\'
-  # Therefore first unquote pathname.
-  pathname = unquote( parsed_uri.path )
-  return os.path.abspath( url2pathname( pathname ) )
+  if sys.version_info < ( 3, 14 ):
+    # Before Python 3.14:
+    # url2pathname doesn't work as expected when uri.path is percent-encoded and
+    # is a windows path for ex:
+    # url2pathname('/C%3a/') == 'C:\\C:'
+    # whereas
+    # url2pathname('/C:/') == 'C:\\'
+    # Therefore first unquote pathname.
+    return os.path.abspath( url2pathname( unquote( parsed_uri.path ) ) )
+  else:
+    # After Python 3.14, url2pathname seems to work properly
+    return os.path.abspath( url2pathname( uri, require_scheme=True ) )
 
 
 def _BuildMessageData( message ):

--- a/ycmd/tests/language_server/language_server_protocol_test.py
+++ b/ycmd/tests/language_server/language_server_protocol_test.py
@@ -153,6 +153,8 @@ class LanguageServerProtocolTest( TestCase ):
                  equal_to( '/usr/local/test/test.test' ) )
     assert_that( lsp.UriToFilePath( 'file:///usr/local/test/test.test' ),
                  equal_to( '/usr/local/test/test.test' ) )
+    assert_that( lsp.UriToFilePath( 'file:///usr/local/test%23foo/test.test' ),
+                 equal_to( '/usr/local/test#foo/test.test' ) )
 
 
   @WindowsOnly


### PR DESCRIPTION
In #1119 a change was made to "unquote" the URI before converting to a file path, ostensibly to support windows. It seems that either that change was broken, or that Python standard library has since been fixed and this has caused legitimate %-encoded paths (like foo#bar/test.c) to now truncate at the #.

The tests added for UriToFilePath with Windows paths still pass unchanged without the hack on Python 3.14 so I'm happy to just remove the hack.

Fixes #1814

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1815)
<!-- Reviewable:end -->
